### PR TITLE
Revert moving txs/receipts into separated dbs

### DIFF
--- a/integration/presets.go
+++ b/integration/presets.go
@@ -43,21 +43,6 @@ func Pbl1RoutingConfig() RoutingConfig {
 				Type: "pebble-fsh",
 				Name: "events",
 			},
-			"evm/X": { // tx hash -> tx
-				Type: "pebble-fsh",
-				Name: "txs",
-				Table: "X",
-			},
-			"evm/x": { // tx hash -> tx position
-				Type: "pebble-fsh",
-				Name: "txs",
-				Table: "x",
-			},
-			"evm/r": { // block id -> receipts
-				Type: "pebble-fsh",
-				Name: "receipts",
-			},
-
 			"evm/M": {
 				Type: "pebble-drc",
 				Name: "evm-data",


### PR DESCRIPTION
This reverts https://github.com/Fantom-foundation/go-opera-norma/pull/37 - moving txs and receipts into a standalone database in the default presets.

It does not bring any benefit except easier measuring of the consumed space during testing.

It is still possible to do this by configuring it in the config toml file.

I want to revert this change for easier migration of legacy nodes - avoiding the need for migration.