### PR TITLE
Upgrade carmen to version with Amount type

### DIFF
--- a/cmd/sonictool/check/archive.go
+++ b/cmd/sonictool/check/archive.go
@@ -23,7 +23,7 @@ func CheckArchiveStateDb(dataDir string, cacheRatio cachescale.Func) error {
 	if err != nil {
 		return fmt.Errorf("failed to check archive state dir: %w", err)
 	}
-	if err := mpt.VerifyArchive(archiveDir, info.Config, verificationObserver{}); err != nil {
+	if err := mpt.VerifyArchiveTrie(archiveDir, info.Config, verificationObserver{}); err != nil {
 		return fmt.Errorf("archive state verification failed: %w", err)
 	}
 	log.Info("Verification of the archive state succeed")

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -178,6 +178,9 @@ func (s *PublicTxTraceAPI) replayBlock(ctx context.Context, block *evmcore.EvmBl
 				failed = true
 				log.Error("Cannot replay transaction", "txHash", tx.Hash().String(), "err", err.Error())
 			}
+			if err := state.Error(); err != nil {
+				return nil, fmt.Errorf("StateDB error when replaying tx %s: %w", tx.Hash().String(), err)
+			}
 
 			if res != nil && res.Err != nil {
 				failed = true
@@ -261,6 +264,9 @@ func (s *PublicTxTraceAPI) traceTx(
 			return nil, fmt.Errorf("invalid transaction replay state at %s", tx.Hash().String())
 		}
 		return &at, nil
+	}
+	if err := state.Error(); err != nil {
+		return nil, fmt.Errorf("StateDB error when replaying tx %s: %w", tx.Hash().String(), err)
 	}
 	// If the timer caused an abort, return an appropriate error message
 	if vmenv.Cancelled() {

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -121,6 +121,10 @@ func applyTransaction(
 	if err != nil {
 		return nil, 0, result == nil, err
 	}
+	if err := statedb.Error(); err != nil {
+		return nil, 0, result == nil, err
+	}
+
 	// Notify about logs with potential state changes
 	logs := statedb.GetLogs(tx.Hash(), blockHash)
 	for _, l := range logs {

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-require github.com/Fantom-foundation/Carmen/go v0.0.0-20240507092214-445df9f3b43c
+require github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240507092214-445df9f3b43c h1:zSUdDjwjcgrQ6Ov0a/wranXE50jpjXHwClfEPiVVpMs=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240507092214-445df9f3b43c/go.mod h1:d7YbZSMQ+IIrxAfQKBs75V50T+J/VDCyKavnRZxSNdQ=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8 h1:IPtyB4nzqCmt6as6D7NpgZV3Hnh7FlucoHw5+FlAFfM=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4 h1:AA0BtERxmlf7jvDF4fwIB2k/Lsc7HTRE3QHTZnfcSVA=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4/go.mod h1:/yIHWCDDJcdKMJYvOLdYOnHt5eUBF9XWnrvrNE+90ik=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240523185630-b058188a043a h1:JSaTMHvYKZOizg2EcJeNEiIpdF939Xw80g/sHd2qeWQ=

--- a/gossip/evmstore/carmen.go
+++ b/gossip/evmstore/carmen.go
@@ -1,7 +1,9 @@
 package evmstore
 
 import (
+	"errors"
 	cc "github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/amount"
 	carmen "github.com/Fantom-foundation/Carmen/go/state"
 	"github.com/Fantom-foundation/go-opera/inter/state"
 	"github.com/ethereum/go-ethereum/common"
@@ -25,10 +27,12 @@ type CarmenStateDB struct {
 	// current transaction - set by Prepare
 	txHash  common.Hash
 	txIndex int
+
+	err error
 }
 
 func (c *CarmenStateDB) Error() error {
-	return nil
+	return c.err
 }
 
 func (c *CarmenStateDB) AddLog(log *types.Log) {
@@ -89,7 +93,7 @@ func (c *CarmenStateDB) Empty(addr common.Address) bool {
 }
 
 func (c *CarmenStateDB) GetBalance(addr common.Address) *big.Int {
-	return c.db.GetBalance(cc.Address(addr))
+	return c.db.GetBalance(cc.Address(addr)).ToBig()
 }
 
 func (c *CarmenStateDB) GetNonce(addr common.Address) uint64 {
@@ -136,12 +140,22 @@ func (c *CarmenStateDB) HasSuicided(addr common.Address) bool {
 	return c.db.HasSuicided(cc.Address(addr))
 }
 
-func (c *CarmenStateDB) AddBalance(addr common.Address, amount *big.Int) {
-	c.db.AddBalance(cc.Address(addr), amount)
+func (c *CarmenStateDB) AddBalance(addr common.Address, amountInt *big.Int) {
+	am, err := amount.NewFromBigInt(amountInt)
+	if err != nil {
+		c.err = errors.Join(c.err, err)
+		return
+	}
+	c.db.AddBalance(cc.Address(addr), am)
 }
 
-func (c *CarmenStateDB) SubBalance(addr common.Address, amount *big.Int) {
-	c.db.SubBalance(cc.Address(addr), amount)
+func (c *CarmenStateDB) SubBalance(addr common.Address, amountInt *big.Int) {
+	am, err := amount.NewFromBigInt(amountInt)
+	if err != nil {
+		c.err = errors.Join(c.err, err)
+		return
+	}
+	c.db.SubBalance(cc.Address(addr), am)
 }
 
 func (c *CarmenStateDB) SetBalance(addr common.Address, amount *big.Int) {

--- a/gossip/evmstore/carmen.go
+++ b/gossip/evmstore/carmen.go
@@ -141,6 +141,10 @@ func (c *CarmenStateDB) HasSuicided(addr common.Address) bool {
 }
 
 func (c *CarmenStateDB) AddBalance(addr common.Address, amountInt *big.Int) {
+	if amountInt.Sign() < 0 {
+		c.SubBalance(addr, amountInt.Abs(amountInt))
+		return
+	}
 	am, err := amount.NewFromBigInt(amountInt)
 	if err != nil {
 		c.err = errors.Join(c.err, err)
@@ -150,6 +154,10 @@ func (c *CarmenStateDB) AddBalance(addr common.Address, amountInt *big.Int) {
 }
 
 func (c *CarmenStateDB) SubBalance(addr common.Address, amountInt *big.Int) {
+	if amountInt.Sign() < 0 {
+		c.AddBalance(addr, amountInt.Abs(amountInt))
+		return
+	}
 	am, err := amount.NewFromBigInt(amountInt)
 	if err != nil {
 		c.err = errors.Join(c.err, err)

--- a/gossip/evmstore/statedb_verify.go
+++ b/gossip/evmstore/statedb_verify.go
@@ -44,7 +44,7 @@ func (s *Store) VerifyWorldState(expectedBlockNum uint64, expectedHash common.Ha
 	if err != nil {
 		return fmt.Errorf("failed to check archive dir: %w", err)
 	}
-	if err := mpt.VerifyArchive(archiveDir, archiveInfo.Config, observer); err != nil {
+	if err := mpt.VerifyArchiveTrie(archiveDir, archiveInfo.Config, observer); err != nil {
 		return fmt.Errorf("archive verification failed: %w", err)
 	}
 	s.Log.Info("Archive verified successfully.")

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -2,6 +2,7 @@ package makegenesis
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -257,7 +258,7 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 			return buf, nil
 		}
 		if name == genesisstore.FwsLiveSection(0) {
-			err := mptIo.Export(filepath.Join(b.carmenDir, "live"), buf)
+			err := mptIo.Export(context.Background(), filepath.Join(b.carmenDir, "live"), buf)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
From review in https://github.com/Fantom-foundation/Sonic/pull/187 it seems the Carmen upgrade and related migration from big.Int amounts to Carmen specific Amount type would be better to do in a standalone PR.

Because of the conversion, StateDB can now produce error which can be exported only through dedicated Error() method. Then we need to make sure this method is called after EVM run.
