### PR TITLE
Fix tracing of block 1 - ignore missing stateRoot of block 0 in blocks db

### DIFF
--- a/gossip/evmstore/statedb.go
+++ b/gossip/evmstore/statedb.go
@@ -52,7 +52,7 @@ func (s *Store) GetRpcStateDb(blockNum *big.Int, stateRoot common.Hash) (state.S
 	if err != nil {
 		return nil, err
 	}
-	if stateDb.GetHash() != cc.Hash(stateRoot) {
+	if stateDb.GetHash() != cc.Hash(stateRoot) && blockNum.Sign() != 0 {
 		return nil, fmt.Errorf("unable to get Carmen archive StateDB - unexpected state root (%x != %x)", stateDb.GetHash(), stateRoot)
 	}
 	return CreateCarmenStateDb(stateDb), nil


### PR DESCRIPTION
This should fix issue #179 - impossibility to trace block 1.

Tracing is unable to obtain starting state of the block 1, which is the StateRoot of block 0. However blocks db returns zero stateRoot for the block 0. Carmen knows the correct state, but it is not unable to verify it against the blocks db. This add exception for the block 0 into the check.