### PR TITLE
Upgrade Tosca and Carmen (incompatible S5 change)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,8 @@ require (
 )
 
 require (
-	github.com/Fantom-foundation/Carmen/go v0.0.0-20231124092524-cc66783f55ae
-	github.com/Fantom-foundation/Tosca v0.0.0-20231103111201-05bbc1e5ebfc
+	github.com/Fantom-foundation/Carmen/go v0.0.0-20231129181318-ae939c03e7cd
+	github.com/Fantom-foundation/Tosca v0.0.0-20231128155433-68fe1e727ad7
 )
 
 require (
@@ -116,6 +116,7 @@ require (
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	pgregory.net/rand v1.0.2 // indirect
 )
 
 replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20231003122306-febfe681b4a7

--- a/go.sum
+++ b/go.sum
@@ -57,10 +57,10 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20231124092524-cc66783f55ae h1:9rvJ9u+fTkwF4FHScOOcL/GGEVDA3X2KlCcWpXmGDI0=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20231124092524-cc66783f55ae/go.mod h1:zfuEHNMEp1q5Nt7U8Uf28Ary8kNXfVQT7TQv0urQgDY=
-github.com/Fantom-foundation/Tosca v0.0.0-20231103111201-05bbc1e5ebfc h1:yr0MZ1ZCFjo2SyoKHcFd+LqX3vNP0Vu88CnybsncWRw=
-github.com/Fantom-foundation/Tosca v0.0.0-20231103111201-05bbc1e5ebfc/go.mod h1:0IgKse/LqcyoneFnQSrBqw/lQ3CHopUcdWmqnAJiQLA=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20231129181318-ae939c03e7cd h1:eZXObU0xYR2F22GZQKErXhljMknuUMnMx5eDs5iWANs=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20231129181318-ae939c03e7cd/go.mod h1:zfuEHNMEp1q5Nt7U8Uf28Ary8kNXfVQT7TQv0urQgDY=
+github.com/Fantom-foundation/Tosca v0.0.0-20231128155433-68fe1e727ad7 h1:xhjgoifoss7pt+O97ADXSh3Q283sW7zb6oNlMQZlj04=
+github.com/Fantom-foundation/Tosca v0.0.0-20231128155433-68fe1e727ad7/go.mod h1:0IgKse/LqcyoneFnQSrBqw/lQ3CHopUcdWmqnAJiQLA=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20231003122306-febfe681b4a7 h1:AWVp8bMwysTNE2/yORyxk4KF+isK9wFkPeLsT7SYS10=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20231003122306-febfe681b4a7/go.mod h1:qk1JSsat4pdiDpbt6T4MmcGp02kiq8xOREvDhiKJoFQ=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20230629034932-42bae8eeb426 h1:TCsCxpzd2ETqHJMdkw09Ck1mmnNgx/Z4h6i6kDOexYI=
@@ -618,6 +618,8 @@ github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6S
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=
+github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
+github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
@@ -1034,6 +1036,10 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+pgregory.net/rand v1.0.2 h1:ASEbkvwOmY/UPF2evJPBJ8XZg71xdKWYdByqKapI7Vw=
+pgregory.net/rand v1.0.2/go.mod h1:EyNx8APnDE3Svi8sWgUZ5lOiz60cNZUPPBTyzOUpPl4=
+pgregory.net/rapid v0.4.8 h1:d+5SGZWUbJPbl3ss6tmPFqnNeQR6VDOFly+eTjwPiEw=
+pgregory.net/rapid v0.4.8/go.mod h1:Z5PbWqjvWR1I3UGjvboUuan4fe4ZYEYNLNQLExzCoUs=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=


### PR DESCRIPTION
Upgrade Tosca and Carmen to up-to-date version.

Carmen upgrade includes a change in the database format - **old db backups will not be usable**.