### PR TITLE
Remove automated publishing of opera client

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -27,10 +27,4 @@ jobs:
         run: go test -v ./...
 
       - name: Build
-        run: make opera
-
-      - name: Publish
-        uses: actions/upload-artifact@v2
-        with:
-          name: opera
-          path: ./build/opera
+        run: make


### PR DESCRIPTION
This PR updates the github workflow file processing incoming pull requests by eliminating the automated upload of the `opera` binary.

Since the Sonic migration, the `opera` binary is not actually created any more. However, recently this final upload step started to fail because of the out-dated version of the upload script (see [Deprecation notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)).