### PR TITLE
Avoid overriding already initialized datadir

### DIFF
--- a/cmd/sonictool/db/dbutils.go
+++ b/cmd/sonictool/db/dbutils.go
@@ -34,6 +34,15 @@ func makeDatabaseHandles() uint64 {
 	return raised / 6 + 1
 }
 
+func AssertDatabaseNotInitialized(dataDir string) error {
+	_, err1 := os.Stat(filepath.Join(dataDir, "chaindata"))
+	_, err2 := os.Stat(filepath.Join(dataDir, "carmen"))
+	if !errors.Is(err1, os.ErrNotExist) && !errors.Is(err2, os.ErrNotExist) {
+		return fmt.Errorf("database directories 'chaindata' and 'carmen' already exists")
+	}
+	return nil
+}
+
 func RemoveDatabase(dataDir string) error {
 	err1 := os.RemoveAll(filepath.Join(dataDir, "chaindata"))
 	err2 := os.RemoveAll(filepath.Join(dataDir, "carmen"))

--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -14,6 +14,9 @@ import (
 )
 
 func ImportGenesisStore(genesisStore *genesisstore.Store, dataDir string, validatorMode bool, cacheRatio cachescale.Func) error {
+	if err := db.AssertDatabaseNotInitialized(dataDir); err != nil {
+		return fmt.Errorf("database in datadir is already initialized: %w", err)
+	}
 	if err := db.RemoveDatabase(dataDir); err != nil {
 		return fmt.Errorf("failed to remove existing data from the datadir: %w", err)
 	}


### PR DESCRIPTION
When the database is already initialized, avoid overriding it by the sonictool genesis tool:
```
sonictool --datadir=/tmp/opera genesis fake 1
database in datadir is already initialized: database directories 'chaindata' and 'carmen' already exists
```
When any of the carmen or chaindata directories are missing, the database is supposed to be corrupted, directories are removed and recreated from the genesis file.