### PR TITLE
Handle latest and pending options for trace namespace call

### DIFF
--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -46,14 +46,14 @@ func (s *PublicTxTraceAPI) Transaction(ctx context.Context, hash common.Hash) (*
 func (s *PublicTxTraceAPI) Block(ctx context.Context, numberOrHash rpc.BlockNumberOrHash) (*[]txtrace.ActionTrace, error) {
 
 	blockNumber, _ := numberOrHash.Number()
-	currentBlockNumber := s.b.CurrentBlock().NumberU64()
-
-	if blockNumber == rpc.LatestBlockNumber {
-		blockNumber = rpc.BlockNumber(currentBlockNumber)
-	}
 
 	if blockNumber == rpc.PendingBlockNumber {
 		return nil, fmt.Errorf("cannot trace pending block")
+	}
+
+	currentBlockNumber := s.b.CurrentBlock().NumberU64()
+	if blockNumber == rpc.LatestBlockNumber {
+		blockNumber = rpc.BlockNumber(currentBlockNumber)
 	}
 
 	if uint64(blockNumber.Int64()) > currentBlockNumber {

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -486,7 +486,7 @@ func parseFilterArguments(b Backend, args FilterArgs) (fromBlock rpc.BlockNumber
 	if args.FromBlock != nil {
 		fromBlock = *args.FromBlock.BlockNumber
 		if fromBlock == rpc.LatestBlockNumber || fromBlock == rpc.PendingBlockNumber {
-			toBlock = blockHead
+			fromBlock = blockHead
 		}
 	}
 

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -48,6 +48,14 @@ func (s *PublicTxTraceAPI) Block(ctx context.Context, numberOrHash rpc.BlockNumb
 	blockNumber, _ := numberOrHash.Number()
 	currentBlockNumber := s.b.CurrentBlock().NumberU64()
 
+	if blockNumber == rpc.LatestBlockNumber {
+		blockNumber = rpc.BlockNumber(currentBlockNumber)
+	}
+
+	if blockNumber == rpc.PendingBlockNumber {
+		return nil, fmt.Errorf("cannot trace pending block")
+	}
+
 	if uint64(blockNumber.Int64()) > currentBlockNumber {
 		return nil, fmt.Errorf("requested block nr %v > current node block nr %v", blockNumber.Int64(), currentBlockNumber)
 	}
@@ -473,17 +481,22 @@ func addBlocksForProcessing(ctx context.Context, fromBlock rpc.BlockNumber, toBl
 // Parses rpc call arguments
 func parseFilterArguments(b Backend, args FilterArgs) (fromBlock rpc.BlockNumber, toBlock rpc.BlockNumber, fromAddresses map[common.Address]struct{}, toAddresses map[common.Address]struct{}) {
 
+	blockHead := rpc.BlockNumber(b.CurrentBlock().NumberU64())
+
 	if args.FromBlock != nil {
 		fromBlock = *args.FromBlock.BlockNumber
+		if fromBlock == rpc.LatestBlockNumber || fromBlock == rpc.PendingBlockNumber {
+			toBlock = blockHead
+		}
 	}
 
 	if args.ToBlock != nil {
 		toBlock = *args.ToBlock.BlockNumber
 		if toBlock == rpc.LatestBlockNumber || toBlock == rpc.PendingBlockNumber {
-			toBlock = rpc.BlockNumber(b.CurrentBlock().NumberU64())
+			toBlock = blockHead
 		}
 	} else {
-		toBlock = rpc.BlockNumber(b.CurrentBlock().NumberU64())
+		toBlock = blockHead
 	}
 
 	if args.FromAddress != nil {


### PR DESCRIPTION
When using "latest" and "pending" in RPC call for tracing block and tracing filter, it was not correctly translated to a block number. This PR fixes this.