### PR TITLE
Skip offline validators in isMyTurn

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -44,6 +44,8 @@ var (
 	txsSkippedNotMyTurn         = metrics.GetOrRegisterCounter("emitter/skipped/notmyturn", nil)         // tx should be handled by other validator
 	txsSkippedOutdated          = metrics.GetOrRegisterCounter("emitter/skipped/outdated", nil)          // tx skipped because it is outdated
 
+	skippedOfflineValidatorsCounter = metrics.GetOrRegisterCounter("emitter/skipped_offline", nil)
+
 	eventTimeToConfirmTimer = metrics.GetOrRegisterTimer("emitter/timetoconfirm", nil)
 	txTimeToEmitTimer       = metrics.GetOrRegisterTimer("emitter/timetoemit", nil)
 	txEndToEndTimer         = metrics.GetOrRegisterTimer("emitter/endtoendtime", nil)

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -130,9 +130,14 @@ func (em *Emitter) isMyTxTurn(txHash common.Hash, sender common.Address, account
 	// take a validator from the sequence, skip offline validators
 	for ; roundIndex < len(rounds); roundIndex++ {
 		chosenValidator := validators.GetID(idx.Validator(rounds[roundIndex]))
-		if !em.offlineValidators[chosenValidator] {
-			return chosenValidator == me
+		if chosenValidator == me {
+			return true // current validator is the chosen - emit
 		}
+		if !em.offlineValidators[chosenValidator] {
+			return false // chosen validator is online - don't emit
+		}
+		// otherwise try next validator in the sequence
+		skippedOfflineValidatorsCounter.Inc(1)
 	}
 	return false
 }


### PR DESCRIPTION
"isMyTurn" method determines, which validator is supposed to emit individual txs. If the validator is offline, the tx waits for 8 second in the txpool, until the tx is assigned to another validator.

The emitter has available offline validators monitoring for purposes of calculation of the total stake of online validators, which is used to determine an emitting interval. (Validators with lower stake should emit fewer events to reduce network load.)

**This patch make use of this offline validators monitoring, to exclude them from validators assigned by "isMyTurn" method.**

Because the set of offline validators is not guaranteed to be identical across all nodes, we cannot exclude offline nodes from the weighted permutation - we need to get always the same permutation for a tx, independently on offline state of validators.

Instead, if we see that the currently chosen validator is offline, we skip its round and we continue with the following validator in the permutation.

![image](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/1fdeacad-ff5b-4946-b914-54827da8513c)

This modification introduce slightly higher probability of including one tx into a block multiple times (it will be marked as a "skipped tx" because of a duplicated nonce), however in my experiments were no visible difference - cca 2 skipped txs per 2000 processed txs before and also after.

![image](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/c7efbc25-dc6f-4410-9ffb-e7650aae52bf)
