### PR TITLE
Fix race in peer progress

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -292,7 +292,7 @@ func newHandler(
 			if p == nil || p.Useless() {
 				return 0
 			}
-			return p.GetEpoch()
+			return p.GetProgress().Epoch
 		},
 	})
 	h.dagSeeder = dagstreamseeder.New(h.config.Protocol.DagStreamSeeder, dagstreamseeder.Callbacks{
@@ -328,7 +328,7 @@ func newHandler(
 			if p == nil || p.Useless() {
 				return 0
 			}
-			return p.GetLastBlockIdx()
+			return p.GetProgress().LastBlockIdx
 		},
 	})
 	h.bvSeeder = bvstreamseeder.New(h.config.Protocol.BvStreamSeeder, bvstreamseeder.Callbacks{
@@ -369,7 +369,7 @@ func newHandler(
 			if p == nil || p.Useless() {
 				return 0
 			}
-			return p.GetLastBlockIdx()
+			return p.GetProgress().LastBlockIdx
 		},
 	})
 	h.brSeeder = brstreamseeder.New(h.config.Protocol.BrStreamSeeder, brstreamseeder.Callbacks{
@@ -407,7 +407,7 @@ func newHandler(
 			if p == nil || p.Useless() {
 				return 0
 			}
-			return p.GetEpoch()
+			return p.GetProgress().Epoch
 		},
 	})
 	h.epSeeder = epstreamseeder.New(h.config.Protocol.EpStreamSeeder, epstreamseeder.Callbacks{

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -103,14 +103,6 @@ func (p *peer) GetProgress() PeerProgress {
 	return p.progress
 }
 
-func (p *peer) GetEpoch() idx.Epoch {
-	return (idx.Epoch)(atomic.LoadUint32((*uint32)(&p.progress.Epoch)))
-}
-
-func (p *peer) GetLastBlockIdx() idx.Block {
-	return (idx.Block)(atomic.LoadUint64((*uint64)(&p.progress.LastBlockIdx)))
-}
-
 func (p *peer) InterestedIn(h hash.Event) bool {
 	e := h.Epoch()
 


### PR DESCRIPTION
Should fix following race:
```
==================
WARNING: DATA RACE
Read at 0x00c079f6e188 by goroutine 2528:
  github.com/Fantom-foundation/go-opera/gossip.newHandler.func7()
      /home/jand/go-opera-norma/gossip/handler.go:295 +0xa4   // (gossip.peer).progress.Epoch
  github.com/Fantom-foundation/go-opera/gossip/protocols/dag/dagstream/dagstreamleecher.(*Leecher).selectSessionPeerCandidates()
      /home/jand/go-opera-norma/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go:114 +0x2d5
  github.com/Fantom-foundation/go-opera/gossip/protocols/dag/dagstream/dagstreamleecher.(*Leecher).selectSessionPeerCandidates-fm()
      <autogenerated>:1 +0x33
  github.com/Fantom-foundation/lachesis-base/gossip/basestream/basestreamleecher.(*BaseLeecher).Routine()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/basestream/basestreamleecher/base_leecher.go:62 +0xde
  github.com/Fantom-foundation/lachesis-base/gossip/basestream/basestreamleecher.(*BaseLeecher).loop()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/basestream/basestreamleecher/base_leecher.go:78 +0xf1
  github.com/Fantom-foundation/lachesis-base/gossip/basestream/basestreamleecher.(*BaseLeecher).Start.func1()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/basestream/basestreamleecher/base_leecher.go:50 +0x68

Previous write at 0x00c079f6e188 by goroutine 2600:
  github.com/Fantom-foundation/go-opera/gossip.(*peer).SetProgress()
      /home/jand/go-opera-norma/gossip/peer.go:96 +0x94
  github.com/Fantom-foundation/go-opera/gossip.(*handler).handleMsg()
      /home/jand/go-opera-norma/gossip/handler.go:1015 +0x3eb3
  github.com/Fantom-foundation/go-opera/gossip.(*handler).handle()
      /home/jand/go-opera-norma/gossip/handler.go:852 +0x1bec
  github.com/Fantom-foundation/go-opera/gossip.MakeProtocols.func1()
      /home/jand/go-opera-norma/gossip/service.go:373 +0x1ea
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/p2p/peer.go:407 +0xf4

Goroutine 2528 (running) created at:
  github.com/Fantom-foundation/lachesis-base/gossip/basestream/basestreamleecher.(*BaseLeecher).Start()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/basestream/basestreamleecher/base_leecher.go:48 +0xa5
  github.com/Fantom-foundation/go-opera/gossip.(*handler).Start()
      /home/jand/go-opera-norma/gossip/handler.go:696 +0xa3a
  github.com/Fantom-foundation/go-opera/gossip.(*Service).Start()
      /home/jand/go-opera-norma/gossip/service.go:451 +0x504
...

Goroutine 2600 (running) created at:
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/p2p/peer.go:405 +0x111
  github.com/ethereum/go-ethereum/p2p.(*Peer).run()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/p2p/peer.go:250 +0x219
  github.com/ethereum/go-ethereum/p2p.(*Server).runPeer()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/p2p/server.go:1081 +0x373
  github.com/ethereum/go-ethereum/p2p.(*Server).launchPeer.func1()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/p2p/server.go:1064 +0x44
==================
```