### PR TITLE
GetBlockReceipts accepts BlockNumberOrHash instead of BlockNumber

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1776,10 +1776,25 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 }
 
 // GetBlockReceipts returns a set of transaction receipts for the given block by the extended block number.
-func (s *PublicTransactionPoolAPI) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber) ([]map[string]interface{}, error) {
-	header, err := s.b.HeaderByNumber(ctx, number)
-	if header == nil || err != nil {
-		return nil, err
+func (s *PublicTransactionPoolAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error) {
+	var (
+		err    error
+		number rpc.BlockNumber
+		header *evmcore.EvmHeader
+	)
+
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		number = blockNr
+		header, err = s.b.HeaderByNumber(ctx, number)
+		if err != nil {
+			return nil, err
+		}
+	} else if blockHash, ok := blockNrOrHash.Hash(); ok {
+		header, err = s.b.HeaderByHash(ctx, blockHash)
+		if err != nil {
+			return nil, err
+		}
+		number = rpc.BlockNumber(header.Number.Uint64())
 	}
 
 	receipts, err := s.b.GetReceiptsByNumber(ctx, number)


### PR DESCRIPTION
This is needed since some protocols use this endpoint by passing the blockHash instead of the blockNumber. So both options need be available

Please check if what you want to add to `go-opera` list meets [quality standards](https://github.com/Fantom-foundation/go-opera/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.

**Please provide package links to:**

- github.com repo:
- godoc.org:
- goreportcard.com:
- coverage service link ([cover.run](https://cover.run/), [gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.), example: `[![cover.run](https://cover.run/go/github.com/user/repository.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Fuser%2Frepository)`

**Make sure that you've checked the boxes below before you submit PR:**
- [X] I have added my package in alphabetical order.
- [X] I have an appropriate description with correct grammar.
- [X] I know that this package was not listed before.
- [X] I have added godoc link to the repo and to my pull request.
- [X] I have added coverage service link to the repo and to my pull request.
- [X] I have added goreportcard link to the repo and to my pull request.
- [X] I have read [Contribution guidelines](https://github.com/Fantom-foundation/go-opera/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/Fantom-foundation/go-opera/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/Fantom-foundation/go-opera/blob/master/CONTRIBUTING.md#quality-standard).
