### PR TITLE
Revert adding multi-threaded gzip (except genesis export)

### DIFF
--- a/cmd/sonictool/chain.go
+++ b/cmd/sonictool/chain.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"compress/gzip"
 	"fmt"
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/chain"
 	"github.com/Fantom-foundation/go-opera/config/flags"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/log"
-	gzip "github.com/klauspost/pgzip"
 	"gopkg.in/urfave/cli.v1"
 	"io"
 	"os"

--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"github.com/Fantom-foundation/go-opera/config"
@@ -14,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	gzip "github.com/klauspost/pgzip"
 	"github.com/status-im/keycard-go/hexutils"
 	"gopkg.in/urfave/cli.v1"
 	"io"

--- a/opera/genesisstore/disk.go
+++ b/opera/genesisstore/disk.go
@@ -2,9 +2,9 @@ package genesisstore
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"fmt"
-	gzip "github.com/klauspost/pgzip"
 	"io"
 	"strings"
 	"time"
@@ -125,8 +125,8 @@ func OpenGenesisStore(rawReader ReadAtSeekerCloser) (*Store, genesis.Hashes, err
 
 		off := offset // standalone variable for each Unit instance
 		units = append(units, readersmap.Unit{
-			Name: unit.UnitName,
-			ReaderProvider: func() (io.Reader, error) {
+			Name:   unit.UnitName,
+			ReaderProvider: func () (io.Reader, error) {
 				unitReader := io.NewSectionReader(rawReader, off+headerSize, off+headerSize+int64(dataCompressedSize))
 				gzipReader, err := gzip.NewReader(unitReader)
 				if err != nil {


### PR DESCRIPTION
Parallel gzip fails to extract old genesis files.
This revert returns golang native gzip back for genesis import/events import/events export, but keeps parallel gzip for genesis export.

This partialy reverts commit 04905ab5456a55176e4a8de1fbe35afb94215d08 (#131).