### PR TITLE
Remove OverrideMinGasPrice from the binary genesis structure

### DIFF
--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -104,8 +104,8 @@ func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
 		rules.Economy.LongGasPower.AllocPerSec = *json.Rules.LongGasAllocPerSec
 	}
 	if json.Rules.OverrideMinGasPrice != nil {
-		rules.Economy.OverrideMinGasPrice = big.NewInt(int64(*json.Rules.OverrideMinGasPrice))
-		rules.Economy.MinGasPrice = rules.Economy.OverrideMinGasPrice
+		opera.OverrideMinGasPrice = big.NewInt(int64(*json.Rules.OverrideMinGasPrice))
+		rules.Economy.MinGasPrice = opera.OverrideMinGasPrice
 	}
 
 	builder.SetCurrentEpoch(ier.LlrIdxFullEpochRecord{

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -13,8 +13,8 @@ func UpdateRules(src Rules, diff []byte) (res Rules, err error) {
 	res.NetworkID = src.NetworkID
 	res.Name = src.Name
 	// norma specific override of MinGasPrice by overridden value
-	if res.Economy.OverrideMinGasPrice != nil && res.Economy.OverrideMinGasPrice.Sign() > 0 {
-		res.Economy.MinGasPrice = res.Economy.OverrideMinGasPrice
+	if OverrideMinGasPrice != nil && OverrideMinGasPrice.Sign() > 0 {
+		res.Economy.MinGasPrice = OverrideMinGasPrice
 	}
 	return
 }

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -30,6 +30,9 @@ var DefaultVMConfig = vm.Config{
 	},
 }
 
+// OverrideMinGasPrice is a Norma specific override of MinGasPrice
+var OverrideMinGasPrice *big.Int
+
 // FakeGasPowerCoefficient multiplies gas limits in Fakenet - allows to increase the network throughput
 // by increasing the amount of gas per block, event, epoch and for each validator per second
 var FakeGasPowerCoefficient = uint64(1)
@@ -104,9 +107,6 @@ type EconomyRules struct {
 	Gas GasRules
 
 	MinGasPrice *big.Int
-
-	// norma specific override of MinGasPrice
-	OverrideMinGasPrice *big.Int
 
 	ShortGasPower GasPowerRules
 	LongGasPower  GasPowerRules
@@ -210,7 +210,6 @@ func DefaultEconomyRules() EconomyRules {
 		BlockMissedSlack: 50,
 		Gas:              DefaultGasRules(),
 		MinGasPrice:      big.NewInt(1e9),
-		OverrideMinGasPrice: big.NewInt(0),
 		ShortGasPower:    DefaultShortGasPowerRules(),
 		LongGasPower:     DefaulLongGasPowerRules(),
 	}


### PR DESCRIPTION
go-opera-norma currently fails to use official mainnet genesis file (fails to unmarshal), because a new field have been added into its rules structure.
This moves the additional `OverrideMinGasPrice` into a standalone variable, outside of the rules structure.

This PR keeps the field in JSON genesis file, only the binary-genesis structure is affected, no config changes are necessary at our testing servers.

(The `OverrideMinGasPrice` field is relevant only for testnet usages, should not be part of the production node.)