### PR TITLE
Fix starvation problem in main emitter processing loop

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -147,19 +147,17 @@ func (em *Emitter) Start() {
 	em.wg.Add(1)
 	go func() {
 		defer em.wg.Done()
-		tick := 11 * time.Millisecond
-		timer := time.NewTimer(tick)
-		defer timer.Stop()
+		ticker := time.NewTicker(11 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case txNotify := <-newTxsCh:
 				em.memorizeTxTimes(txNotify.Txs)
-			case <-timer.C:
+			case <-ticker.C:
 				em.tick()
 			case <-done:
 				return
 			}
-			timer.Reset(tick)
 		}
 	}()
 }


### PR DESCRIPTION
This PR fixes a starvation problem in the emitter's main processing loop: if too many incoming transactions are registered (one every 11 milliseconds, ~90 Tx/s) the emitter process is starved out and no block is created.

With this change, the emitter ticker does not get reset every time a notification is received, improving the smoothness of the block processing system.