### PR TITLE
Fix MinGasPrice override - move into flags

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/evmstore"
 	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/statedb"
+	"math/big"
 	"os"
 	"path"
 	"path/filepath"
@@ -68,12 +69,10 @@ var (
 		Name:  "statedb.impl",
 		Usage: "Implementation of StateDB to use (geth/carmen-s3/carmen-s5)",
 	}
-
 	archiveImplFlag = cli.StringFlag{
 		Name:  "archive.impl",
 		Usage: "Implementation of Carmen Archive to use (none/ldb/s5)",
 	}
-
 	vmImplFlag = cli.StringFlag{
 		Name:  "vm.impl",
 		Usage: "Implementation of EVM to use (geth/lfvm/lfvm-si)",
@@ -83,7 +82,6 @@ var (
 		Name:  "noevmlogs",
 		Usage: "Disable recording of EVM logs",
 	}
-
 	disableTxHashesFlag = cli.BoolFlag{
 		Name:  "notxhashes",
 		Usage: "Disable indexing of tx hashes",
@@ -92,6 +90,11 @@ var (
 	carmenEvmStoreFlag = cli.BoolFlag{
 		Name:  "carmenevmstore",
 		Usage: "Switch to using Carmen EvmStore for receipts and txs.",
+	}
+
+	overrideMinGasPriceFlag = cli.Uint64Flag{
+		Name: "overridemingasprice",
+		Usage: "Override the MinGasPrice with given value",
 	}
 
 	// DataDirFlag defines directory to store Lachesis state and user's wallets
@@ -600,6 +603,10 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 	// Set default VM implementation
 	if impl := ctx.GlobalString(vmImplFlag.Name); impl != "" {
 		opera.DefaultVMConfig.InterpreterImpl = impl
+	}
+
+	if overrideMinGasPrice := ctx.GlobalUint64(overrideMinGasPriceFlag.Name); overrideMinGasPrice != 0 {
+		opera.OverrideMinGasPrice = big.NewInt(int64(overrideMinGasPrice))
 	}
 
 	if ctx.GlobalBool(disableLogsFlag.Name) {

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -135,6 +135,7 @@ func initFlags() {
 		disableLogsFlag,
 		disableTxHashesFlag,
 		carmenEvmStoreFlag,
+		overrideMinGasPriceFlag,
 	}
 	legacyRpcFlags = []cli.Flag{
 		utils.NoUSBFlag,

--- a/example-genesis.json
+++ b/example-genesis.json
@@ -7,8 +7,7 @@
     "MaxEventGas": 10028000000,
     "MaxEpochGas": 1500000000000,
     "ShortGasAllocPerSec": 5600000000000,
-    "LongGasAllocPerSec": 2800000000000,
-    "OverrideMinGasPrice": 10
+    "LongGasAllocPerSec": 2800000000000
   },
   "accounts": [
     {

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -38,7 +38,6 @@ type NetworkRules struct {
 	MaxEventGas         *uint64 `json:",omitempty"`
 	LongGasAllocPerSec  *uint64 `json:",omitempty"`
 	ShortGasAllocPerSec *uint64 `json:",omitempty"`
-	OverrideMinGasPrice *uint64 `json:",omitempty"`
 }
 
 type Account struct {
@@ -102,10 +101,6 @@ func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
 	}
 	if json.Rules.LongGasAllocPerSec != nil {
 		rules.Economy.LongGasPower.AllocPerSec = *json.Rules.LongGasAllocPerSec
-	}
-	if json.Rules.OverrideMinGasPrice != nil {
-		opera.OverrideMinGasPrice = big.NewInt(int64(*json.Rules.OverrideMinGasPrice))
-		rules.Economy.MinGasPrice = opera.OverrideMinGasPrice
 	}
 
 	builder.SetCurrentEpoch(ier.LlrIdxFullEpochRecord{

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -206,13 +206,18 @@ func FakeNetRules() Rules {
 
 // DefaultEconomyRules returns mainnet economy
 func DefaultEconomyRules() EconomyRules {
-	return EconomyRules{
+	rules := EconomyRules{
 		BlockMissedSlack: 50,
 		Gas:              DefaultGasRules(),
 		MinGasPrice:      big.NewInt(1e9),
 		ShortGasPower:    DefaultShortGasPowerRules(),
 		LongGasPower:     DefaulLongGasPowerRules(),
 	}
+	// hack for performance testing
+	if OverrideMinGasPrice != nil && OverrideMinGasPrice.Sign() > 0 {
+		rules.MinGasPrice = OverrideMinGasPrice
+	}
+	return rules
 }
 
 // FakeEconomyRules returns fakenet economy


### PR DESCRIPTION
This if fix of #56, where was OverrideMinGasPrice removed from the opera rules binary structure.
Now is the override applied only when the genesis file is applied, which means the configuration is lost after the node restart. (the genesis application is skipped, as it is already applied)

From this reason, the override is not configured from the genesis file anymore, I am moving it here into node cmd parameters:
```
 --overridemingasprice=123 
```