### PR TITLE
Add log message before Carmen close

### DIFF
--- a/gossip/evmstore/store.go
+++ b/gossip/evmstore/store.go
@@ -91,10 +91,12 @@ func (s *Store) Close() error {
 	s.EvmLogs.Close()
 
 	if s.liveStateDb != nil {
+		s.Log.Info("Closing State DB...")
 		err := s.liveStateDb.Close()
 		if err != nil {
-			return fmt.Errorf("failed to close Carmen State: %w", err)
+			return fmt.Errorf("failed to close State DB: %w", err)
 		}
+		s.Log.Info("State DB closed")
 		s.carmenState = nil
 		s.liveStateDb = nil
 	}


### PR DESCRIPTION
While Sonic stops, there is no indication why the client is so long idle. Adding log message letting the user know about the state-db closing in progress.

```
INFO [05-15|17:36:10.631] Stopping Fantom protocol 
INFO [05-15|17:36:10.632] Fantom protocol stopped 
INFO [05-15|17:36:10.633] Fantom service stopped 
INFO [05-15|17:36:10.633] Closing State DB...                      module=evm-store
INFO [05-15|17:36:10.855] State DB closed                          module=evm-store
```