### PR TITLE
Add hashes of archive genesis Mainnet epoch 282500

### DIFF
--- a/cmd/sonictool/genesis/allowed.go
+++ b/cmd/sonictool/genesis/allowed.go
@@ -137,6 +137,16 @@ var (
 				genesisstore.FwsLiveSection(0): hash.HexToHash("0x47025ee3895fe976750bdd883f84ef451a5fe1051d4d2ca294bebf63eb6555c6"),
 			},
 		},
+		{
+			Name:   "Mainnet-282500 with Carmen live and archive state",
+			Header: mainnetHeader,
+			Hashes: genesis.Hashes{
+				genesisstore.EpochsSection(0):     hash.HexToHash("0x46ed30acff8b17680e73e78bcc1c1ece2b0288fecc8fce0e01bd058fa2d34c2b"),
+				genesisstore.BlocksSection(0):     hash.HexToHash("0x2bd68ede30496bc53a57f53f2a47e22a4d0c6ae21168717078bb09c2e09e9b10"),
+				genesisstore.FwsLiveSection(0):    hash.HexToHash("0x47025ee3895fe976750bdd883f84ef451a5fe1051d4d2ca294bebf63eb6555c6"),
+				genesisstore.FwsArchiveSection(0): hash.HexToHash("0x7d8c63e5a080fd53daa991aa30d5b990d421c199d7c3c398982a73ddc59b1541"),
+			},
+		},
 
 		{
 			Name:   "Testnet-2458 with pruned MPT",


### PR DESCRIPTION
This adds main-net genesis section hashes for the archive genesis generated at epoch 282500.