### PR TITLE
Avoid db breaking by rpc/validator mode switching

### DIFF
--- a/cmd/sonictool/main.go
+++ b/cmd/sonictool/main.go
@@ -50,6 +50,7 @@ func main() {
 						GenesisFlag,
 						ExperimentalFlag,
 						CacheFlag,
+						ModeFlag,
 					},
 					Description: "TBD",
 					CustomHelpTemplate: AppHelpTemplate,
@@ -63,6 +64,7 @@ func main() {
 						GenesisFlag,
 						ExperimentalFlag,
 						CacheFlag,
+						ModeFlag,
 					},
 					Description: "TBD",
 					CustomHelpTemplate: AppHelpTemplate,
@@ -104,6 +106,7 @@ func main() {
 					Flags: []cli.Flag{
 						DataDirFlag,
 						CacheFlag,
+						ModeFlag,
 					},
 					Description: "TBD",
 					CustomHelpTemplate: AppHelpTemplate,


### PR DESCRIPTION
Adding check, which terminates the node start, if the node starts in a different node mode, then corresponds to its database:

rpc to validator mode:
`
failed to initialize the node: failed to make consensus engine: failed to open EvmStore: starting node with disabled archive (validator mode), but the archive database exists - terminated to avoid archive-live states inconsistencies (remove the datadir/carmen/archive to enforce starting as a validator)
`

validator to rpc:
`
failed to initialize the node: failed to make consensus engine: failed to open EvmStore: starting node with enabled archive (rpc mode), but the archive database does exists - terminated to avoid creating an inconsistent archive database (re-apply genesis and resync the node to switch to archive configuration)
`

The db stays untouched, the db is NOT broken by this, restarting in correct mode is successful.