### PR TITLE
Fix behavior of isAllowedToEmit

### DIFF
--- a/gossip/emitter/control.go
+++ b/gossip/emitter/control.go
@@ -104,25 +104,30 @@ func (em *Emitter) isAllowedToEmit(e inter.EventI, eTxs bool, metric ancestor.Me
 			}
 		}
 	}
-	// Slow down emitting if no txs to confirm/originate
+	// Avoid emitting if no txs to confirm/originate
 	{
-		if passedTime < em.intervals.Max &&
-			em.idle() &&
+		if em.idle() &&
 			!eTxs {
 			return false
 		}
 	}
+	// enforced !em.idle() || eTxs
+
 	// Emitting is controlled by the efficiency metric
 	{
+		// Min already enforced in tick(), just to make sure
 		if passedTime < em.intervals.Min {
 			return false
 		}
+
+		// Slow down emitting if no txs to confirm and will not help the consensus significantly
 		if adjustedPassedTime < em.intervals.Min &&
-			!em.idle() {
+			em.idle() {
 			return false
 		}
+
+		// Slow down if no txs to originate (but at least 1 tx to confirm)
 		if adjustedPassedIdleTime < em.intervals.Confirming &&
-			!em.idle() &&
 			!eTxs {
 			return false
 		}


### PR DESCRIPTION
The `isAllowedToEmit` methods determines, if the Emit method should or should not emit a new event.

The relevant part is this condition:
```
if adjustedPassedTime < em.intervals.Min && // a longer interval needs to pass
	!em.idle() { // if the chain is not idle (there are txs in unconfirmed events)
	return false // don't emit
}
```
This condition postpones the event emitting, if the chain **is not idle** - if there are unconfirmed txs.
The correct behavior should be the right opposite - to postpone emitting if all txs are confirmed - if the chain **is idle**.

This fix improves the network TTF significantly:
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/ba0af10d-47b5-4aca-b7ac-ed89794ffa01)

This affects also the txpool usage and throughput when using sonicfeeder:
![image](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/fe915b18-30e1-4458-ba26-b9dd8cc1ee87)

The rest of changes are meaningless - removing always-false or always-true parts of conditions.