### PR TITLE
Include tracing fixes

### DIFF
--- a/cmd/sonicd/launcher.go
+++ b/cmd/sonicd/launcher.go
@@ -27,6 +27,11 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/debug"
 	_ "github.com/Fantom-foundation/go-opera/version"
+
+	// Force-load the tracer engines to trigger registration
+	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
+	_ "github.com/ethereum/go-ethereum/eth/tracers/live"
+	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 )
 
 var (

--- a/cmd/sonicd/launcher.go
+++ b/cmd/sonicd/launcher.go
@@ -130,6 +130,8 @@ func initFlags() {
 		flags.RPCGlobalEVMTimeoutFlag,
 		flags.RPCGlobalTxFeeCapFlag,
 		flags.RPCGlobalTimeoutFlag,
+		flags.BatchRequestLimit,
+		flags.BatchResponseMaxSize,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -291,6 +291,16 @@ var (
 		Usage: "Time limit for RPC calls execution",
 		Value: gossip.DefaultConfig(cachescale.Identity).RPCTimeout,
 	}
+	BatchRequestLimit = &cli.IntFlag{
+		Name:     "rpc.batch-request-limit",
+		Usage:    "Maximum number of requests in a batch",
+		Value:    node.DefaultConfig.BatchRequestLimit,
+	}
+	BatchResponseMaxSize = &cli.IntFlag{
+		Name:     "rpc.batch-response-max-size",
+		Usage:    "Maximum number of bytes returned from a batched call",
+		Value:    node.DefaultConfig.BatchResponseMaxSize,
+	}
 	ModeFlag = cli.StringFlag{
 		Name:  "mode",
 		Usage: `Mode of the node ("rpc" or "validator")`,

--- a/config/node_config.go
+++ b/config/node_config.go
@@ -194,6 +194,12 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(flags.HTTPPathPrefixFlag.Name) {
 		cfg.HTTPPathPrefix = ctx.GlobalString(flags.HTTPPathPrefixFlag.Name)
 	}
+	if ctx.IsSet(flags.BatchRequestLimit.Name) {
+		cfg.BatchRequestLimit = ctx.Int(flags.BatchRequestLimit.Name)
+	}
+	if ctx.IsSet(flags.BatchResponseMaxSize.Name) {
+		cfg.BatchResponseMaxSize = ctx.Int(flags.BatchResponseMaxSize.Name)
+	}
 }
 
 // setWS creates the WebSocket RPC listener interface string from the set

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1981,6 +1981,7 @@ func (api *PublicDebugAPI) TraceTransaction(ctx context.Context, hash common.Has
 	defer statedb.Release()
 
 	txctx := &tracers.Context{
+		BlockHash:   block.Hash,
 		BlockNumber: block.Number,
 		TxIndex:     int(index),
 		TxHash:      hash,
@@ -2104,16 +2105,16 @@ func (api *PublicDebugAPI) traceBlock(ctx context.Context, block *evmcore.EvmBlo
 
 	var (
 		txs       = block.Transactions
-		blockHash = block.Hash
 		signer    = gsignercache.Wrap(types.MakeSigner(api.b.ChainConfig(), block.Number, uint64(block.Time.Unix())))
 		results   = make([]*txTraceResult, len(txs))
 	)
 	for i, tx := range txs {
 		msg, _ := evmcore.TxAsMessage(tx, signer, block.BaseFee)
 		txctx := &tracers.Context{
-			BlockHash: blockHash,
-			TxIndex:   i,
-			TxHash:    tx.Hash(),
+			BlockHash:   block.Hash,
+			BlockNumber: block.Number,
+			TxIndex:     i,
+			TxHash:      tx.Hash(),
 		}
 		res, err := api.traceTx(ctx, tx, msg, txctx, block.Header(), statedb, config)
 		if err != nil {

--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -65,6 +65,7 @@ func NewEVMTxContext(msg Message) vm.TxContext {
 	return vm.TxContext{
 		Origin:   msg.From,
 		GasPrice: new(big.Int).Set(msg.GasPrice),
+		BlobFeeCap: msg.BlobGasFeeCap,
 	}
 }
 

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -218,22 +218,20 @@ func TxAsMessage(tx *types.Transaction, signer types.Signer, baseFee *big.Int) (
 	if !internaltx.IsInternal(tx) {
 		return core.TransactionToMessage(tx, signer, baseFee)
 	} else {
-		return &core.Message{
-			From:       internaltx.InternalSender(tx),
-			To:         tx.To(),
-			Nonce:      tx.Nonce(),
-			Value:      tx.Value(),
-			GasLimit:   tx.Gas(),
-			GasPrice:   tx.GasPrice(),
-			GasFeeCap:  tx.GasFeeCap(),
-			GasTipCap:  tx.GasTipCap(),
-			Data:       tx.Data(),
-			AccessList: tx.AccessList(),
-			/* // TODO: add support for blob gas and hashes
-			BlobGasFeeCap:     *big.Int,
-			BlobHashes:        []common.Hash,
-			*/
-			SkipAccountChecks: true,
+		return &core.Message{ // internal tx - no signature checking
+			From:              internaltx.InternalSender(tx),
+			To:                tx.To(),
+			Nonce:             tx.Nonce(),
+			Value:             tx.Value(),
+			GasLimit:          tx.Gas(),
+			GasPrice:          tx.GasPrice(),
+			GasFeeCap:         tx.GasFeeCap(),
+			GasTipCap:         tx.GasTipCap(),
+			Data:              tx.Data(),
+			AccessList:        tx.AccessList(),
+			BlobGasFeeCap:     tx.BlobGasFeeCap(),
+			BlobHashes:        tx.BlobHashes(),
+			SkipAccountChecks: true, // don't check sender nonce and being EOA
 		}, nil
 	}
 }


### PR DESCRIPTION
* Add import of tracers to register them
* Add `rpc.batch-request-limit` and `rpc.batch-response-max-size` flags (limits supported by new ethereum)
* Fix StateDB usage in tracing (WrapStateDbWithLogger usage)
*  Include fix #194
* Always set block number/block hash into the EVM in tracing
* Resolve todo for blobs of internal txs (probably not going to be used ever, but better to have it consistent)