### PR TITLE
Rename sonictool genesis subcommands

### DIFF
--- a/cmd/sonictool/genesis.go
+++ b/cmd/sonictool/genesis.go
@@ -30,9 +30,9 @@ var (
 	}
 )
 
-func sonicGenesisImport(ctx *cli.Context) error {
+func snapshotGenesisImport(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
-		return fmt.Errorf("this command requires an argument - the genesis file to import")
+		return fmt.Errorf("this command requires an argument - the tar.gz snapshot file to import")
 	}
 	dataDir := ctx.GlobalString(flags.DataDirFlag.Name)
 	if dataDir == "" {
@@ -46,7 +46,7 @@ func sonicGenesisImport(ctx *cli.Context) error {
 	return genesis.SonicImport(dataDir, genesisReader)
 }
 
-func legacyGenesisImport(ctx *cli.Context) error {
+func gfileGenesisImport(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		return fmt.Errorf("this command requires an argument - the genesis file to import")
 	}
@@ -65,7 +65,7 @@ func legacyGenesisImport(ctx *cli.Context) error {
 
 	genesisReader, err := os.Open(ctx.Args().First())
 	if err != nil {
-		return fmt.Errorf("failed to open the legacy genesis file: %w", err)
+		return fmt.Errorf("failed to open the genesis file: %w", err)
 	}
 	defer genesisReader.Close()
 

--- a/cmd/sonictool/main.go
+++ b/cmd/sonictool/main.go
@@ -23,25 +23,22 @@ func main() {
 	app.Commands = []cli.Command{
 		{
 			Name:     "genesis",
-			Usage:    "Download or import genesis files",
+			Usage:    "Import a genesis file",
 			Description: "TBD",
+
+			ArgsUsage: "<filename>",
+			Action:    gfileGenesisImport,
+			Flags: []cli.Flag{
+				ExperimentalFlag,
+				ModeFlag,
+			},
+
 			Subcommands: []cli.Command{
 				{
-					Name:   "sonic",
-					Usage:  "Initialize the database from a tar.gz genesis file",
-					ArgsUsage: "<filename>",
-					Action: sonicGenesisImport,
-					Description: "TBD",
-				},
-				{
-					Name:   "legacy",
-					Usage:  "Initialize the database from a legacy genesis file",
-					ArgsUsage: "<filename>",
-					Action: legacyGenesisImport,
-					Flags: []cli.Flag{
-						ExperimentalFlag,
-						ModeFlag,
-					},
+					Name:        "snapshot",
+					Usage:       "Initialize the database from a tar.gz snapshot file",
+					ArgsUsage:   "<filename>",
+					Action:      snapshotGenesisImport,
 					Description: "TBD",
 				},
 				{


### PR DESCRIPTION
```
build/sonictool --datadir ... genesis file.g
build/sonictool --datadir ... genesis snapshot file.tar.gz
build/sonictool --datadir ... genesis json file.json
build/sonictool --datadir ... genesis fake 3
```

```
build/sonictool genesis --help
NAME:
   sonictool genesis - TBD

USAGE:
   sonictool genesis command [command options] <filename>

COMMANDS:
     snapshot  Initialize the database from a tar.gz snapshot file
     json      Initialize the database from a testing JSON genesis file
     fake      Initialize the database for a fakenet testing network

OPTIONS:
   --experimental  Allow experimental features
   --mode value    Mode of the node ("rpc" or "validator") (default: "rpc")
   --help, -h      show help
```