### PR TITLE
Fix genesis tools after moving live state into live dir

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -657,7 +657,7 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 	}
 
 	if ctx.GlobalBool(carmenEvmStoreFlag.Name) {
-		evmStoreDir := filepath.Join(cfg.Node.DataDir, "carmen")
+		evmStoreDir := filepath.Join(cfg.Node.DataDir, "carmen", "evmstore")
 		err := os.MkdirAll(evmStoreDir, 0700)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create carmen evmstore dir; %v", err)

--- a/cmd/opera/launcher/genesiscmd.go
+++ b/cmd/opera/launcher/genesiscmd.go
@@ -413,7 +413,7 @@ func exportGenesis(ctx *cli.Context) error {
 			return err
 		}
 
-		err = mptIo.Export(filepath.Join(cfg.Node.DataDir, "carmen"), writer)
+		err = mptIo.Export(filepath.Join(cfg.Node.DataDir, "carmen", "live"), writer)
 		if err != nil {
 			return err
 		}

--- a/statedb/import.go
+++ b/statedb/import.go
@@ -44,15 +44,16 @@ func (m *StateDbManager) ImportWorldState(liveReader io.Reader, archiveReader io
 		return fmt.Errorf("carmen state must be closed before the FWS data import")
 	}
 
-	if err := os.MkdirAll(m.parameters.Directory, 0700); err != nil {
+	liveDir := filepath.Join(m.parameters.Directory, "live")
+	if err := os.MkdirAll(liveDir, 0700); err != nil {
 		return fmt.Errorf("failed to create carmen dir during FWS import; %v", err)
 	}
-	if err := io2.ImportLiveDb(m.parameters.Directory, liveReader); err != nil {
+	if err := io2.ImportLiveDb(liveDir, liveReader); err != nil {
 		return fmt.Errorf("failed to import LiveDB; %v", err)
 	}
 
 	if m.parameters.Archive == carmen.S5Archive {
-		archiveDir := m.parameters.Directory + string(filepath.Separator) + "archive"
+		archiveDir := filepath.Join(m.parameters.Directory, "archive")
 		if err := os.MkdirAll(archiveDir, 0700); err != nil {
 			return fmt.Errorf("failed to create carmen archive dir during FWS import; %v", err)
 		}

--- a/statedb/verify.go
+++ b/statedb/verify.go
@@ -32,11 +32,12 @@ func (m *StateDbManager) VerifyWorldState(expectedBlockNum uint64, expectedHash 
 	m.logger.Log.Info("State hash matches the last block state root.")
 
 	// verify the live world state
-	info, err := io.CheckMptDirectoryAndGetInfo(m.parameters.Directory)
+	liveDir := filepath.Join(m.parameters.Directory, "live")
+	info, err := io.CheckMptDirectoryAndGetInfo(liveDir)
 	if err != nil {
 		return fmt.Errorf("failed to check live state dir: %w", err)
 	}
-	if err := mpt.VerifyFileLiveTrie(m.parameters.Directory, info.Config, observer); err != nil {
+	if err := mpt.VerifyFileLiveTrie(liveDir, info.Config, observer); err != nil {
 		return fmt.Errorf("live state verification failed: %w", err)
 	}
 	m.logger.Log.Info("Live state verified successfully.")
@@ -45,7 +46,7 @@ func (m *StateDbManager) VerifyWorldState(expectedBlockNum uint64, expectedHash 
 	if m.parameters.Archive != carmen.S5Archive {
 		return nil // skip archive checks when S5 archive is not used
 	}
-	archiveDir := m.parameters.Directory + string(filepath.Separator) + "archive"
+	archiveDir := filepath.Join(m.parameters.Directory, "archive")
 	archiveInfo, err := io.CheckMptDirectoryAndGetInfo(archiveDir)
 	if err != nil {
 		return fmt.Errorf("failed to check archive dir: %w", err)


### PR DESCRIPTION
New Carmen version have moved live state database from `datadir/carmen` into `datadir/carmen/live`.

This fixes related tools to reflect this change.