### PR TITLE
Handle dag_getEvent panic on invalid input

### DIFF
--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"strconv"
 	"strings"
@@ -163,7 +164,11 @@ func (b *EthAPIBackend) GetFullEventID(shortEventID string) (hash.Event, error) 
 	s := strings.Split(shortEventID, ":")
 	if len(s) == 1 {
 		// it's a full hash
-		return hash.HexToEventHash(shortEventID), nil
+		eventHash, err := hexutil.Decode(shortEventID)
+		if err != nil {
+			return hash.Event{}, errors.Wrap(err, "full hash parsing error")
+		}
+		return hash.Event(hash.BytesToHash(eventHash)), nil
 	}
 	// short hash
 	epoch, lamport, prefix, err := decodeShortEventID(s)


### PR DESCRIPTION
For RPC request
```
{"jsonrpc":"2.0","method":"dag_getEvent","params":["invalid"],"id":1}
```
the Sonic client fails:
```
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"method handler crashed"}}
```
and prints stacktrace into the log.

This fix handles the invalid input better:
```
{"jsonrpc":"2.0","method":"dag_getEvent","params":["invalid"],"id":1}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"full hash parsing error: hex string without 0x prefix"}}
```