### PR TITLE
Set Carmen cache size by --cache parameter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -225,7 +225,7 @@ func setDBConfig(cfg Config, cacheRatio cachescale.Func) (Config, error) {
 const (
 	// DefaultCacheSize is calculated as memory consumption in a worst case scenario with default configuration
 	// Average memory consumption might be 3-5 times lower than the maximum
-	DefaultCacheSize  = 3600
+	DefaultCacheSize  = 6144
 	ConstantCacheSize = 400
 )
 

--- a/gossip/evmstore/config.go
+++ b/gossip/evmstore/config.go
@@ -45,9 +45,11 @@ func DefaultStoreConfig(scale cachescale.Func) StoreConfig {
 			EvmBlocksSize:     scale.U(6 * opt.MiB),
 		},
 		StateDb: carmen.Parameters{
-			Variant:   "go-file",
-			Schema:    carmen.Schema(5),
-			Archive:   carmen.S5Archive,
+			Variant:      "go-file",
+			Schema:       carmen.Schema(5),
+			Archive:      carmen.S5Archive,
+			LiveCache:    scale.I64(1940 * opt.MiB),
+			ArchiveCache: scale.I64(1940 * opt.MiB),
 		},
 	}
 }


### PR DESCRIPTION
This changes Carmen cache allocation from default (4.8 GB) to 1.9GB.
The Opera caches should consume 6 GB after this change in total. (2.2 GB opera caches, 1.9 GB carmen live state, 1.9 GB carmen archive state)