### PR TITLE
Add RPC response size limit for debug and trace namespace

### DIFF
--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -306,6 +306,11 @@ var (
 		Usage: "Limit for concurent js engines in RPC calls execution",
 		Value: gossip.DefaultConfig(cachescale.Identity).JSTracerLimit,
 	}
+	MaxResponseSizeFlag = cli.IntFlag{
+		Name:  "rpc.maxresponsesize",
+		Usage: "Limit maximum size in some RPC calls execution",
+		Value: gossip.DefaultConfig(cachescale.Identity).MaxResponseSize,
+	}
 	ModeFlag = cli.StringFlag{
 		Name:  "mode",
 		Usage: `Mode of the node ("rpc" or "validator")`,

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1220,7 +1220,10 @@ func FormatLogs(logs []vm.StructLog) (json.RawMessage, error) {
 	formatted := make([]StructLogRes, len(logs))
 
 	// resultBuffer is buffer for collecting logs
-	resultBuffer := NewJsonResultBuffer()
+	resultBuffer, err := NewJsonResultBuffer()
+	if err != nil {
+		return nil, err
+	}
 
 	for index, trace := range logs {
 		formatted[index] = StructLogRes{
@@ -1258,7 +1261,7 @@ func FormatLogs(logs []vm.StructLog) (json.RawMessage, error) {
 			return nil, err
 		}
 	}
-	return resultBuffer.GetResult(), nil
+	return resultBuffer.GetResult()
 }
 
 type extBlockApi struct {

--- a/ethapi/limit.go
+++ b/ethapi/limit.go
@@ -1,0 +1,55 @@
+package ethapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+var (
+	// responseSizeLimit limits maximum size of RPC response
+	responseSizeLimit int
+	// ErrMaxResponseSize is returned if size of the RPC call
+	// response is over defined limit
+	ErrMaxResponseSize = errors.New("response size exceeded")
+)
+
+// SetResponseSizeLimit sets maximum size of RPC response in bytes
+func SetResponseSizeLimit(limit int) {
+	responseSizeLimit = limit
+}
+
+// JsonResultBuffer is a bytes buffer for jsonRawMessage result
+type JsonResultBuffer struct {
+	bytes.Buffer
+}
+
+// NewJsonResultBuffer creates new bytes buffer
+func NewJsonResultBuffer() *JsonResultBuffer {
+	b := JsonResultBuffer{}
+	b.WriteString("[")
+	return &b
+}
+
+// GetResult returns finalized byte array
+func (b *JsonResultBuffer) GetResult() []byte {
+	b.WriteString("]")
+	return b.Bytes()
+}
+
+// AddObject marshals and adds object into buffer.
+// In case that buffer size is over defined limit, error is returned
+func (b *JsonResultBuffer) AddObject(obj interface{}) error {
+	res, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if responseSizeLimit > 0 && b.Len()+len(res) > responseSizeLimit {
+		return ErrMaxResponseSize
+	}
+	if b.Len() > 1 {
+		b.WriteString(",")
+	}
+	b.Write(res)
+	return nil
+}

--- a/ethapi/limit.go
+++ b/ethapi/limit.go
@@ -6,12 +6,21 @@ import (
 	"errors"
 )
 
+const (
+	// bufferStartSize default buffer start size in bytes
+	bufferStartSize = 100000
+)
+
 var (
 	// responseSizeLimit limits maximum size of RPC response
 	responseSizeLimit int
 	// ErrMaxResponseSize is returned if size of the RPC call
 	// response is over defined limit
 	ErrMaxResponseSize = errors.New("response size exceeded")
+	// ErrResponseTooLarge is returned when the result buffer cannot be expanded
+	ErrResponseTooLarge = errors.New("response too large")
+	// ErrCannotInitBuffer is returned when initialization of the buffer failed
+	ErrCannotInitBuffer = errors.New("cannot initialize write buffer")
 )
 
 // SetResponseSizeLimit sets maximum size of RPC response in bytes
@@ -25,16 +34,27 @@ type JsonResultBuffer struct {
 }
 
 // NewJsonResultBuffer creates new bytes buffer
-func NewJsonResultBuffer() *JsonResultBuffer {
-	b := JsonResultBuffer{}
-	b.WriteString("[")
-	return &b
+func NewJsonResultBuffer() (b *JsonResultBuffer, err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrCannotInitBuffer
+		}
+	}()
+	b = &JsonResultBuffer{}
+	// grow buffer to default start size
+	b.Grow(bufferStartSize)
+	if err := b.writeString("["); err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetResult returns finalized byte array
-func (b *JsonResultBuffer) GetResult() []byte {
-	b.WriteString("]")
-	return b.Bytes()
+func (b *JsonResultBuffer) GetResult() ([]byte, error) {
+	if err := b.writeString("]"); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 // AddObject marshals and adds object into buffer.
@@ -48,8 +68,24 @@ func (b *JsonResultBuffer) AddObject(obj interface{}) error {
 		return ErrMaxResponseSize
 	}
 	if b.Len() > 1 {
-		b.WriteString(",")
+		if err := b.writeString(","); err != nil {
+			return err
+		}
 	}
-	b.Write(res)
+	if err = b.writeString(string(res)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeString appends the contents of s to the buffer and handle possible panic
+func (b *JsonResultBuffer) writeString(s string) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrResponseTooLarge
+		}
+	}()
+	b.WriteString(s)
 	return nil
 }

--- a/ethapi/limit.go
+++ b/ethapi/limit.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// bufferStartSize default buffer start size in bytes
-	bufferStartSize = 100000
+	bufferStartSize = 10 * 1024
 )
 
 var (

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -343,7 +343,10 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (js
 	var traceAdded, traceCount uint
 
 	// resultBuffer is buffer for collecting result traces
-	resultBuffer := NewJsonResultBuffer()
+	resultBuffer, err := NewJsonResultBuffer()
+	if err != nil {
+		return nil, err
+	}
 	// parse arguments
 	fromBlock, toBlock, fromAddresses, toAddresses := parseFilterArguments(s.b, args)
 
@@ -365,7 +368,7 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (js
 				traceAdded++
 			}
 			if traceAdded >= args.Count {
-				return resultBuffer.GetResult(), nil
+				return resultBuffer.GetResult()
 			}
 			traceCount++
 		}
@@ -375,14 +378,17 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (js
 			return nil, ctx.Err()
 		}
 	}
-	return resultBuffer.GetResult(), nil
+	return resultBuffer.GetResult()
 }
 
 // Filter specified block range in parallel
 func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (json.RawMessage, error) {
 
 	// resultBuffer is buffer for collecting result traces
-	resultBuffer := NewJsonResultBuffer()
+	resultBuffer, err := NewJsonResultBuffer()
+	if err != nil {
+		return nil, err
+	}
 	// parse arguments
 	fromBlock, toBlock, fromAddresses, toAddresses := parseFilterArguments(s.b, args)
 	// add context cancel function
@@ -446,7 +452,7 @@ func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args Filte
 		}
 	}
 
-	return resultBuffer.GetResult(), nil
+	return resultBuffer.GetResult()
 }
 
 // Fills blocks into provided channel for processing and close the channel in the end

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -361,7 +361,7 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (js
 		for _, trace := range traces {
 
 			if traceCount >= args.After {
-				err := resultBuffer.AddObject(trace)
+				err := resultBuffer.AddObject(&trace)
 				if err != nil {
 					return nil, err
 				}
@@ -414,9 +414,11 @@ func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args Filte
 				if res.err != nil {
 					cancelFunc(res.err)
 				} else {
-					err := resultBuffer.AddObject(res.trace)
-					if err != nil {
-						cancelFunc(err)
+					for _, trace := range res.trace {
+						err := resultBuffer.AddObject(&trace)
+						if err != nil {
+							cancelFunc(err)
+						}
 					}
 				}
 			case <-ctx.Done():

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -110,6 +110,9 @@ type (
 		// JSTracerLimit is a global JS engine limit for RPC debug methods execution.
 		JSTracerLimit int
 
+		// MaxResponseSize is a limit for maximum response size in some RPC calls
+		MaxResponseSize int
+
 		RPCBlockExt bool
 	}
 
@@ -229,6 +232,8 @@ func DefaultConfig(scale cachescale.Func) Config {
 		BatchRequestLimit: 1000,
 
 		JSTracerLimit: 1000,
+
+		MaxResponseSize: 25 * 1024 * 1024,
 	}
 	sessionCfg := cfg.Protocol.DagStreamLeecher.Session
 	cfg.Protocol.DagProcessor.EventsBufferLimit.Num = idx.Event(sessionCfg.ParallelChunksDownload)*

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -264,6 +264,7 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	rpc.SetExecutionTimeLimit(config.RPCTimeout)
 	rpc.SetBatchItemLimit(config.BatchRequestLimit)
 	tracers.SetConcurentJSLimit(config.JSTracerLimit)
+	ethapi.SetResponseSizeLimit(config.MaxResponseSize)
 
 	// create API backend
 	svc.EthAPI = &EthAPIBackend{false, svc, stateReader, txSigner, config.AllowUnprotectedTxs}


### PR DESCRIPTION
This PR adds configurable limit for RPC response size for namespace debug and trace.
Limit can be configured with CLI parameter:
- rpc.maxresponsesize

Or with config file variable:
- MaxResponseSize

Size is set in bytes and default for this variable is set to 25MB