### PR TITLE
Allow disabling receipts storing (affects BlockRecord hash)

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -83,6 +83,11 @@ var (
 		Usage: "Disable recording of EVM logs",
 	}
 
+	disableReceiptsFlag = cli.BoolFlag{
+		Name:  "noreceipts",
+		Usage: "Disable recording of receipts",
+	}
+
 	// DataDirFlag defines directory to store Lachesis state and user's wallets
 	DataDirFlag = utils.DirectoryFlag{
 		Name:  "datadir",
@@ -593,6 +598,10 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 
 	if ctx.GlobalBool(disableLogsFlag.Name) {
 		cfg.OperaStore.EVM.DisableLogsIndexing = true
+	}
+
+	if ctx.GlobalBool(disableReceiptsFlag.Name) {
+		cfg.OperaStore.EVM.DisableReceiptsStoring = true
 	}
 
 	err = setValidator(ctx, &cfg.Emitter)

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -133,6 +133,7 @@ func initFlags() {
 		archiveImplFlag,
 		vmImplFlag,
 		disableLogsFlag,
+		disableReceiptsFlag,
 	}
 	legacyRpcFlags = []cli.Flag{
 		utils.NoUSBFlag,

--- a/gossip/evmstore/config.go
+++ b/gossip/evmstore/config.go
@@ -38,6 +38,8 @@ type (
 		EnablePreimageRecording bool
 		// Disables EVM logs indexing
 		DisableLogsIndexing bool
+		// Disables storing of txs receipts
+		DisableReceiptsStoring bool
 	}
 )
 

--- a/gossip/evmstore/store_receipts.go
+++ b/gossip/evmstore/store_receipts.go
@@ -13,6 +13,10 @@ import (
 
 // SetReceipts stores transaction receipts.
 func (s *Store) SetReceipts(n idx.Block, receipts types.Receipts) {
+	if s.cfg.DisableReceiptsStoring {
+		return
+	}
+
 	receiptsStorage := make([]*types.ReceiptForStorage, receipts.Len())
 	for i, r := range receipts {
 		receiptsStorage[i] = (*types.ReceiptForStorage)(r)
@@ -26,6 +30,10 @@ func (s *Store) SetReceipts(n idx.Block, receipts types.Receipts) {
 
 // SetRawReceipts stores raw transaction receipts.
 func (s *Store) SetRawReceipts(n idx.Block, receipts []*types.ReceiptForStorage) (size int) {
+	if s.cfg.DisableReceiptsStoring {
+		return 0
+	}
+
 	buf, err := rlp.EncodeToBytes(receipts)
 	if err != nil {
 		s.Log.Crit("Failed to encode rlp", "err", err)
@@ -50,6 +58,10 @@ func (s *Store) GetRawReceiptsRLP(n idx.Block) rlp.RawValue {
 }
 
 func (s *Store) GetRawReceipts(n idx.Block) ([]*types.ReceiptForStorage, int) {
+	if s.cfg.DisableReceiptsStoring {
+		return nil, 0
+	}
+
 	buf := s.GetRawReceiptsRLP(n)
 	if buf == nil {
 		return nil, 0
@@ -74,6 +86,10 @@ func UnwrapStorageReceipts(receiptsStorage []*types.ReceiptForStorage, n idx.Blo
 
 // GetReceipts returns stored transaction receipts.
 func (s *Store) GetReceipts(n idx.Block, signer types.Signer, hash common.Hash, txs types.Transactions) types.Receipts {
+	if s.cfg.DisableReceiptsStoring {
+		return nil
+	}
+
 	// Get data from LRU cache first.
 	if s.cache.Receipts != nil {
 		if c, ok := s.cache.Receipts.Get(n); ok {

--- a/inter/ibr/inter_block_records.go
+++ b/inter/ibr/inter_block_records.go
@@ -41,7 +41,7 @@ func (br LlrFullBlockRecord) Hash() hash.Hash {
 		Atropos:      br.Atropos,
 		Root:         br.Root,
 		TxHash:       inter.CalcTxHash(br.Txs),
-		ReceiptsHash: inter.CalcReceiptsHash(br.Receipts),
+		//ReceiptsHash: inter.CalcReceiptsHash(br.Receipts),
 		Time:         br.Time,
 		GasUsed:      br.GasUsed,
 	}.Hash()


### PR DESCRIPTION
This allows to disable storing of txs receipts to save cca 10% of the disk space on validators.

This removes receipts from the BlockRecord hash, to make sure validators with enabled and validators with disabled option will vote for the same BlockRecord hash. (Should be irrelevant if snapsync is not supported.)

This needs to be tested more deeply yet for side effects!