### PR TITLE
Remove RecoverEVM (does not work with Carmen)

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -477,52 +477,6 @@ func consensusCallbackBeginBlockFn(
 	}
 }
 
-func (s *Service) ReexecuteBlocks(from, to idx.Block) {
-	blockProc := s.blockProcModules
-	upgradeHeights := s.store.GetUpgradeHeights()
-	evmStateReader := s.GetEvmStateReader()
-	prev := s.store.GetBlock(from)
-	for b := from + 1; b <= to; b++ {
-		block := s.store.GetBlock(b)
-		blockCtx := iblockproc.BlockCtx{
-			Idx:     b,
-			Time:    block.Time,
-			Atropos: block.Atropos,
-		}
-		statedb, err := s.store.evm.StateDB(prev.Root)
-		if err != nil {
-			log.Crit("Failue to re-execute blocks", "err", err)
-		}
-		es := s.store.GetHistoryEpochState(s.store.FindBlockEpoch(b))
-		evmProcessor := blockProc.EVMModule.Start(blockCtx, statedb, evmStateReader, func(t *types.Log) {}, es.Rules, es.Rules.EvmChainConfig(upgradeHeights))
-		txs := s.store.GetBlockTxs(b, block)
-		evmProcessor.Execute(txs)
-		evmProcessor.Finalize()
-		statedb.Release()
-		_ = s.store.evm.Commit(b, block.Root, false)
-		s.store.evm.Cap()
-		s.mayCommit(false)
-		prev = block
-	}
-}
-
-func (s *Service) RecoverEVM() {
-	start := s.store.GetLatestBlockIndex()
-	for b := start; b >= 1 && b > start-20000; b-- {
-		block := s.store.GetBlock(b)
-		if block == nil {
-			break
-		}
-		if s.store.evm.HasStateDB(block.Root) {
-			if b != start {
-				s.Log.Warn("Reexecuting blocks after abrupt stopping", "from", b, "to", start)
-				s.ReexecuteBlocks(b, start)
-			}
-			break
-		}
-	}
-}
-
 // spillBlockEvents excludes first events which exceed MaxBlockGas
 func spillBlockEvents(store *Store, block *inter.Block, network opera.Rules) (*inter.Block, inter.EventPayloads) {
 	fullEvents := make(inter.EventPayloads, len(block.Events))

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -434,7 +434,6 @@ func (s *Service) Start() error {
 	if s.store.evm.IsEvmSnapshotPaused() && !s.config.AllowSnapsync {
 		return errors.New("cannot halt snapsync and start fullsync")
 	}
-	s.RecoverEVM()
 	root := s.store.GetBlockState().FinalizedStateRoot
 	if !s.store.evm.HasStateDB(root) {
 		if !s.config.AllowSnapsync {


### PR DESCRIPTION
RecoverEVM method allows to fix legacy EVM state, however it cannot be used with Carmen.

RecoverEVM finds in EVM data the last stateRoot, which is correctly written and then it reexecutes following blocks on it to obtain the latest state (where all known block are applied).
In theory, it could work with Carmen, if we introduce State, which would read the archive, but commit into live state. But it would work only when the live state would be the state of some previous block, not something in-between, when a part of block batch would be written, so it does not seems to be useful enough to sustain it.