### PR TITLE
Upgrade Carmen to 7f258ce to avoid too often checkpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-require github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8
+require github.com/Fantom-foundation/Carmen/go v0.0.0-20240812081626-7f258ce901b3
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8 h1:IPtyB4nzqCmt6as6D7NpgZV3Hnh7FlucoHw5+FlAFfM=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240801115916-95f776fc98c8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240812081626-7f258ce901b3 h1:4Ggh+U5qrxXFsH+n11v07j1vZxBY5hdE7Rs4jzOn3EA=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240812081626-7f258ce901b3/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4 h1:AA0BtERxmlf7jvDF4fwIB2k/Lsc7HTRE3QHTZnfcSVA=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4/go.mod h1:/yIHWCDDJcdKMJYvOLdYOnHt5eUBF9XWnrvrNE+90ik=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240814103603-fd3f24371804 h1:lDu7jjnBbxBOhzjWxOBDjK6oWDl6Ko/BLnSXQTQ+BNM=


### PR DESCRIPTION
Carmen version [95f776f](https://github.com/Fantom-foundation/Carmen/commit/95f776fc98c831d198c14a96130b69c76999adbc) may be extremely slow when running in archive mode.

Upgrading to fixed version, which has passed the full archive recording test.