### PR TITLE
Turn db heal tool to db revert tool

### DIFF
--- a/cmd/opera/launcher/dbcmd.go
+++ b/cmd/opera/launcher/dbcmd.go
@@ -23,6 +23,10 @@ var (
 		Name:  "experimental",
 		Usage: "Allow experimental DB fixing",
 	}
+	targetEpochFlag = cli.Uint64Flag{
+		Name:  "target.epoch",
+		Usage: "The target epoch number to revert the db state to",
+	}
 	dbCommand = cli.Command{
 		Name:        "db",
 		Usage:       "A set of commands related to leveldb database",
@@ -58,18 +62,20 @@ will migrate tables layout according to the configuration.
 `,
 			},
 			{
-				Name:      "heal",
-				Usage:     "Experimental - try to heal dirty DB",
+				Name:      "revert",
+				Usage:     "Experimental - revert Opera database to given epoch",
 				ArgsUsage: "",
-				Action:    utils.MigrateFlags(healDirty),
+				Action:    utils.MigrateFlags(revertDb),
 				Category:  "DB COMMANDS",
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
 					experimentalFlag,
+					targetEpochFlag,
 				},
 				Description: `
-opera db heal --experimental
-Experimental - try to heal dirty DB.
+opera db revert --experimental --target.epoch 123
+Experimental - revert the DB state to given epoch.
+If Carmen is used, its database must be replaced with appropriate older version manually.
 `,
 			},
 		},


### PR DESCRIPTION
This tool allows to revert state of the leveldb opera database to given previous epoch start before starting using a pre-prepared carmen database generated by aida for the given epoch.