### PR TITLE
Prevent damaging Carmen database by re-applying genesis

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -216,7 +216,13 @@ func loadAllConfigs(file string, cfg *config) error {
 	return err
 }
 
-func mayGetGenesisStore(ctx *cli.Context) *genesisstore.Store {
+func mayGetGenesisStore(ctx *cli.Context, cfg *config) *genesisstore.Store {
+	if futils.FileExists(path.Join(cfg.Node.DataDir, "chaindata")) {
+		log.Info("chaindata already exist, skipping genesis")
+		// repeated genesis processing is no-op for geth, but it collides with existing Carmen database
+		return nil
+	}
+
 	switch {
 	case ctx.GlobalIsSet(JsonGenesisFlag.Name):
 		genesisPath := ctx.GlobalString(JsonGenesisFlag.Name)

--- a/cmd/opera/launcher/consolecmd.go
+++ b/cmd/opera/launcher/consolecmd.go
@@ -77,7 +77,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/JavaScript-Cons
 func localConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
 	cfg := makeAllConfigs(ctx)
-	genesisStore := mayGetGenesisStore(ctx)
+	genesisStore := mayGetGenesisStore(ctx, cfg)
 	node, _, nodeClose := makeNode(ctx, cfg, genesisStore)
 	startNode(ctx, node)
 	defer nodeClose()
@@ -172,7 +172,7 @@ func dialRPC(endpoint string) (*rpc.Client, error) {
 func ephemeralConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
 	cfg := makeAllConfigs(ctx)
-	genesisStore := mayGetGenesisStore(ctx)
+	genesisStore := mayGetGenesisStore(ctx, cfg)
 	node, _, nodeClose := makeNode(ctx, cfg, genesisStore)
 	startNode(ctx, node)
 	defer nodeClose()

--- a/cmd/opera/launcher/import.go
+++ b/cmd/opera/launcher/import.go
@@ -77,8 +77,8 @@ func importEvents(ctx *cli.Context) error {
 	}
 
 	// avoid P2P interaction, API calls and events emitting
-	genesisStore := mayGetGenesisStore(ctx)
 	cfg := makeAllConfigs(ctx)
+	genesisStore := mayGetGenesisStore(ctx, cfg)
 	cfg.Opera.Protocol.EventsSemaphoreLimit.Size = math.MaxUint32
 	cfg.Opera.Protocol.EventsSemaphoreLimit.Num = math.MaxUint32
 	cfg.Emitter.Validator = emitter.ValidatorConfig{}

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -282,7 +282,7 @@ func lachesisMain(ctx *cli.Context) error {
 	//defer tracingStop()
 
 	cfg := makeAllConfigs(ctx)
-	genesisStore := mayGetGenesisStore(ctx)
+	genesisStore := mayGetGenesisStore(ctx, cfg)
 	node, _, nodeClose := makeNode(ctx, cfg, genesisStore)
 	defer nodeClose()
 	startNode(ctx, node)


### PR DESCRIPTION
The Carmen database is shared between the genesis generating (which happens everytime when the node starts with --fakenet or --jsongenesis) and the production run.

As a consequence, when fakenet/jsongenesis Opera is restarted, the `makefakegenesis.FakeGenesisStore` method tries to apply genesis transactions on the top of the existing live state. The result is damaged carmen live state and/or failed genesis txs application.

This fix checks if the dir "chaindata" in datadir already exists, if not, we can be sure this is the first start and the genesis needs to be applied. Otherwise applying the genesis is skipped.

This simple check may be insufficient in situation where the node is stopped in the middle of the first start - however we can always remove the "chaindata" dir, as we already do everytime when the database is damaged, like after the node kill.