### PR TITLE
Refactor block/header serialization in RPC - remove duplicite code

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Fantom-foundation/go-opera/utils"
 	"github.com/Fantom-foundation/go-opera/utils/signers/gsignercache"
 	"github.com/Fantom-foundation/go-opera/utils/signers/internaltx"
-	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -776,7 +775,7 @@ func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.
 		if err != nil {
 			return nil, err
 		}
-		return s.rpcMarshalHeader(header, receipts), nil
+		return header.ToJson(receipts), nil
 	}
 	return nil, err
 }
@@ -789,7 +788,7 @@ func (s *PublicBlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.H
 		if err != nil {
 			return nil, err
 		}
-		return s.rpcMarshalHeader(header, receipts), nil
+		return header.ToJson(receipts), nil
 	}
 	return nil, err
 }
@@ -813,7 +812,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.B
 		if err != nil {
 			return nil, err
 		}
-		return s.rpcMarshalBlock(block, receipts, true, fullTx)
+		return RPCMarshalBlock(block, receipts, true, fullTx)
 	}
 	return nil, err
 }
@@ -827,7 +826,7 @@ func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, hash common.Ha
 		if err != nil {
 			return nil, err
 		}
-		return s.rpcMarshalBlock(block, receipts, true, fullTx)
+		return RPCMarshalBlock(block, receipts, true, fullTx)
 	}
 	return nil, err
 }
@@ -1178,101 +1177,6 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args TransactionA
 	return DoEstimateGas(ctx, s.b, args, bNrOrHash, s.b.RPCGasCap())
 }
 
-// ExecutionResult groups all structured logs emitted by the EVM
-// while replaying a transaction in debug mode as well as transaction
-// execution status, the amount of gas used and the return value
-type ExecutionResult struct {
-	Gas         uint64         `json:"gas"`
-	Failed      bool           `json:"failed"`
-	ReturnValue string         `json:"returnValue"`
-	StructLogs  []StructLogRes `json:"structLogs"`
-}
-
-// StructLogRes stores a structured log emitted by the EVM while replaying a
-// transaction in debug mode
-type StructLogRes struct {
-	Pc      uint64             `json:"pc"`
-	Op      string             `json:"op"`
-	Gas     uint64             `json:"gas"`
-	GasCost uint64             `json:"gasCost"`
-	Depth   int                `json:"depth"`
-	Error   string             `json:"error,omitempty"`
-	Stack   *[]string          `json:"stack,omitempty"`
-	Memory  *[]string          `json:"memory,omitempty"`
-	Storage *map[string]string `json:"storage,omitempty"`
-}
-
-// FormatLogs formats EVM returned structured logs for json output
-func FormatLogs(logs []logger.StructLog) []StructLogRes {
-	formatted := make([]StructLogRes, len(logs))
-	for index, trace := range logs {
-		formatted[index] = StructLogRes{
-			Pc:      trace.Pc,
-			Op:      trace.Op.String(),
-			Gas:     trace.Gas,
-			GasCost: trace.GasCost,
-			Depth:   trace.Depth,
-			Error:   trace.ErrorString(),
-		}
-		if trace.Stack != nil {
-			stack := make([]string, len(trace.Stack))
-			for i, stackValue := range trace.Stack {
-				stack[i] = stackValue.Hex()
-			}
-			formatted[index].Stack = &stack
-		}
-		if trace.Memory != nil {
-			memory := make([]string, 0, (len(trace.Memory)+31)/32)
-			for i := 0; i+32 <= len(trace.Memory); i += 32 {
-				memory = append(memory, fmt.Sprintf("%x", trace.Memory[i:i+32]))
-			}
-			formatted[index].Memory = &memory
-		}
-		if trace.Storage != nil {
-			storage := make(map[string]string)
-			for i, storageValue := range trace.Storage {
-				storage[fmt.Sprintf("%x", i)] = fmt.Sprintf("%x", storageValue)
-			}
-			formatted[index].Storage = &storage
-		}
-	}
-	return formatted
-}
-
-type extBlockApi struct {
-	bloom        types.Bloom
-	receiptsRoot common.Hash
-}
-
-// RPCMarshalHeader converts the given header to the RPC output .
-func RPCMarshalHeader(head *evmcore.EvmHeader, ext extBlockApi) map[string]interface{} {
-	result := map[string]interface{}{
-		"number":           (*hexutil.Big)(head.Number),
-		"epoch":            hexutil.Uint64(hash.Event(head.Hash).Epoch()),
-		"hash":             head.Hash, // store EvmBlock's hash in extra, because extra is always empty
-		"parentHash":       head.ParentHash,
-		"nonce":            types.BlockNonce{},
-		"mixHash":          common.Hash{},
-		"sha3Uncles":       types.EmptyUncleHash,
-		"logsBloom":        ext.bloom,
-		"stateRoot":        head.Root,
-		"miner":            head.Coinbase,
-		"difficulty":       (*hexutil.Big)(new(big.Int)),
-		"extraData":        hexutil.Bytes([]byte{}),
-		"size":             hexutil.Uint64(head.EthHeader().Size()),
-		"gasLimit":         hexutil.Uint64(0xffffffffffff), // don't use too much bits here to avoid parsing issues
-		"gasUsed":          hexutil.Uint64(head.GasUsed),
-		"timestamp":        hexutil.Uint64(head.Time.Unix()),
-		"timestampNano":    hexutil.Uint64(head.Time),
-		"transactionsRoot": head.TxHash,
-		"receiptsRoot":     ext.receiptsRoot,
-	}
-	if head.BaseFee != nil {
-		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
-	}
-	return result
-}
-
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
@@ -1305,24 +1209,6 @@ func RPCMarshalBlock(block *evmcore.EvmBlock, receipts types.Receipts, inclTx bo
 	json.Uncles = make([]common.Hash, 0)
 
 	return json, nil
-}
-
-// rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires
-// a `PublicBlockchainAPI`.
-func (s *PublicBlockChainAPI) rpcMarshalHeader(header *evmcore.EvmHeader, receipts types.Receipts) *evmcore.EvmHeaderJson {
-	return header.ToJson(receipts)
-}
-
-// rpcMarshalBlock uses the generalized output filler, then adds the total difficulty field, which requires
-// a `PublicBlockchainAPI`.
-func (s *PublicBlockChainAPI) rpcMarshalBlock(b *evmcore.EvmBlock, receipts types.Receipts, inclTx bool, fullTx bool) (*evmcore.EvmBlockJson, error) {
-	fields, err := RPCMarshalBlock(b, receipts, inclTx, fullTx)
-	if err != nil {
-		return nil, err
-	}
-
-	fields.TotalDiff = (*hexutil.Big)(s.b.GetTd(b.Hash))
-	return fields, err
 }
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -71,7 +71,6 @@ type Backend interface {
 	ResolveRpcBlockNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (idx.Block, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*evmcore.EvmBlock, error)
 	GetReceiptsByNumber(ctx context.Context, number rpc.BlockNumber) (types.Receipts, error)
-	GetTd(hash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg evmcore.Message, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config) (*vm.EVM, func() error, error)
 	MinGasPrice() *big.Int
 	MaxGasLimit() uint64

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -173,6 +173,7 @@ func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
 		TimeNano:   hexutil.Uint64(h.Time),
 		BaseFee:    (*hexutil.Big)(h.BaseFee),
 		Difficulty: new(hexutil.Big),
+		TotalDiff:  new(hexutil.Big),
 		Hash:       &h.Hash,
 		Epoch:		hexutil.Uint64(hash.Event(h.Hash).Epoch()),
 	}

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -169,6 +169,7 @@ func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
 		Root:       h.Root,
 		TxHash:     h.TxHash,
 		ParentHash: h.ParentHash,
+		UncleHash:  types.EmptyUncleHash,
 		Time:       hexutil.Uint64(h.Time.Unix()),
 		TimeNano:   hexutil.Uint64(h.Time),
 		BaseFee:    (*hexutil.Big)(h.BaseFee),

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -17,6 +17,7 @@
 package evmcore
 
 import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math"
 	"math/big"
 
@@ -126,6 +127,64 @@ func (h *EvmHeader) EthHeader() *types.Header {
 	}
 	// ethHeader.SetExternalHash(h.Hash) < this seems to be an optimization in go-ethereum-substate; skipped for now, needs investigation
 	return ethHeader
+}
+
+// EvmHeaderJson is simplified version of types.Header, but allowing setting custom hash
+type EvmHeaderJson struct {
+	ParentHash  common.Hash      `json:"parentHash"       gencodec:"required"`
+	UncleHash   common.Hash      `json:"sha3Uncles"       gencodec:"required"`
+	Miner       common.Address   `json:"miner"`
+	Root        common.Hash      `json:"stateRoot"        gencodec:"required"`
+	TxHash      common.Hash      `json:"transactionsRoot" gencodec:"required"`
+	ReceiptHash common.Hash      `json:"receiptsRoot"     gencodec:"required"`
+	Bloom       types.Bloom      `json:"logsBloom"        gencodec:"required"`
+	Difficulty  *hexutil.Big     `json:"difficulty"       gencodec:"required"`
+	Number      *hexutil.Big     `json:"number"           gencodec:"required"`
+	GasLimit    hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
+	GasUsed     hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
+	Time        hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
+	TimeNano    hexutil.Uint64   `json:"timestampNano"`
+	Extra       hexutil.Bytes    `json:"extraData"        gencodec:"required"`
+	MixDigest   common.Hash      `json:"mixHash"`
+	Nonce       types.BlockNonce `json:"nonce"`
+	BaseFee     *hexutil.Big     `json:"baseFeePerGas"`
+	Hash        *common.Hash     `json:"hash"`
+	Epoch       hexutil.Uint64   `json:"epoch"`
+	TotalDiff   *hexutil.Big     `json:"totalDifficulty"`
+}
+
+type EvmBlockJson struct {
+	*EvmHeaderJson
+	Txs         []interface{}    `json:"transactions"`
+	Size        *hexutil.Uint64  `json:"size"` // RLP encoded storage size of the block
+	Uncles      []common.Hash    `json:"uncles"`
+}
+
+func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
+	enc := &EvmHeaderJson{
+		Number:     (*hexutil.Big)(h.Number),
+		Miner:      h.Coinbase,
+		GasLimit:   0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
+		GasUsed:    hexutil.Uint64(h.GasUsed),
+		Root:       h.Root,
+		TxHash:     h.TxHash,
+		ParentHash: h.ParentHash,
+		Time:       hexutil.Uint64(h.Time.Unix()),
+		TimeNano:   hexutil.Uint64(h.Time),
+		BaseFee:    (*hexutil.Big)(h.BaseFee),
+		Difficulty: new(hexutil.Big),
+		Hash:       &h.Hash,
+		Epoch:		hexutil.Uint64(hash.Event(h.Hash).Epoch()),
+	}
+	if receipts != nil { // if receipts resolution fails, don't set ReceiptsHash at all
+		if receipts.Len() != 0 {
+			enc.ReceiptHash = types.DeriveSha(receipts, trie.NewStackTrie(nil))
+			enc.Bloom = types.CreateBloom(receipts)
+		} else {
+			enc.ReceiptHash = types.EmptyRootHash
+		}
+	}
+	return enc
 }
 
 // Header is a copy of EvmBlock.EvmHeader.

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -318,10 +318,6 @@ func (b *EthAPIBackend) GetLogs(ctx context.Context, block common.Hash) ([][]*ty
 	return logs, nil
 }
 
-func (b *EthAPIBackend) GetTd(_ common.Hash) *big.Int {
-	return big.NewInt(0)
-}
-
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg evmcore.Message, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 

--- a/gossip/filters/api.go
+++ b/gossip/filters/api.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/go-opera/evmcore"
 	"math/big"
 	"sync"
 	"time"
@@ -192,7 +193,7 @@ func (api *PublicFilterAPI) NewPendingTransactions(ctx context.Context) (*rpc.Su
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newblockfilter
 func (api *PublicFilterAPI) NewBlockFilter() rpc.ID {
 	var (
-		headers   = make(chan *evmHeaderJson)
+		headers   = make(chan *evmcore.EvmHeaderJson)
 		headerSub = api.events.SubscribeNewHeads(headers)
 	)
 
@@ -206,7 +207,7 @@ func (api *PublicFilterAPI) NewBlockFilter() rpc.ID {
 			case h := <-headers:
 				api.filtersMu.Lock()
 				if f, found := api.filters[headerSub.ID]; found {
-					f.hashes = append(f.hashes, h.Hash)
+					f.hashes = append(f.hashes, *h.Hash)
 				}
 				api.filtersMu.Unlock()
 			case <-headerSub.Err():
@@ -231,7 +232,7 @@ func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, er
 	rpcSub := notifier.CreateSubscription()
 
 	go func() {
-		headers := make(chan *evmHeaderJson)
+		headers := make(chan *evmcore.EvmHeaderJson)
 		headersSub := api.events.SubscribeNewHeads(headers)
 
 		for {

--- a/gossip/filters/filter_system.go
+++ b/gossip/filters/filter_system.go
@@ -22,20 +22,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"math/big"
 	"sync"
 	"time"
 
+	"github.com/Fantom-foundation/go-opera/evmcore"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	notify "github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/ethereum/go-ethereum/trie"
-
-	"github.com/Fantom-foundation/go-opera/evmcore"
 )
 
 // Type determines the kind of filter and is used to put the filter in to
@@ -82,7 +78,7 @@ type subscription struct {
 	logsCrit  ethereum.FilterQuery
 	logs      chan []*types.Log
 	hashes    chan []common.Hash
-	headers   chan *evmHeaderJson
+	headers   chan *evmcore.EvmHeaderJson
 	installed chan struct{} // closed when the filter is installed
 	err       chan error    // closed when the filter is uninstalled
 }
@@ -228,7 +224,7 @@ func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs
 		created:   time.Now(),
 		logs:      logs,
 		hashes:    make(chan []common.Hash),
-		headers:   make(chan *evmHeaderJson),
+		headers:   make(chan *evmcore.EvmHeaderJson),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -245,7 +241,7 @@ func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 		created:   time.Now(),
 		logs:      logs,
 		hashes:    make(chan []common.Hash),
-		headers:   make(chan *evmHeaderJson),
+		headers:   make(chan *evmcore.EvmHeaderJson),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -262,7 +258,7 @@ func (es *EventSystem) subscribePendingLogs(crit ethereum.FilterQuery, logs chan
 		created:   time.Now(),
 		logs:      logs,
 		hashes:    make(chan []common.Hash),
-		headers:   make(chan *evmHeaderJson),
+		headers:   make(chan *evmcore.EvmHeaderJson),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -271,7 +267,7 @@ func (es *EventSystem) subscribePendingLogs(crit ethereum.FilterQuery, logs chan
 
 // SubscribeNewHeads creates a subscription that writes the header of a block that is
 // imported in the chain.
-func (es *EventSystem) SubscribeNewHeads(headers chan *evmHeaderJson) *Subscription {
+func (es *EventSystem) SubscribeNewHeads(headers chan *evmcore.EvmHeaderJson) *Subscription {
 	sub := &subscription{
 		id:        rpc.NewID(),
 		typ:       BlocksSubscription,
@@ -294,7 +290,7 @@ func (es *EventSystem) SubscribePendingTxs(hashes chan []common.Hash) *Subscript
 		created:   time.Now(),
 		logs:      make(chan []*types.Log),
 		hashes:    hashes,
-		headers:   make(chan *evmHeaderJson),
+		headers:   make(chan *evmcore.EvmHeaderJson),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -327,69 +323,12 @@ func (es *EventSystem) broadcast(filters filterIndex, ev interface{}) {
 			f.hashes <- hashes
 		}
 	case evmcore.ChainHeadNotify:
-		h := toEvmHeaderJson(&e.Block.EvmHeader)
-		es.calculateExtBlockApi(h)
+		blkNumber := rpc.BlockNumber(e.Block.EvmHeader.Number.Int64())
+		receipts, _ := es.backend.GetReceiptsByNumber(context.Background(), blkNumber)
+		h := e.Block.EvmHeader.ToJson(receipts)
 		for _, f := range filters[BlocksSubscription] {
 			f.headers <- h
 		}
-	}
-}
-
-// evmHeaderJson is simplified version of types.Header, but allowing setting custom hash
-type evmHeaderJson struct {
-	ParentHash       common.Hash      `json:"parentHash"       gencodec:"required"`
-	UncleHash        common.Hash      `json:"sha3Uncles"       gencodec:"required"`
-	Coinbase         common.Address   `json:"miner"`
-	Root             common.Hash      `json:"stateRoot"        gencodec:"required"`
-	TxHash           common.Hash      `json:"transactionsRoot" gencodec:"required"`
-	ReceiptHash      common.Hash      `json:"receiptsRoot"     gencodec:"required"`
-	Bloom            types.Bloom      `json:"logsBloom"        gencodec:"required"`
-	Difficulty       *hexutil.Big     `json:"difficulty"       gencodec:"required"`
-	Number           *hexutil.Big     `json:"number"           gencodec:"required"`
-	GasLimit         hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
-	GasUsed          hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
-	Time             hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
-	Extra            hexutil.Bytes    `json:"extraData"        gencodec:"required"`
-	MixDigest        common.Hash      `json:"mixHash"`
-	Nonce            types.BlockNonce `json:"nonce"`
-	BaseFee          *hexutil.Big     `json:"baseFeePerGas" rlp:"optional"`
-	Hash             common.Hash      `json:"hash"`
-}
-
-func toEvmHeaderJson(h *evmcore.EvmHeader) *evmHeaderJson {
-	enc := &evmHeaderJson{
-		Number:     (*hexutil.Big)(h.Number),
-		Coinbase:   h.Coinbase,
-		GasLimit:   0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
-		GasUsed:    hexutil.Uint64(h.GasUsed),
-		Root:       h.Root,
-		TxHash:     h.TxHash,
-		ParentHash: h.ParentHash,
-		Time:       hexutil.Uint64(h.Time.Unix()),
-		BaseFee:    (*hexutil.Big)(h.BaseFee),
-		Difficulty: new(hexutil.Big),
-		Hash:       h.Hash,
-	}
-	return enc
-}
-
-// calculateExtBlockApi doubles ethapi/PublicBlockChainAPI.calculateExtBlockApi() functionality.
-// TODO: common code.
-func (es *EventSystem) calculateExtBlockApi(h *evmHeaderJson) {
-	blkNumber := rpc.BlockNumber((*big.Int)(h.Number).Int64())
-	if !es.backend.CalcBlockExtApi() || blkNumber == rpc.EarliestBlockNumber {
-		return
-	}
-
-	receipts, err := es.backend.GetReceiptsByNumber(context.Background(), blkNumber)
-	if err != nil {
-		return
-	}
-	if receipts.Len() != 0 {
-		h.ReceiptHash = types.DeriveSha(receipts, trie.NewStackTrie(nil))
-		h.Bloom = types.CreateBloom(receipts)
-	} else {
-		h.ReceiptHash = types.EmptyRootHash
 	}
 }
 


### PR DESCRIPTION
The block/header JSON serialization is duplicated between ethapi (regular RPC queries) and filters (handling of `eth_subscribe(newHeads)`) - this moves this serialization into a single place and ensures the same format for both.