### PR TITLE
Upgrade carmen to to include healing fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-require github.com/Fantom-foundation/Carmen/go v0.0.0-20240918121620-7b3bb4cda1e2
+require github.com/Fantom-foundation/Carmen/go v0.0.0-20240919111317-5c737f72628f
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240918121620-7b3bb4cda1e2 h1:/SgyUZ8xunAftQmJybWQkM1T+n44e38Ljh76xBbxwNE=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20240918121620-7b3bb4cda1e2/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240919111317-5c737f72628f h1:86pdhhkjEuPrtJSZUg1ljHgJlCEFIwz2T9i1NHXaPME=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20240919111317-5c737f72628f/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4 h1:AA0BtERxmlf7jvDF4fwIB2k/Lsc7HTRE3QHTZnfcSVA=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4/go.mod h1:/yIHWCDDJcdKMJYvOLdYOnHt5eUBF9XWnrvrNE+90ik=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240814103603-fd3f24371804 h1:lDu7jjnBbxBOhzjWxOBDjK6oWDl6Ko/BLnSXQTQ+BNM=


### PR DESCRIPTION
After this Carmen fix the healing of broken database succeed (after 5-6 hours) on my testing server (32GB ram):
The CPU usage was high, so probably this can be faster when more CPU cores is used.
```
root@jk-sonic-testing-heal-small2:~# GOMEMLIMIT=20000 sonictool --cache 8000 --datadir=/var/sonic/mainnet heal
INFO [09-19|17:48:13.007] Maximum peer count                       total=50
INFO [09-19|17:48:13.008] Healing gossip db...
INFO [09-19|17:48:13.121] Last closed epoch with available state found epoch=298029
INFO [09-19|17:48:13.122] Reverting to epoch state                 epoch=298029 block=88051672
INFO [09-19|17:48:13.127] Removing excessive events
INFO [09-19|17:48:13.468] Removing epoch DBs - will be recreated on next start
INFO [09-19|17:48:13.468] Removing epoch db                        name=lachesis
INFO [09-19|17:48:13.477] Recreating consensus database
INFO [09-19|17:48:13.484] Clearing DBs dirty flags
INFO [09-19|17:48:13.593] Database set clean                       name=gossip
INFO [09-19|17:48:14.183] Database set clean                       name=lachesis
INFO [09-19|17:48:14.186] Archive state database reverted          block=88051672
INFO [09-19|17:48:14.186] Re-creating live state from the archive...
2024/09/19 17:48:23 [t=   0:09] - exporting codes
2024/09/19 17:48:31 [t=   0:17] - retrieved 1000000 accounts, 118039.72 accounts/s
2024/09/19 17:48:40 [t=   0:25] - retrieved 2000000 accounts, 120482.78 accounts/s
...
2024/09/19 23:36:16 [t= 348:02] - imported 170000000 accounts, 28145.12 accounts/s
2024/09/19 23:36:44 [t= 348:30] - imported 171000000 accounts, 35750.06 accounts/s
INFO [09-19|23:37:04.579] Healing finished
root@jk-sonic-testing-heal-small2:~#
root@jk-sonic-testing-heal-small2:~#
root@jk-sonic-testing-heal-small2:~# GOMEMLIMIT=20000 sonicd --cache 8000 --datadir=/var/sonic/mainnet
INFO [09-20|06:10:49.630] Maximum peer count                       total=50
INFO [09-20|06:10:49.630] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [09-20|06:11:05.504] Genesis is written                       name=main id=250 genesis=0x4a53c5445584b3bfc20dbfb2ec18ae20037c716f3ba2d9e1da768a9deca17cb4
INFO [09-20|06:11:05.575] Loaded local transaction journal         transactions=0 dropped=0
INFO [09-20|06:11:05.576] Regenerated local transaction journal    transactions=0 accounts=0
INFO [09-20|06:11:05.635] Starting peer-to-peer node               instance=Sonic/v1.2.1-e-7256f6f3-1726767570/linux-amd64/go1.22.4
INFO [09-20|06:11:05.857] New local node record                    seq=4 id=fc6fbfbb3e645ab0 ip=127.0.0.1 udp=5050 tcp=5050
INFO [09-20|06:11:05.860] IPC endpoint opened                      url=/var/sonic/mainnet/opera.ipc
INFO [09-20|06:11:05.863] Started P2P networking                   self=enode://f39fe191312483c5a58788ef2485a525e8ea63992ba27962fcea0b667e73eeb6a9c49ccbbe0c6474c090bce3e2e001fa5fcd5364fe050157052a3a5ef405c843@127.0.0.1:5050
INFO [09-20|06:11:08.400] New DAG summary                          new=1 last_id=298029:1:218800 age=1mo14d2h t=1.102ms
INFO [09-20|06:11:08.852] New block                                index=88051673 id=298029:3:8821a9  gas_used=2,724,869 txs=14/0 age=1mo14d2h t=403.124ms
INFO [09-20|06:11:14.579] New block                                index=88051674 id=298029:20:e8c5b4 gas_used=4,855,125 txs=23/0 age=1mo14d2h t=5.727s
INFO [09-20|06:11:14.976] New block                                index=88051675 id=298029:38:44f744 gas_used=3,269,304 txs=20/0 age=1mo14d2h t=392.498ms
```