### PR TITLE
Reiforce txpool queue error handling

### DIFF
--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -290,7 +290,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
 		if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
-			return false, nil
+			return false, old
 		}
 		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
 		a := big.NewInt(100 + int64(priceBump))
@@ -306,7 +306,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
 		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
-			return false, nil
+			return false, old
 		}
 	}
 	// Otherwise overwrite the old transaction with the current one


### PR DESCRIPTION
This adds handling of failed `pool.enqueueTx` operation.

Trying to figure out the failure, where `local` and `pending` decrease down to zero, but some txs stays in the `TxPool.all` set.

If this helps, `txpool_failed_enqueue` counter should show a positive value. (As long as it will be zero, these changes had no effect.)