### PR TITLE
Optimize peer selection for initial events download

### DIFF
--- a/gossip/protocols/blockrecords/brstream/brstreamleecher/leecher.go
+++ b/gossip/protocols/blockrecords/brstream/brstreamleecher/leecher.go
@@ -145,6 +145,15 @@ func getSessionID(block idx.Block, try uint32) uint32 {
 
 func (d *Leecher) startSession(candidates []string) {
 	peer := candidates[rand.Intn(len(candidates))]
+	if d.session.try == 0 && rand.Intn(50) == 0 {
+		// try previous successful peer first
+		for _, candidate := range candidates {
+			if candidate == d.session.peer {
+				peer = candidate
+				break
+			}
+		}
+	}
 
 	start := d.callback.LowestBlockToFill()
 	end := d.callback.MaxBlockToFill()

--- a/gossip/protocols/blockvotes/bvstream/bvstreamleecher/leecher.go
+++ b/gossip/protocols/blockvotes/bvstream/bvstreamleecher/leecher.go
@@ -137,6 +137,15 @@ func getSessionID(block idx.Block, try uint32) uint32 {
 
 func (d *Leecher) startSession(candidates []string) {
 	peer := candidates[rand.Intn(len(candidates))]
+	if d.session.try == 0 && rand.Intn(50) == 0 {
+		// try previous successful peer first
+		for _, candidate := range candidates {
+			if candidate == d.session.peer {
+				peer = candidate
+				break
+			}
+		}
+	}
 
 	startEpoch, startBlock := d.callback.LowestBlockToDecide()
 	endEpoch := d.callback.MaxEpochToDecide()

--- a/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
+++ b/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
@@ -140,6 +140,15 @@ func getSessionID(epoch idx.Epoch, try uint32) uint32 {
 
 func (d *Leecher) startSession(candidates []string) {
 	peer := candidates[rand.Intn(len(candidates))]
+	if d.session.try == 0 && rand.Intn(50) == 0 {
+		// try previous successful peer first
+		for _, candidate := range candidates {
+			if candidate == d.session.peer {
+				peer = candidate
+				break
+			}
+		}
+	}
 
 	typ := dagstream.RequestIDs
 	if d.callback.PeerEpoch(peer) > d.epoch && d.emptyState && d.session.try == 0 {

--- a/gossip/protocols/epochpacks/epstream/epstreamleecher/leecher.go
+++ b/gossip/protocols/epochpacks/epstream/epstreamleecher/leecher.go
@@ -128,6 +128,14 @@ func getSessionID(epoch idx.Epoch, try uint32) uint32 {
 
 func (d *Leecher) startSession(candidates []string) {
 	peer := candidates[rand.Intn(len(candidates))]
+	if d.session.try == 0 && rand.Intn(50) == 0 {
+		// try previous successful peer first
+		for _, candidate := range candidates {
+			if candidate == d.session.peer {
+				peer = candidate
+			}
+		}
+	}
 
 	start := d.callback.LowestEpochToFetch()
 	end := d.callback.MaxEpochToFetch()


### PR DESCRIPTION
For each first attempt in an epoch, pick the previous successful peer in *streamleecher with 98% chance
- The heuristic increases chances that we would pick a healthy peer, instead of a bad peer or a bot
- The randomization is added so that node wouldn't get locked onto a singe peer
- The heuristic is applied to LLR as well (for consistency)

In mainnet, this optimization increases speed of syncing roughly ~1.5x due to the presence of bots. It cannot be measured accurately due varying number of bots

We may want to replace it with a more complex heuristic in future, such that it would increase chances to a select a performant peer in a safe manner

The test TestMisbehaviourProofsWrongBlockEpoch is non-deterministically failing in develop branch, which isn't related to these changes