### PR TITLE
Revert moving statedb setting to fix genesis application

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/Fantom-foundation/go-opera/statedb"
 	"os"
 	"path"
 	"path/filepath"
@@ -182,8 +183,6 @@ type config struct {
 	LachesisStore abft.StoreConfig
 	VectorClock   vecmt.IndexConfig
 	DBs           integration.DBsConfig
-	StateDbImpl   string
-	VmImpl        string
 }
 
 func (c *config) AppConfigs() integration.Configs {
@@ -566,9 +565,15 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 	cfg.Node = nodeConfigWithFlags(ctx, cfg.Node)
 	cfg.DBs = setDBConfig(ctx, cfg.DBs, cacheRatio)
 
-	// StateDB and VM initialization
-	cfg.StateDbImpl = ctx.GlobalString(stateDbImplFlag.Name)
-	cfg.VmImpl = ctx.GlobalString(vmImplFlag.Name)
+	// StateDB initialization
+	if err := statedb.InitializeStateDB(ctx.GlobalString(stateDbImplFlag.Name), cfg.Node.DataDir); err != nil {
+		return nil, fmt.Errorf("failed to initialize StateDB; %s", err)
+	}
+
+	// Set default VM implementation
+	if impl := ctx.GlobalString(vmImplFlag.Name); impl != "" {
+		opera.DefaultVMConfig.InterpreterImpl = impl
+	}
 
 	err = setValidator(ctx, &cfg.Emitter)
 	if err != nil {

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -2,7 +2,6 @@ package launcher
 
 import (
 	"fmt"
-	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/statedb"
 	"path"
 	"sort"
@@ -295,16 +294,6 @@ func makeNode(ctx *cli.Context, cfg *config, genesisStore *genesisstore.Store) (
 	// check errlock file
 	errlock.SetDefaultDatadir(cfg.Node.DataDir)
 	errlock.Check()
-
-	// StateDB initialization
-	if err := statedb.InitializeStateDB(cfg.StateDbImpl, cfg.Node.DataDir); err != nil {
-		utils.Fatalf("Failed to initialize StateDB; %v", err)
-	}
-
-	// Set default VM implementation
-	if cfg.VmImpl != "" {
-		opera.DefaultVMConfig.InterpreterImpl = cfg.VmImpl
-	}
 
 	var g *genesis.Genesis
 	if genesisStore != nil {


### PR DESCRIPTION
This should fix broken genesis application caused by #19.

Current integration does not transfer data from genesis StateDB into the production StateDB, works only because they overlap.
Moving the Carmen initialization into makeNode() stops genesis processing from using Carmen and results in missing data from genesis in the production state.

After this revert, Opera does not restart correctly, requires removing the db again, as re-applying genesis on the second start breaks live state - this will need deeper solution - this fixes what was working before #19.