### PR TITLE
Don't accept non empty blob transactions

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1676,7 +1676,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if err := b.SendTx(ctx, tx); err != nil {
 		return common.Hash{}, err
 	} // Print a log with full tx details for manual investigations and interventions
-	signer := gsignercache.Wrap(types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number, 0 /*timestamp*/))
+	signer := gsignercache.Wrap(types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number, uint64(b.CurrentBlock().Time.Unix())))
 	from, err := types.Sender(signer, tx)
 	if err != nil {
 		return common.Hash{}, err

--- a/eventcheck/epochcheck/epoch_check.go
+++ b/eventcheck/epochcheck/epoch_check.go
@@ -89,6 +89,9 @@ func CheckTxs(txs types.Transactions, rules opera.Rules) error {
 	if rules.Upgrades.London {
 		maxType = 2
 	}
+	if rules.Upgrades.Sonic {
+		maxType = 3
+	}
 	for _, tx := range txs {
 		if tx.Type() > maxType {
 			return ErrUnsupportedTxType

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -658,12 +658,13 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 
 	// Reject blob transactions until EIP-4844 activates or if is already EIP-4844 and they are not empty
-	if !pool.eip4844 && tx.Type() == types.BlobTxType {
-		return ErrTxTypeNotSupported
-	} else if pool.eip4844 && tx.Type() == types.BlobTxType {
+	if tx.Type() == types.BlobTxType {
+		if !pool.eip4844 {
+			return ErrTxTypeNotSupported
+		}
+		// For now, Sonic only supports Blob transactions without blob data.
 		if len(tx.BlobHashes()) > 0 ||
 			(tx.BlobTxSidecar() != nil && len(tx.BlobTxSidecar().BlobHashes()) > 0) {
-
 			return ErrTxTypeNotSupported
 		}
 	}

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -213,7 +213,7 @@ func validateEvents(events chan NewTxsNotify, count int) error {
 		select {
 		case ev := <-events:
 			received = append(received, ev.Txs...)
-		case <-time.After(5*time.Second):
+		case <-time.After(5 * time.Second):
 			return fmt.Errorf("event #%d not fired", len(received))
 		}
 	}


### PR DESCRIPTION
This PR adds validation of the EIP-4844 blob transaction on the transaction pool level. If the blob transaction is not empty, it is not accepted by the transaction pool.

Because this PR is dependant on correct upgrade handling, PR https://github.com/Fantom-foundation/Sonic/pull/216 needs to be merged before this PR