### PR TITLE
Measure disk usage less often

### DIFF
--- a/statedb/switch.go
+++ b/statedb/switch.go
@@ -35,12 +35,12 @@ func InitializeStateDB(impl string, datadir string) error {
 			return fmt.Errorf("failed to create carmen state; %s", err)
 		}
 		liveStateDb = carmen.CreateStateDBUsing(carmenState)
+
+		// measure the size of carmen directory
+		go metrics.MeasureDbDir("statedb/disksize", datadir)
 	} else if impl != "" && impl != "geth" {
 		return fmt.Errorf("statedb impl %s not supported", impl)
 	}
-
-	go metrics.MeasureDbDir("statedb/disksize", datadir)
-
 	return nil
 }
 


### PR DESCRIPTION
Measuring of the used disk space for needs of metrics consumes 13% of the runtime time:

![Screenshot from 2023-09-12 10-02-41](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/95844d7e-f7ef-4b9c-86ce-fd3317354cb4)

While this probably does not slow-down the processing significantly (it runs in a standalone thread), it may generate useless IO - while the directory size measuring runs with 1-second delay, the measured value is collected by prometheus only once per 30 seconds at most. (And for the needs of the metric, measuring once per a minute is more then sufficient.)

This also refactors the way, how is the measured value passed into the metric - as the StandardGauge is an atomic integer itself, using the external atomic integer in the original implementation does not bring anything useful.