### PR TITLE
Reenable network id check when connecting a peer

### DIFF
--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -494,7 +494,7 @@ func (p *peer) Handshake(network uint64, progress PeerProgress, genesis common.H
 		// send both HandshakeMsg and ProgressMsg
 		err := p2p.Send(p.rw, HandshakeMsg, &handshakeData{
 			ProtocolVersion: uint32(p.version),
-			NetworkID:       0, // TODO: set to `network` after all nodes updated to #184
+			NetworkID:       network,
 			Genesis:         genesis,
 		})
 		if err != nil {


### PR DESCRIPTION
There is an old TODO added in https://github.com/Fantom-foundation/go-opera/pull/184/files - the NetworkID check have been disabled in Opera 2 years ago, to be reenabled when all network nodes upgrades to the fixed version.
I think we can reenable this already...

___
Note: We may want to remove also this in future, however it would break the compatibility now:
```
	// TODO: rm after all the nodes updated to #184
	if handshake.NetworkID == 0 {
		handshake.NetworkID = network
	}
```