### PR TITLE
Remove cached signer to re-enable go-ethereum's sender cache

### DIFF
--- a/utils/signers/gsignercache/global_cache.go
+++ b/utils/signers/gsignercache/global_cache.go
@@ -1,32 +1,12 @@
 package gsignercache
 
-import (
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	lru "github.com/hashicorp/golang-lru"
-)
-
-var (
-	globalCache, _ = lru.New(40000)
-)
-
-type WlruCache struct {
-	Cache *lru.Cache
-}
-
-func (w *WlruCache) Add(txid common.Hash, c types.CachedSender) {
-	w.Cache.Add(txid, c)
-}
-
-func (w *WlruCache) Get(txid common.Hash) *types.CachedSender {
-	ic, ok := w.Cache.Get(txid)
-	if !ok {
-		return nil
-	}
-	c := ic.(types.CachedSender)
-	return &c
-}
+import "github.com/ethereum/go-ethereum/core/types"
 
 func Wrap(signer types.Signer) types.Signer {
-	return types.WrapWithCachedSigner(signer, &WlruCache{globalCache})
+	// There used to be a different signer type wrapping the passed in
+	// signer to add a global cache for results. However, this feature
+	// is no longer needed since go-ethereum's core library is caching
+	// results as well. The utilization of both actually caused the
+	// accidential disabling of either.
+	return signer
 }


### PR DESCRIPTION
Opera is using a wrapped version of a `go-ethereum`'s [types.Signer](https://github.com/ethereum/go-ethereum/blob/v1.12.0/core/types/transaction_signing.go#L161) interface caching results for future lookups. However, go-ethereum's core library is already [implementing](https://github.com/ethereum/go-ethereum/blob/v1.12.0/core/types/transaction_signing.go#L137-L145) such a cache, which fails to be active due to the missing implementation of go-opera's CachedSigner `Equal` function (and it is not trivial to implement this).

By removing the specialization of the `go-opera` signer, `go-ethereum`'s caching mechanism is re-enabled, significantly reducing processing costs.

CPU profile before fix (total visible processing time ~3.4s):
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/4097849/722187d4-d904-4f12-b604-29f553532b3f)

CPU profile after fix (total visible processing time ~0.8s):
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/4097849/f0a8c13f-7b69-40f7-9c04-5b9ff24be3fc)


The function is even more often used outside the transaction ingestion code:
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/4097849/d4e4bf80-5fb1-4cc6-bb9c-ac5057bf2fe1)
