### PR TITLE
Add missing prometheus metrics

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -36,6 +36,7 @@ var (
 	headFastBlockGauge = metrics.GetOrRegisterGauge("chain/head/receipt", nil)
 
 	blockExecutionTimer = metrics.GetOrRegisterResettingTimer("chain/execution", nil)
+	blockExecutionNonResettingTimer = metrics.GetOrRegisterTimer("chain/execution/nonresetting", nil)
 	blockAgeGauge       = metrics.GetOrRegisterGauge("chain/block/age", nil)
 
 	processedTxsMeter    = metrics.GetOrRegisterMeter("chain/txs/processed", nil)
@@ -313,7 +314,9 @@ func consensusCallbackBeginBlockFn(
 					store.EvmStore().SetCachedEvmBlock(blockCtx.Idx, evmBlock)
 
 					// Update the metrics touched during block processing
-					blockExecutionTimer.Update(time.Since(executionStart))
+					executionTime := time.Since(executionStart)
+					blockExecutionTimer.Update(executionTime)
+					blockExecutionNonResettingTimer.Update(executionTime)
 
 					// Update the metrics touched by new block
 					headBlockGauge.Update(int64(blockCtx.Idx))


### PR DESCRIPTION
Fixes #218.
Add following prometheus metrics, used in Norma testing:
* `chain_execution_nonresetting` - because original `chain_execution` metrics is being reset regularly in the new ethereum, I am adding the original non-resetted metrics as a new metric.
* `chain_info` metrics added in the new ethereum made working by setting the chain_id into it

```
# TYPE chain_info gauge
chain_info {chain_id="4003"} 1

# TYPE chain_execution_count counter - is being reset to zero regularly with the new ethereum
chain_execution_count 1

# TYPE chain_execution summary - is being reset to zero regularly with the new ethereum
chain_execution {quantile="0.5"} 151768
chain_execution {quantile="0.75"} 151768
chain_execution {quantile="0.95"} 151768
chain_execution {quantile="0.99"} 151768
chain_execution {quantile="0.999"} 151768
chain_execution {quantile="0.9999"} 151768

# TYPE chain_execution_nonresetting_count counter - replacement of old chain_execution_count
chain_execution_nonresetting_count 9

# TYPE chain_execution_nonresetting summary - replacement of old chain_execution
chain_execution_nonresetting {quantile="0.5"} 138109
chain_execution_nonresetting {quantile="0.75"} 800485
chain_execution_nonresetting {quantile="0.95"} 2.499486e+06
chain_execution_nonresetting {quantile="0.99"} 2.499486e+06
chain_execution_nonresetting {quantile="0.999"} 2.499486e+06
chain_execution_nonresetting {quantile="0.9999"} 2.499486e+06
```