### PR TITLE
Empty parents for genesis events and parents tests

### DIFF
--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/common"
@@ -55,6 +56,12 @@ func TestEmitter(t *testing.T) {
 	external.EXPECT().StateDB().
 		Return(nil).
 		AnyTimes()
+	external.EXPECT().GetLastEvent(idx.Epoch(1), cfg.Validator.ID).
+		Return(nil).
+		Times(1)
+	external.EXPECT().GetHeads(idx.Epoch(1)).
+		Return(hash.Events{(&tdag.TestEvent{}).ID(), (&tdag.TestEvent{}).ID()}).
+		Times(0)
 
 	em := NewEmitter(cfg, World{
 		External: external,
@@ -114,5 +121,18 @@ func TestEmitter(t *testing.T) {
 
 	t.Run("tick", func(t *testing.T) {
 		em.tick()
+	})
+
+	t.Run("chooseParentsGenesis", func(t *testing.T) {
+		selfParent, parents, ok := em.chooseParents(idx.Epoch(1), cfg.Validator.ID)
+		if selfParent != nil {
+			t.Error("genesis event must not have self parent")
+		}
+		if len(parents) > 0 {
+			t.Error("genesis event must not have any parents")
+		}
+		if !ok {
+			t.Error("genesis parent assignment must succeed without any parents")
+		}
 	})
 }

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/common"
@@ -56,12 +55,6 @@ func TestEmitter(t *testing.T) {
 	external.EXPECT().StateDB().
 		Return(nil).
 		AnyTimes()
-	external.EXPECT().GetLastEvent(idx.Epoch(1), cfg.Validator.ID).
-		Return(nil).
-		Times(1)
-	external.EXPECT().GetHeads(idx.Epoch(1)).
-		Return(hash.Events{(&tdag.TestEvent{}).ID(), (&tdag.TestEvent{}).ID()}).
-		Times(0)
 
 	em := NewEmitter(cfg, World{
 		External: external,
@@ -121,18 +114,5 @@ func TestEmitter(t *testing.T) {
 
 	t.Run("tick", func(t *testing.T) {
 		em.tick()
-	})
-
-	t.Run("chooseParentsGenesis", func(t *testing.T) {
-		selfParent, parents, ok := em.chooseParents(idx.Epoch(1), cfg.Validator.ID)
-		if selfParent != nil {
-			t.Error("genesis event must not have self parent")
-		}
-		if len(parents) > 0 {
-			t.Error("genesis event must not have any parents")
-		}
-		if !ok {
-			t.Error("genesis parent assignment must succeed without any parents")
-		}
 	})
 }

--- a/gossip/emitter/parents.go
+++ b/gossip/emitter/parents.go
@@ -39,17 +39,15 @@ func (em *Emitter) buildSearchStrategies(maxParents idx.Event) []ancestor.Search
 // chooseParents selects an "optimal" parents set for the validator
 func (em *Emitter) chooseParents(epoch idx.Epoch, myValidatorID idx.ValidatorID) (*hash.Event, hash.Events, bool) {
 	selfParent := em.world.GetLastEvent(epoch, myValidatorID)
-	heads := em.world.GetHeads(epoch) // events with no descendants
-
-	if selfParent != nil && len(em.world.DagIndex().NoCheaters(selfParent, hash.Events{*selfParent})) == 0 {
+	if selfParent == nil {
+		return nil, nil, true
+	}
+	if len(em.world.DagIndex().NoCheaters(selfParent, hash.Events{*selfParent})) == 0 {
 		em.Periodic.Error(time.Second, "Events emitting isn't allowed due to the doublesign", "validator", myValidatorID)
 		return nil, nil, false
 	}
-
-	var parents hash.Events
-	if selfParent != nil {
-		parents = hash.Events{*selfParent}
-	}
+	parents := hash.Events{*selfParent}
+	heads := em.world.GetHeads(epoch) // events with no descendants
 	parents = ancestor.ChooseParents(parents, heads, em.buildSearchStrategies(em.maxParents-idx.Event(len(parents))))
 	return selfParent, parents, true
 }

--- a/gossip/emitter/parents_test.go
+++ b/gossip/emitter/parents_test.go
@@ -7,14 +7,35 @@ import (
 	"github.com/Fantom-foundation/go-opera/vecmt"
 	"github.com/Fantom-foundation/lachesis-base/emitter/ancestor"
 	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/golang/mock/gomock"
 )
 
-func TestChooseParents(t *testing.T) {
+func TestChooseParents_NoParentsForGenesisEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	external := mock.NewMockExternal(ctrl)
+	em := NewEmitter(DefaultConfig(), World{External: external})
+
+	epoch := idx.Epoch(1)
+	validatorId := idx.ValidatorID(1)
+
+	external.EXPECT().GetLastEvent(epoch, validatorId)
+
+	selfParent, parents, ok := em.chooseParents(epoch, validatorId)
+	if selfParent != nil {
+		t.Error("genesis event must not have self parent")
+	}
+	if len(parents) > 0 {
+		t.Error("genesis event must not have any parents")
+	}
+	if !ok {
+		t.Error("genesis parent assignment must always succeed")
+	}
+}
+
+func TestChooseParents_NonGenesisEventMustHaveOneSelfParent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	external := mock.NewMockExternal(ctrl)
 	em := NewEmitter(DefaultConfig(), World{External: external})
@@ -22,57 +43,29 @@ func TestChooseParents(t *testing.T) {
 	em.payloadIndexer = ancestor.NewPayloadIndexer(3)
 
 	epoch := idx.Epoch(1)
-	nodes := tdag.GenNodes(2)
-	vEmpty, vNonEmpty := nodes[0], nodes[1]
-	selfParentHash := sampleProcessedEvent(1, em.payloadIndexer)
+	validatorId := idx.ValidatorID(1)
 
-	vi := vecmt.NewIndex(nil, vecmt.LiteConfig())
-	vi.Reset(pos.ArrayToValidators(nodes, []pos.Weight{1, 1}), memorydb.New(), nil)
+	validatorIndex := vecmt.NewIndex(nil, vecmt.LiteConfig())
+	validatorIndex.Reset(pos.ArrayToValidators(
+		[]idx.ValidatorID{1, 2},
+		[]pos.Weight{1, 1},
+	), memorydb.New(), nil)
 
-	external.EXPECT().GetLastEvent(epoch, vEmpty).
-		Return(nil).
-		Times(1)
-	external.EXPECT().GetLastEvent(epoch, vNonEmpty).
-		Return(&selfParentHash).
-		Times(1)
-	external.EXPECT().GetHeads(epoch).
-		Return(hash.Events{sampleProcessedEvent(2, em.payloadIndexer), sampleProcessedEvent(3, em.payloadIndexer)}).
-		Times(1)
-	external.EXPECT().DagIndex().
-		Return(vi).
-		Times(1)
+	selfParentHash := hash.Event{1}
 
-	t.Run("emptyChooseParents", func(t *testing.T) {
-		selfParent, parents, ok := em.chooseParents(epoch, vEmpty)
-		if selfParent != nil {
-			t.Error("genesis event must not have self parent")
-		}
-		if len(parents) > 0 {
-			t.Error("genesis event must not have any parents")
-		}
-		if !ok {
-			t.Error("genesis parent assignment must always succeed")
-		}
-	})
+	external.EXPECT().GetLastEvent(epoch, validatorId).Return(&selfParentHash)
+	external.EXPECT().GetHeads(epoch).Return(hash.Events{{2}, {3}})
+	external.EXPECT().DagIndex().Return(validatorIndex)
 
-	t.Run("nonEmptyChooseParents", func(t *testing.T) {
-		selfParent, parents, ok := em.chooseParents(epoch, vNonEmpty)
-		if selfParent == nil {
-			t.Error("non-genesis event must have a self parent")
-		}
-		// strategies sometimes choose the same parent multiple times, test for minimal amount (1 self parent + 1 random/metric)
-		if wantMin, got := 2, len(parents); got < wantMin {
-			t.Errorf("incorrect number of event parents, expected at least: %d, got: %d", wantMin, got)
-		}
-		if !ok {
-			t.Error("parent assignment must succeed when no cheating is detected")
-		}
-	})
-
-}
-
-func sampleProcessedEvent(id uint8, payloadIndexer *ancestor.PayloadIndexer) hash.Event {
-	event := (&tdag.TestEvent{}).Build([24]byte{id})
-	payloadIndexer.ProcessEvent(event, ancestor.Metric(id))
-	return event.ID()
+	selfParent, parents, ok := em.chooseParents(epoch, validatorId)
+	if selfParent == nil {
+		t.Error("non-genesis event must have a self parent")
+	}
+	// strategies sometimes choose the same parent multiple times, test for minimal amount (1 self parent + 1 random/metric)
+	if wantMin, got := 2, len(parents); got < wantMin {
+		t.Errorf("incorrect number of event parents, expected at least: %d, got: %d", wantMin, got)
+	}
+	if !ok {
+		t.Error("parent assignment must succeed when no cheating is detected")
+	}
 }

--- a/gossip/emitter/parents_test.go
+++ b/gossip/emitter/parents_test.go
@@ -1,0 +1,78 @@
+package emitter
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/go-opera/gossip/emitter/mock"
+	"github.com/Fantom-foundation/go-opera/vecmt"
+	"github.com/Fantom-foundation/lachesis-base/emitter/ancestor"
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/golang/mock/gomock"
+)
+
+func TestChooseParents(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	external := mock.NewMockExternal(ctrl)
+	em := NewEmitter(DefaultConfig(), World{External: external})
+	em.maxParents = 3
+	em.payloadIndexer = ancestor.NewPayloadIndexer(3)
+
+	epoch := idx.Epoch(1)
+	nodes := tdag.GenNodes(2)
+	vEmpty, vNonEmpty := nodes[0], nodes[1]
+	selfParentHash := sampleProcessedEvent(1, em.payloadIndexer)
+
+	vi := vecmt.NewIndex(nil, vecmt.LiteConfig())
+	vi.Reset(pos.ArrayToValidators(nodes, []pos.Weight{1, 1}), memorydb.New(), nil)
+
+	external.EXPECT().GetLastEvent(epoch, vEmpty).
+		Return(nil).
+		Times(1)
+	external.EXPECT().GetLastEvent(epoch, vNonEmpty).
+		Return(&selfParentHash).
+		Times(1)
+	external.EXPECT().GetHeads(epoch).
+		Return(hash.Events{sampleProcessedEvent(2, em.payloadIndexer), sampleProcessedEvent(3, em.payloadIndexer)}).
+		Times(1)
+	external.EXPECT().DagIndex().
+		Return(vi).
+		Times(1)
+
+	t.Run("emptyChooseParents", func(t *testing.T) {
+		selfParent, parents, ok := em.chooseParents(epoch, vEmpty)
+		if selfParent != nil {
+			t.Error("genesis event must not have self parent")
+		}
+		if len(parents) > 0 {
+			t.Error("genesis event must not have any parents")
+		}
+		if !ok {
+			t.Error("genesis parent assignment must always succeed")
+		}
+	})
+
+	t.Run("nonEmptyChooseParents", func(t *testing.T) {
+		selfParent, parents, ok := em.chooseParents(epoch, vNonEmpty)
+		if selfParent == nil {
+			t.Error("non-genesis event must have a self parent")
+		}
+		// strategies sometimes choose the same parent multiple times, test for minimal amount (1 self parent + 1 random/metric)
+		if wantMin, got := 2, len(parents); got < wantMin {
+			t.Errorf("incorrect number of event parents, expected at least: %d, got: %d", wantMin, got)
+		}
+		if !ok {
+			t.Error("parent assignment must succeed when no cheating is detected")
+		}
+	})
+
+}
+
+func sampleProcessedEvent(id uint8, payloadIndexer *ancestor.PayloadIndexer) hash.Event {
+	event := (&tdag.TestEvent{}).Build([24]byte{id})
+	payloadIndexer.ProcessEvent(event, ancestor.Metric(id))
+	return event.ID()
+}


### PR DESCRIPTION
This PR makes all genesis events not have any parents. Having a parent by other creator as a genesis turns out to be problematic due to Lachesis' iterative frame calculation, thus inducing frame non-monotonicity for the event chains. Such non-monotonicity makes future incrementalization efforts impossible and potentially hides other performance and security concerns.
