### PR TITLE
Update go-ethereum-substate version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240805085850-c5da31170f7d
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240814103603-fd3f24371804
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210201043429-a8e90a2a4f88

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8 h1:IPt
 github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4 h1:AA0BtERxmlf7jvDF4fwIB2k/Lsc7HTRE3QHTZnfcSVA=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4/go.mod h1:/yIHWCDDJcdKMJYvOLdYOnHt5eUBF9XWnrvrNE+90ik=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240805085850-c5da31170f7d h1:IVSjtTGWOSpphQ60feRDF8ixDEcGFimqRLijDurTLzk=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240805085850-c5da31170f7d/go.mod h1:c3Vd9obNDz3aXon1eECFubH6ewx9ZIUI6MCiZV7zAhE=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240814103603-fd3f24371804 h1:lDu7jjnBbxBOhzjWxOBDjK6oWDl6Ko/BLnSXQTQ+BNM=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240814103603-fd3f24371804/go.mod h1:c3Vd9obNDz3aXon1eECFubH6ewx9ZIUI6MCiZV7zAhE=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00 h1:yw5QaA7u4t2/j7VIGrMt640Kuhsx6pEIHM3bj10glWc=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00/go.mod h1:Ogv5etzSmM2rQ4eN3OfmyitwWaaPjd4EIDiW/NAbYGk=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=


### PR DESCRIPTION
Fix for closing all rpc connections while shuting down node as described in this [PR](https://github.com/Fantom-foundation/go-ethereum-substate/pull/63)

Solves https://github.com/Fantom-foundation/Sonic/issues/191