### PR TITLE
Improve TxNoncer writes performance

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -464,8 +464,9 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 // Nonce returns the next nonce of an account, with all transactions executable
 // by the pool already applied on top.
 func (pool *TxPool) Nonce(addr common.Address) uint64 {
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
+	// Write lock because underlying state will mutate db even for read access.
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
 
 	return pool.pendingNonces.get(addr)
 }


### PR DESCRIPTION
7.6% of the Opera runtime (during 2500txs/sec) is consumed in `txNoncer.set` operation:

![Screenshot from 2023-09-11 21-03-00](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/787bdac2-fdef-46e8-a837-25e301bb9e3f)

This operation is composed of two parts:
* Writing into a map (address to nonce integer)
* Locking a noncer mutex

The noncer mutex can be removed, if the txpool mutex will be hold for write in the TxPool.Nonce() method.
Currently is hold only for reading there, which allows to call Stats/GasPrice/Count/Status concurrently. But multiple Nonce() calls are avoided by the noncer mutex.

The removing of the mutex decrease the time of `txNoncer.set` **from 77s to 66s** per 10 minutes cpuprofile.

This improves the performance of pushing transactions into the chain, however it can slow down txpool related readonly RPC calls - like eth_gasPrice)