### PR TITLE
Allow disabling evm logs recording

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -78,6 +78,11 @@ var (
 		Usage: "Implementation of EVM to use (geth/lfvm/lfvm-si)",
 	}
 
+	disableLogsFlag = cli.BoolFlag{
+		Name:  "noevmlogs",
+		Usage: "Disable recording of EVM logs",
+	}
+
 	// DataDirFlag defines directory to store Lachesis state and user's wallets
 	DataDirFlag = utils.DirectoryFlag{
 		Name:  "datadir",
@@ -584,6 +589,10 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 	// Set default VM implementation
 	if impl := ctx.GlobalString(vmImplFlag.Name); impl != "" {
 		opera.DefaultVMConfig.InterpreterImpl = impl
+	}
+
+	if ctx.GlobalBool(disableLogsFlag.Name) {
+		cfg.OperaStore.EVM.DisableLogsIndexing = true
 	}
 
 	err = setValidator(ctx, &cfg.Emitter)

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -132,6 +132,7 @@ func initFlags() {
 		stateDbImplFlag,
 		archiveImplFlag,
 		vmImplFlag,
+		disableLogsFlag,
 	}
 	legacyRpcFlags = []cli.Flag{
 		utils.NoUSBFlag,

--- a/gossip/evmstore/config.go
+++ b/gossip/evmstore/config.go
@@ -36,6 +36,8 @@ type (
 		Cache StoreCacheConfig
 		// Enables tracking of SHA3 preimages in the VM
 		EnablePreimageRecording bool
+		// Disables EVM logs indexing
+		DisableLogsIndexing bool
 	}
 )
 

--- a/gossip/evmstore/store.go
+++ b/gossip/evmstore/store.go
@@ -77,7 +77,11 @@ func NewStore(dbs kvdb.DBProducer, cfg StoreConfig) *Store {
 	}
 
 	s.initEVMDB()
-	s.EvmLogs = topicsdb.NewWithThreadPool(dbs)
+	if cfg.DisableLogsIndexing {
+		s.EvmLogs = topicsdb.NewDummy()
+	} else {
+		s.EvmLogs = topicsdb.NewWithThreadPool(dbs)
+	}
 	s.initCache()
 
 	return s

--- a/topicsdb/dummy.go
+++ b/topicsdb/dummy.go
@@ -1,0 +1,25 @@
+package topicsdb
+
+import (
+	"context"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// dummyIndex is empty implementation of Index
+type dummyIndex struct{}
+
+func (n dummyIndex) FindInBlocks(ctx context.Context, from, to idx.Block, pattern [][]common.Hash) (logs []*types.Log, err error) {
+	return nil, ErrLogsNotRecorded
+}
+
+func (n dummyIndex) Push(recs ...*types.Log) error {
+	return nil
+}
+
+func (n dummyIndex) Close() {}
+
+func (n dummyIndex) WrapTablesAsBatched() (unwrap func()) {
+	return func() {}
+}

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -13,13 +13,13 @@ import (
 const maxTopicsCount = 5 // count is limited hard to 5 by EVM (see LOG0...LOG4 ops)
 
 var (
-	ErrEmptyTopics  = fmt.Errorf("empty topics")
-	ErrTooBigTopics = fmt.Errorf("too many topics")
+	ErrEmptyTopics     = fmt.Errorf("empty topics")
+	ErrTooBigTopics    = fmt.Errorf("too many topics")
+	ErrLogsNotRecorded = fmt.Errorf("logs are not being recorded")
 )
 
 type Index interface {
 	FindInBlocks(ctx context.Context, from, to idx.Block, pattern [][]common.Hash) (logs []*types.Log, err error)
-	ForEachInBlocks(ctx context.Context, from, to idx.Block, pattern [][]common.Hash, onLog func(*types.Log) (gonext bool)) error
 	Push(recs ...*types.Log) error
 	Close()
 
@@ -37,6 +37,10 @@ func New(dbs kvdb.DBProducer) Index {
 func NewWithThreadPool(dbs kvdb.DBProducer) Index {
 	tt := newIndex(dbs)
 	return &withThreadPool{tt}
+}
+
+func NewDummy() Index {
+	return &dummyIndex{}
 }
 
 func limitPattern(pattern [][]common.Hash) (limited [][]common.Hash, err error) {


### PR DESCRIPTION
This allows to disable recording of EVM logs emitted from contracts and save that way 60% of the disk space.

Adds cmd flag:
```
  --noevmlogs                         Disable recording of EVM logs
```