### PR TITLE
Unify eth and ftm rpc namespaces

### DIFF
--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -106,7 +106,7 @@ type Backend interface {
 
 func GetAPIs(apiBackend Backend) []rpc.API {
 	nonceLock := new(AddrLocker)
-	orig := []rpc.API{
+	return []rpc.API{
 		{
 			Namespace: "eth",
 			Version:   "1.0",
@@ -164,31 +164,4 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Public:    true,
 		},
 	}
-
-	// NOTE: eth-namespace is doubled as ftm-namespace for branding purpose
-	double := []rpc.API{
-		{
-			Namespace: "ftm",
-			Version:   "1.0",
-			Service:   NewPublicEthereumAPI(apiBackend),
-			Public:    true,
-		}, {
-			Namespace: "ftm",
-			Version:   "1.0",
-			Service:   NewPublicBlockChainAPI(apiBackend),
-			Public:    true,
-		}, {
-			Namespace: "ftm",
-			Version:   "1.0",
-			Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),
-			Public:    true,
-		}, {
-			Namespace: "ftm",
-			Version:   "1.0",
-			Service:   NewPublicAccountAPI(apiBackend.AccountManager()),
-			Public:    true,
-		},
-	}
-
-	return append(orig, double...)
 }

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -407,6 +407,18 @@ func (s *Service) APIs() []rpc.API {
 		},
 	}...)
 
+	// eth-namespace is doubled as ftm-namespace for branding purpose
+	for _, api := range apis {
+		if api.Namespace == "eth" {
+			apis = append(apis, rpc.API{
+				Namespace: "ftm",
+				Version:   api.Version,
+				Service:   api.Service,
+				Public:    api.Public,
+			})
+		}
+	}
+
 	return apis
 }
 


### PR DESCRIPTION
This makes the "ftm" RPC namespace indentical with "eth" namespace.