### PR TITLE
Upgrade carmen, disable node flusher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-require github.com/Fantom-foundation/Carmen/go v0.0.0-20240627085016-204b50159b28
+require github.com/Fantom-foundation/Carmen/go v0.0.0-20240710073916-102aeea2a9ce
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240627085016-204b50159b28 h1:l2/QVcO6e1SR6EPIOYvIyzmJyI4IwKk+/XsIFTCUVgA=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240627085016-204b50159b28/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240710073916-102aeea2a9ce h1:Ovi+tUN5CrvMBj/+u0WCKNthgVsD1caDqeXTNliVfLk=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240710073916-102aeea2a9ce/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4 h1:AA0BtERxmlf7jvDF4fwIB2k/Lsc7HTRE3QHTZnfcSVA=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4/go.mod h1:/yIHWCDDJcdKMJYvOLdYOnHt5eUBF9XWnrvrNE+90ik=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240523185630-b058188a043a h1:JSaTMHvYKZOizg2EcJeNEiIpdF939Xw80g/sHd2qeWQ=


### PR DESCRIPTION
This upgrades carmen to include https://github.com/Fantom-foundation/Carmen/pull/949 - disabling problematic background flushing.