### PR TITLE
Allow disabling TxPosition indexing

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -83,6 +83,11 @@ var (
 		Usage: "Disable recording of EVM logs",
 	}
 
+	disableTxHashesFlag = cli.BoolFlag{
+		Name:  "notxhashes",
+		Usage: "Disable indexing of tx hashes",
+	}
+
 	// DataDirFlag defines directory to store Lachesis state and user's wallets
 	DataDirFlag = utils.DirectoryFlag{
 		Name:  "datadir",
@@ -593,6 +598,10 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 
 	if ctx.GlobalBool(disableLogsFlag.Name) {
 		cfg.OperaStore.EVM.DisableLogsIndexing = true
+	}
+
+	if ctx.GlobalBool(disableTxHashesFlag.Name) {
+		cfg.OperaStore.EVM.DisableTxHashesIndexing = true
 	}
 
 	err = setValidator(ctx, &cfg.Emitter)

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -133,6 +133,7 @@ func initFlags() {
 		archiveImplFlag,
 		vmImplFlag,
 		disableLogsFlag,
+		disableTxHashesFlag,
 	}
 	legacyRpcFlags = []cli.Flag{
 		utils.NoUSBFlag,

--- a/gossip/evmstore/config.go
+++ b/gossip/evmstore/config.go
@@ -38,6 +38,8 @@ type (
 		EnablePreimageRecording bool
 		// Disables EVM logs indexing
 		DisableLogsIndexing bool
+		// Disables storing of txs positions
+		DisableTxHashesIndexing bool
 	}
 )
 

--- a/gossip/evmstore/store_tx_position.go
+++ b/gossip/evmstore/store_tx_position.go
@@ -19,6 +19,10 @@ type TxPosition struct {
 
 // SetTxPosition stores transaction block and position.
 func (s *Store) SetTxPosition(txid common.Hash, position TxPosition) {
+	if s.cfg.DisableTxHashesIndexing {
+		return
+	}
+
 	s.rlp.Set(s.table.TxPositions, txid.Bytes(), &position)
 
 	// Add to LRU cache.
@@ -27,6 +31,10 @@ func (s *Store) SetTxPosition(txid common.Hash, position TxPosition) {
 
 // GetTxPosition returns stored transaction block and position.
 func (s *Store) GetTxPosition(txid common.Hash) *TxPosition {
+	if s.cfg.DisableTxHashesIndexing {
+		return nil
+	}
+
 	// Get data from LRU cache first.
 	if c, ok := s.cache.TxPositions.Get(txid.String()); ok {
 		if b, ok := c.(*TxPosition); ok {


### PR DESCRIPTION
This allows to disable index of TxPositions.
This db table maps tx hashes to their position in events and allows to obtain a tx by hash from the event in the db.
(For non-event txs it maps to block number.)

This should reduce the disk usage of "txs" database for validator nodes at the absolute minimum, so it can bring up to 10% reduction of opera datadir.

The "txs" database contains otherwise non-event txs (epoch sealing txs, txs from genesis, txs from snapsync), which should be insignificant and is required for FullBlockRecords.

(This was tested locally only for now, waiting for new testing network.)