### PR TITLE
Remove snapsync from protocols

### DIFF
--- a/gossip/service.go
+++ b/gossip/service.go
@@ -3,7 +3,6 @@ package gossip
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"math/big"
 	"math/rand"
 	"sync"
@@ -392,10 +391,7 @@ func MakeProtocols(svc *Service, backend *handler, disc enode.Iterator) []p2p.Pr
 
 // Protocols returns protocols the service can communicate on.
 func (s *Service) Protocols() []p2p.Protocol {
-	protos := append(
-		MakeProtocols(s, s.handler, s.operaDialCandidates),
-		snap.MakeProtocols((*snapHandler)(s.handler), s.snapDialCandidates)...)
-	return protos
+	return MakeProtocols(s, s.handler, s.operaDialCandidates)
 }
 
 // APIs returns api methods the service wants to expose on rpc channels.


### PR DESCRIPTION
This removes the fantom snapsync protocol from the client advertised protocols and avoids crashes like this:

```
Oct 12 19:52:16 demon038 opera[274671]: panic: runtime error: invalid memory address or nil pointer dereference
Oct 12 19:52:16 demon038 opera[274671]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7bc0d0]
Oct 12 19:52:16 demon038 opera[274671]: goroutine 522690 [running]:
Oct 12 19:52:16 demon038 opera[274671]: github.com/ethereum/go-ethereum/core/state/snapshot.(*Tree).generating(0x0)
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/core/state/snapshot/snapshot.go:817 +0x30
Oct 12 19:52:16 demon038 opera[274671]: github.com/ethereum/go-ethereum/core/state/snapshot.(*Tree).StorageIterator(0x16cadc0?, {0xbc, 0xab, 0xb3, 0xca, 0xd0, 0x41, 0xed, 0x9a, 0x2a, ...}, ...)
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/core/state/snapshot/snapshot.go:741 +0x27
Oct 12 19:52:16 demon038 opera[274671]: github.com/ethereum/go-ethereum/eth/protocols/snap.handleMessage({0x1be2d18, 0xc0322d4600}, 0xc0bf41bc40)
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/eth/protocols/snap/handler.go:288 +0x2598
Oct 12 19:52:16 demon038 opera[274671]: github.com/ethereum/go-ethereum/eth/protocols/snap.handle({0x1be2d18, 0xc0322d4600}, 0xc0bf41bc40)
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/eth/protocols/snap/handler.go:133 +0x37
Oct 12 19:52:16 demon038 opera[274671]: github.com/ethereum/go-ethereum/eth/protocols/snap.MakeProtocols.func2.1(0xc0323f6280?)
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/eth/protocols/snap/handler.go:113 +0x25
Oct 12 19:52:16 demon038 opera[274671]: github.com/Fantom-foundation/go-opera/gossip.(*handler).runSnapExtension(0xc0322d4600, 0xc0bf41bc40, 0xc0c7e79cf8)
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go-opera-norma/gossip/handler_snap.go:68 +0x244
Oct 12 19:52:16 demon038 opera[274671]: github.com/Fantom-foundation/go-opera/gossip.(*snapHandler).RunPeer(0x1?, 0xc0da5fbc20?, 0x1bda310?)
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go-opera-norma/gossip/handler_snap.go:34 +0x13
Oct 12 19:52:16 demon038 opera[274671]: github.com/ethereum/go-ethereum/eth/protocols/snap.MakeProtocols.func2(0x0?, {0x1bda310?, 0xc0877b1360?})
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/eth/protocols/snap/handler.go:112 +0x9b
Oct 12 19:52:16 demon038 opera[274671]: github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/p2p/peer.go:407 +0x7b
Oct 12 19:52:16 demon038 opera[274671]: created by github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols in goroutine 522542
Oct 12 19:52:16 demon038 opera[274671]:         /home/jkalina/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/p2p/peer.go:405 +0x9e
```

This also removes the condition, which marks peers, which does not supports snapsync, as useless. (The node allows only 10% of useless peers - rejects useless peers with "too many peers" err if not enough useful peers are connected.)

**Warning to consider:** After this change, the node advertise it does not support snapsync, which will make difficult for it to find some peers in mainnet. (Because other nodes will apply the "useless-ness" condition above.)