### PR TITLE
Fix CI tests by adding Carmen build

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -15,7 +15,11 @@ jobs:
       - name: Golang dependency
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '1.20'
+
+      - name: Build Carmen
+        working-directory: ./carmen/go/lib
+        run: ./build_libcarmen.sh
 
       - name: Run unit tests
         run: go test -v ./...


### PR DESCRIPTION
This fixes CI failures caused by missing/not built libcarmen.so library.