### PR TITLE
Fix #103 - legacy genesis unpacking tmp dir

### DIFF
--- a/gossip/evmstore/statedb_import.go
+++ b/gossip/evmstore/statedb_import.go
@@ -56,7 +56,7 @@ func (s *Store) ImportLegacyEvmData(evmItems genesis.EvmItems, blockNum uint64, 
 	}
 	defer s.Close()
 
-	carmenDir, err := os.MkdirTemp("", "opera-tmp-import-legacy-genesis")
+	carmenDir, err := os.MkdirTemp(s.parameters.Directory, "opera-tmp-import-legacy-genesis")
 	if err != nil {
 		panic(fmt.Errorf("failed to create temporary dir for legacy EVM data import: %v", err))
 	}


### PR DESCRIPTION
Fix of #103 - legacy genesis should not unpack into /tmp, as it may be too small.