### PR TITLE
Fix txpool test synchronization issue

### DIFF
--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -1349,7 +1349,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 		txs = append(txs, transaction(uint64(j), 100000, key))
 	}
 	// Import the batch and verify that limits have been enforced
-	pool.AddRemotes(txs)
+	pool.AddRemotesSync(txs)
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
@@ -2043,7 +2043,7 @@ func TestDualHeapEviction(t *testing.T) {
 				highCap = txs[i]
 			}
 		}
-		pool.AddRemotes(txs)
+		pool.AddRemotesSync(txs)
 		pending, queued := pool.Stats()
 		if pending+queued != 20 {
 			t.Fatalf("transaction count mismatch: have %d, want %d", pending+queued, 10)


### PR DESCRIPTION
This should fix random failures of txpool unit tests:
```
=== NAME  TestDualHeapEviction
    tx_pool_test.go:2049: transaction count mismatch: have 13, want 10
--- FAIL: TestDualHeapEviction (0.14s)
```
The tests adds txs asynchronous - without waiting until their adding finish.
The unit test fails if the txpool stats checked too soon.