### PR TITLE
Fix opera StateDB test

### DIFF
--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -445,8 +445,7 @@ func (env *testEnv) callContract(
 		call.Value = new(big.Int)
 	}
 	// Set infinite balance to the fake caller account.
-	from := state.GetOrNewStateObject(call.From)
-	from.SetBalance(big.NewInt(math.MaxInt64))
+	state.SetBalance(call.From, big.NewInt(math.MaxInt64))
 
 	msg := callmsg{call}
 


### PR DESCRIPTION
This fixes opera test after introducing Carmen.
Method state.GetOrNewStateObject have been removed from the StateDB interface, as it is not available with Carmen, SetBalance have been introduced directly into the StateDB instead.