### PR TITLE
Fix db-specific prometheus metrics naming

### DIFF
--- a/integration/metric.go
+++ b/integration/metric.go
@@ -146,16 +146,16 @@ func (db *DBProducerWithMetrics) OpenDB(name string) (kvdb.Store, error) {
 		return nil, err
 	}
 	dm := WrapStoreWithMetrics(ds)
-	// disk size gauge should be meter separatly for each db name; otherwise,
-	// the last db siae metric will overwrite all the previoius one
+	// disk size gauge should be metered separately for each db name; otherwise,
+	// the last db size metric will overwrite all the previous ones
 	dm.diskSizeGauge = metrics.GetOrRegisterGauge("opera/chaindata/"+strings.ReplaceAll(name, "-", "_")+"/disk/size", nil)
-	if strings.HasPrefix(name, "gossip-") || strings.HasPrefix(name, "lachesis-") {
+	if strings.HasPrefix(name, "gossip-") || strings.HasPrefix(name, "lachesis-") || strings.HasPrefix(name, "epoch-") {
 		name = "epochs"
 	}
 	logger := log.New("database", name)
 	dm.log = logger
-	dm.diskReadMeter = metrics.GetOrRegisterMeter("opera/chaindata/"+name+"/disk/read", nil)
-	dm.diskWriteMeter = metrics.GetOrRegisterMeter("opera/chaindata/"+name+"/disk/write", nil)
+	dm.diskReadMeter = metrics.GetOrRegisterMeter("opera/chaindata/"+strings.ReplaceAll(name, "-", "_")+"/disk/read", nil)
+	dm.diskWriteMeter = metrics.GetOrRegisterMeter("opera/chaindata/"+strings.ReplaceAll(name, "-", "_")+"/disk/write", nil)
 
 	// Start up the metrics gathering and return
 	go dm.meter(metricsGatheringInterval)


### PR DESCRIPTION
Prometheus currently fails to gather Opera metrics because of `"-"` character in the metric name:

```
invalid metric type "3_disk_read gauge"
```
Without this fix Opera produce metrics like:
```
# TYPE opera_chaindata_epoch-3_disk_read gauge
opera_chaindata_epoch-3_disk_read 0

# TYPE opera_chaindata_epoch-3_disk_write gauge
opera_chaindata_epoch-3_disk_write 419
```
This fixes the metrics names to not include `"-"` character and to merge all epoch dbs data into "epochs" metric correctly.