### PR TITLE
Add metrics for EndToEnd/TimeToEmit/TimeToConfirm

### DIFF
--- a/utils/txtime/txtime.go
+++ b/utils/txtime/txtime.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	globalFinalized, _    = wlru.New(30000, 30000)
-	globalNonFinalized, _ = wlru.New(5000, 5000)
+	globalFinalized, _    = wlru.New(30000, 300000)
+	globalNonFinalized, _ = wlru.New(5000, 50000)
 	Enabled               = false
 )
 
@@ -46,4 +46,19 @@ func Of(txid common.Hash) time.Time {
 	now := time.Now()
 	Saw(txid, now)
 	return now
+}
+
+func Get(txid common.Hash) time.Time {
+	if !Enabled {
+		return time.Time{}
+	}
+	v, has := globalFinalized.Get(txid)
+	if has {
+		return v.(time.Time)
+	}
+	v, has = globalNonFinalized.Get(txid)
+	if has {
+		return v.(time.Time)
+	}
+	return time.Time{}
 }


### PR DESCRIPTION
Add metrics for the network latency / time to finality measuring:

* `emitter/timetoconfirm` - the time since emitting event until the event confirming (including into a block)
* `emitter/timetoemit` - the time since the first tx observing until its including into an event
* `emitter/endtoendtime` - the time from from the first tx obserting until its including into a block

Only events/txs of the local validator are included.