### PR TITLE
Close Carmen database on shutdown

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Fantom-foundation/go-opera/opera"
-	"github.com/Fantom-foundation/go-opera/statedb"
 	"os"
 	"path"
 	"path/filepath"
@@ -183,6 +182,8 @@ type config struct {
 	LachesisStore abft.StoreConfig
 	VectorClock   vecmt.IndexConfig
 	DBs           integration.DBsConfig
+	StateDbImpl   string
+	VmImpl        string
 }
 
 func (c *config) AppConfigs() integration.Configs {
@@ -565,15 +566,9 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 	cfg.Node = nodeConfigWithFlags(ctx, cfg.Node)
 	cfg.DBs = setDBConfig(ctx, cfg.DBs, cacheRatio)
 
-	// StateDB initialization
-	if err := statedb.InitializeStateDB(ctx.GlobalString(stateDbImplFlag.Name), cfg.Node.DataDir); err != nil {
-		return nil, fmt.Errorf("failed to initialize StateDB; %s", err)
-	}
-
-	// Set default VM implementation
-	if impl := ctx.GlobalString(vmImplFlag.Name); impl != "" {
-		opera.DefaultVMConfig.InterpreterImpl = impl
-	}
+	// StateDB and VM initialization
+	cfg.StateDbImpl = ctx.GlobalString(stateDbImplFlag.Name)
+	cfg.VmImpl = ctx.GlobalString(vmImplFlag.Name)
 
 	err = setValidator(ctx, &cfg.Emitter)
 	if err != nil {

--- a/statedb/switch.go
+++ b/statedb/switch.go
@@ -22,7 +22,7 @@ func InitializeStateDB(impl string, datadir string) error {
 
 		err := os.MkdirAll(datadir, 0700)
 		if err != nil {
-			panic(fmt.Errorf("failed to create carmen dir"))
+			return fmt.Errorf("failed to create carmen dir")
 		}
 		params := carmen.Parameters{
 			Schema:    carmen.StateSchema(3),
@@ -31,7 +31,7 @@ func InitializeStateDB(impl string, datadir string) error {
 		}
 		carmenState, err = carmen.NewGoCachedFileState(params)
 		if err != nil {
-			panic(fmt.Errorf("failed to create carmen state; %s", err))
+			return fmt.Errorf("failed to create carmen state; %s", err)
 		}
 		liveStateDb = carmen.CreateStateDBUsing(carmenState)
 	} else if impl != "" && impl != "geth" {
@@ -88,4 +88,14 @@ func GetRpcStateDb(useLatest bool, blockNum *big.Int, stateRoot common.Hash, evm
 	} else {
 		return state.NewWithSnapLayers(stateRoot, evmState, snaps, 0)
 	}
+}
+
+func ShutdownStateDB() error {
+	if carmenState != nil {
+		err := carmenState.Close()
+		if err != nil {
+			return fmt.Errorf("failed to close carmen state; %s", err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This ensures the Carmen database is closed correctly on the node shutdown.

The Carmen database initialization is also moved out from the configuration parsing.