### PR TITLE
Fix DiscoveryV5 and disable DiscoveryV4 by default

### DIFF
--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -39,7 +39,6 @@ func EventsImport(ctx *cli.Context, files ...string) error {
 	cfg.Node.IPCPath = ""
 	cfg.Node.HTTPHost = ""
 	cfg.Node.WSHost = ""
-	cfg.Node.NoUSB = true
 	cfg.Node.P2P.ListenAddr = ""
 	cfg.Node.P2P.NoDiscovery = true
 	cfg.Node.P2P.BootstrapNodes = nil

--- a/config/config_custom_test.go
+++ b/config/config_custom_test.go
@@ -44,7 +44,7 @@ func TestConfigFile(t *testing.T) {
 		"Empty":   {},
 		"Default": asDefault,
 		"UserDefined": {enode.MustParse(
-			"enr:-HW4QIEFxJwyZzPQJPE2DbQpEu7FM1Gv99VqJ3CbLb22fm9_V9cfdZdSBpZCyrEb5UfMeC6k9WT0iaaeAjRcuzCfr4yAgmlkgnY0iXNlY3AyNTZrMaECps0D9hhmXEN5BMgVVe0xT5mpYU9zv4YxCdTApmfP-l0",
+			"enr:-J-4QJmPmUmu14Pn7gUtRNfKHaWFQpcX6fgqrNheDSWUN6giKtix8Lh6EKfymTdXCI5HKGmyl0C5eOKvem5xdC70hLEBgmlkgnY0gmlwhMCoAQKFb3BlcmHHxoQHxfIKgIlzZWNwMjU2azGhAjYQROWoAXivxhtYYBXGXzQrBTAHGJT9XPP69oUzDDWwhHNuYXDAg3RjcIITuoN1ZHCCE7o",
 		)},
 	} {
 		t.Run(name+"BootstrapNodes", func(t *testing.T) {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -24,7 +24,7 @@ var NodeDefaultConfig = node.Config{
 	WSModules:           []string{},
 	GraphQLVirtualHosts: []string{"localhost"},
 	P2P: p2p.Config{
-		NoDiscovery: false, // enable discovery v4 by default
+		NoDiscovery: true, // disable discovery v4 by default
 		DiscoveryV5: true,  // enable discovery v5 by default
 		ListenAddr:  fmt.Sprintf(":%d", flags.ListenPortFlag.Value),
 		MaxPeers:    50,

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240411094650-918ca51f544d
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240415075552-d50d9a8cac8c
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210201043429-a8e90a2a4f88

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/Fantom-foundation/Carmen/go v0.0.0-20240410130417-b32b42b6efcb h1:3WD
 github.com/Fantom-foundation/Carmen/go v0.0.0-20240410130417-b32b42b6efcb/go.mod h1:2lViPW06I9AP6tPm0Xrwmvnw50foRSfjpKLQiaNox2I=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4 h1:AA0BtERxmlf7jvDF4fwIB2k/Lsc7HTRE3QHTZnfcSVA=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4/go.mod h1:/yIHWCDDJcdKMJYvOLdYOnHt5eUBF9XWnrvrNE+90ik=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240411094650-918ca51f544d h1:P9qtDbwPqoWeQThztFB0Gvw8kaRBCAzXgZEU0Fv6pzo=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240411094650-918ca51f544d/go.mod h1:Hu8U9SrXP6ABqtSNfJHw8lRGnr6tyma9PNZvwTweDjQ=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240415075552-d50d9a8cac8c h1:Io8Zl6AFv1ppRq9NMHnZwOe5kvMqZ1KvUxNTbhuiioo=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240415075552-d50d9a8cac8c/go.mod h1:Hu8U9SrXP6ABqtSNfJHw8lRGnr6tyma9PNZvwTweDjQ=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00 h1:yw5QaA7u4t2/j7VIGrMt640Kuhsx6pEIHM3bj10glWc=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00/go.mod h1:Ogv5etzSmM2rQ4eN3OfmyitwWaaPjd4EIDiW/NAbYGk=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=


### PR DESCRIPTION
* Add Discovery fix https://github.com/Fantom-foundation/go-ethereum-substate/pull/56
* Disable DiscoveryV4 by default
* Deprecated NoUSB flag not set anymore during events import (avoid deprecation warning)