### PR TITLE
Re-add support of older events format emitting

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -381,7 +381,12 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 		selfParentTime = selfParentHeader.CreationTime()
 	}
 
-	version := uint8(2) // post-LLR event format
+	version := uint8(0)
+	if em.world.GetRules().Upgrades.Sonic {
+		version = 2
+	} else if em.world.GetRules().Upgrades.Llr {
+		version = 1
+	}
 
 	mutEvent := &inter.MutableEventPayload{}
 	mutEvent.SetVersion(version)


### PR DESCRIPTION
Re-add switch choosing the emitted event version in dependence on enabled network upgrades.