### PR TITLE
Remove checking of stateRoot for TxPool - using newer state is ok

### DIFF
--- a/statedb/switch.go
+++ b/statedb/switch.go
@@ -182,9 +182,7 @@ func GetLiveStateDb(stateRoot hash.Hash, evmState state.Database, snaps *snapsho
 // GetTxPoolStateDb obtains StateDB for TxPool evaluation - the latest finalized, read-only
 func GetTxPoolStateDb(stateRoot common.Hash, evmState state.Database, snaps *snapshot.Tree) (*state.StateDB, error) {
 	if carmenState != nil {
-		if compatibleHashes && liveStateDb.GetHash() != cc.Hash(stateRoot) {
-			return nil, fmt.Errorf("unable to get Carmen live StateDB (txpool) - unexpected state root (%x != %x)", liveStateDb.GetHash(), stateRoot)
-		}
+		// for TxPool it is ok to provide a newer state (with a different hash)
 		stateDb := carmen.CreateNonCommittableStateDBUsing(carmenState)
 		return state.NewWrapper(CreateCarmenStateDb(stateDb)), nil
 	} else {


### PR DESCRIPTION
Current version too often produce errors like this:
```
Nov 29 12:09:15 demon060 opera[291516]: ERROR[11-29|12:09:15.164] Failed to reset txpool state             block=820,915 root=10e4cd..c42182  err="unable to get Carmen live StateDB (txpool) - unexpected state root (986861f5cfec15b620d262073785aedb3fe6b7c057593ec6a88ffd713b019485 != 10e4cd85ff3b67a1d189c1e69a255ba9d5c4bea8a47c32c863697fc67bc42182)"
```
The actual state hash (9868...) is actually the hash of the following block's state - TxPool reset signal arrives late and the LiveState already contains a state for the following block. But this is OK for TxPool purposes - we can safely ignore the expected stateRoot for TxPool and just always provide the most up-to-date state.
The assertion was just unnecessary strong. 