### PR TITLE
Add support of ftm_getProof RPC method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.3
 
 require (
-	github.com/Fantom-foundation/Carmen/go v0.0.0-20240729142044-e8e39a51fff4 // TODO
+	github.com/Fantom-foundation/Carmen/go v0.0.0-20240730125059-67a796a300a8
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/cespare/cp v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.3
 
 require (
-	github.com/Fantom-foundation/Carmen/go v0.0.0-20240720214637-e2e21d535f38
+	github.com/Fantom-foundation/Carmen/go v0.0.0-20240729142044-e8e39a51fff4 // TODO
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240720214637-e2e21d535f38 h1:II6sFXE7yRR0wDTuEUixmppF6+Jj/nv/OJe5UrPq3rw=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240720214637-e2e21d535f38/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240729142044-e8e39a51fff4 h1:Nx0kKD/p1igPrSO9PpNKXz5oiYk1gWdC4K84694SSsE=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240729142044-e8e39a51fff4/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240529085303-2400937cc3b1 h1:iVbLlmFYPlK31O8psS9H+Y+uop0AC1jqCoRErauaHj0=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240529085303-2400937cc3b1/go.mod h1:6LG3apXyp0InsMXGq9YmzUiV7H0BOuUHrcu3oQY9boE=
 github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240320160249-81827a18147c h1:g35kQNkq/VGiFak0joC4hcL/TZIi1KQZkatIlLZnOy0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240729142044-e8e39a51fff4 h1:Nx0kKD/p1igPrSO9PpNKXz5oiYk1gWdC4K84694SSsE=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240729142044-e8e39a51fff4/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240730125059-67a796a300a8 h1:hbHhCRMCzwvfGZRfDcIbGw3oUl18Eqrq5QeyJ2clbm0=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240730125059-67a796a300a8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240529085303-2400937cc3b1 h1:iVbLlmFYPlK31O8psS9H+Y+uop0AC1jqCoRErauaHj0=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240529085303-2400937cc3b1/go.mod h1:6LG3apXyp0InsMXGq9YmzUiV7H0BOuUHrcu3oQY9boE=
 github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240320160249-81827a18147c h1:g35kQNkq/VGiFak0joC4hcL/TZIi1KQZkatIlLZnOy0=

--- a/inter/state/adapter.go
+++ b/inter/state/adapter.go
@@ -1,8 +1,8 @@
 package state
 
 import (
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/holiman/uint256"
@@ -15,9 +15,7 @@ type StateDB interface {
 	GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log
 	SetTxContext(thash common.Hash, ti int)
 	TxIndex() int
-	GetProof(addr common.Address) ([][]byte, error)
-	GetStorageProof(a common.Address, key common.Hash) ([][]byte, error)
-	StorageTrie(addr common.Address) state.Trie
+	GetProof(addr common.Address, keys []common.Hash) (witness.Proof, error)
 	SetBalance(addr common.Address, amount *uint256.Int)
 	SetCode(addr common.Address, code []byte)
 	SetStorage(addr common.Address, storage map[common.Hash]common.Hash)


### PR DESCRIPTION
This adds support of eth_getProof/ftm_getProof method into the RPC interface.

~**To be done:** replace working version of carmen with the main branch when https://github.com/Fantom-foundation/Carmen/pull/975 merged.~