### PR TITLE
Fix updating TxPool real-use metrics

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1274,6 +1274,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	// Ensure pool.queue and pool.pending sizes stay within the configured limits.
 	pool.truncatePending()
 	pool.truncateQueue()
+	pool.updateUsedGauges()
 
 	// Update all accounts to the latest known pending nonce
 	for addr, list := range pool.pending {


### PR DESCRIPTION
Currently are TxPool real-use metrics updated when adding a new tx. But they are not updated, when txs are removed which leads to incorrect data in charts:

![image](https://github.com/Fantom-foundation/go-opera-norma/assets/3178122/ad1454cc-33fd-4b6f-a34b-75e1ff54df9d)

The green line should follow the purple one, but it does not, which would mean there are unreleased txs in "all" txs set, but that is not true - real reason is the missing metrics update. (The right triangle is after the fix.)