### PR TITLE
Add cache for block hashes in the emitter world's GetBlockRecordHash

### DIFF
--- a/gossip/service.go
+++ b/gossip/service.go
@@ -3,12 +3,13 @@ package gossip
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"math/big"
 	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"
@@ -331,8 +332,11 @@ func (s *Service) EmitterWorld(signer valkeystore.SignerI) emitter.World {
 	return emitter.World{
 		External: &emitterWorld{
 			emitterWorldProc: emitterWorldProc{s},
-			emitterWorldRead: emitterWorldRead{s.store},
-			WgMutex:          wgmutex.New(s.engineMu, &s.blockProcWg),
+			emitterWorldRead: emitterWorldRead{
+				Store:          s.store,
+				blockHashCache: newBlockHashCache(),
+			},
+			WgMutex: wgmutex.New(s.engineMu, &s.blockProcWg),
 		},
 		TxPool:   s.txpool,
 		Signer:   signer,


### PR DESCRIPTION
This cache eliminates the repeated re-computation of hashes for blocks as part of the `addLlrBlockVotes` function.

Before this change:
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/4097849/76543f9f-56a6-43ed-8d20-abf0b8ba0428)

After the change:
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/4097849/86f85ac7-d3ad-4026-87ab-49fa13fa1a9a)

This also smoothed out the block processing rate. Before:
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/4097849/31abd4cb-ea7f-44b3-b00c-26670c9c67b3)

After:
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/4097849/ec537688-e919-41ce-8fdb-212ab1f5ffd2)
