### PR TITLE
Add snapsync back into supported P2P protocols (fixes #5)

### DIFF
--- a/gossip/service.go
+++ b/gossip/service.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"math/big"
 	"math/rand"
 	"sync"
@@ -387,7 +388,9 @@ func MakeProtocols(svc *Service, backend *handler, disc enode.Iterator) []p2p.Pr
 
 // Protocols returns protocols the service can communicate on.
 func (s *Service) Protocols() []p2p.Protocol {
-	protos := MakeProtocols(s, s.handler, s.operaDialCandidates)
+	protos := append(
+		MakeProtocols(s, s.handler, s.operaDialCandidates),
+		snap.MakeProtocols((*snapHandler)(s.handler), s.snapDialCandidates)...)
 	return protos
 }
 


### PR DESCRIPTION
This is partial revert of changes made in  #1 - it re-add snapsync into the list of supported P2P protocols.

By my testing, this fixes issue #5 (Opera does not sync when joined to fakenet which already contains transactions)