### PR TITLE
Move blocks/txs/receipts into a separated dbs

### DIFF
--- a/integration/presets.go
+++ b/integration/presets.go
@@ -43,6 +43,21 @@ func Pbl1RoutingConfig() RoutingConfig {
 				Type: "pebble-fsh",
 				Name: "events",
 			},
+			"evm/X": { // tx hash -> tx
+				Type: "pebble-fsh",
+				Name: "txs",
+				Table: "X",
+			},
+			"evm/x": { // tx hash -> tx position
+				Type: "pebble-fsh",
+				Name: "txs",
+				Table: "x",
+			},
+			"evm/r": { // block id -> receipts
+				Type: "pebble-fsh",
+				Name: "receipts",
+			},
+
 			"evm/M": {
 				Type: "pebble-drc",
 				Name: "evm-data",


### PR DESCRIPTION
This moves parts of current "main" database (which mysteriously occupied 19% of all dbs in our second Sonic run) into two new databases:
* "txs" database
* "receipts" database

This makes the "main" db smaller than 0.5% of the space consumed by Opera databases,  effectively removing it from charts of the space usage. All significantly big data are moved into these new dbs.

![image](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/433e24b9-9275-4bb1-89be-9bd9fcdc516a)
