### PR TITLE
Avoid null topics in logs in RPC

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1701,6 +1701,9 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 		l.TxHash = hash
 		l.BlockHash = header.Hash
 		l.BlockNumber = blockNumber
+		if l.Topics == nil {
+			l.Topics = []common.Hash{}
+		}
 	}
 
 	// Derive the sender.

--- a/gossip/filters/api.go
+++ b/gossip/filters/api.go
@@ -474,6 +474,11 @@ func returnLogs(logs []*types.Log) []*types.Log {
 	if logs == nil {
 		return []*types.Log{}
 	}
+	for _, l := range logs {
+		if l.Topics == nil {
+			l.Topics = []common.Hash{}
+		}
+	}
 	return logs
 }
 


### PR DESCRIPTION
This extends RPC api to never return a null Topics field in the getLogs / getTransactionReceipt responses.