### PR TITLE
Suppress panic flag for event file importing

### DIFF
--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -182,6 +182,7 @@ be gzipped.
 					ArgsUsage: "<filename> (<filename 2> ... <filename N>)",
 					Flags: []cli.Flag{
 						ModeFlag,
+						flags.SuppressFramePanicFlag,
 					},
 					Description: `
     sonictool --datadir=<datadir> events import <filenames> [--mode=validator]

--- a/config/config.go
+++ b/config/config.go
@@ -330,6 +330,10 @@ func MakeAllConfigsFromFile(ctx *cli.Context, configFile string) (*Config, error
 		return nil, err
 	}
 
+	if ctx.IsSet(flags.SuppressFramePanicFlag.Name) {
+		cfg.Lachesis.SuppressFramePanic = true
+	}
+
 	return &cfg, nil
 }
 

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -17,12 +17,13 @@
 package flags
 
 import (
+	"strings"
+
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	pcsclite "github.com/gballet/go-libpcsclite"
 	"gopkg.in/urfave/cli.v1"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/node"
 )
@@ -292,14 +293,14 @@ var (
 		Value: gossip.DefaultConfig(cachescale.Identity).RPCTimeout,
 	}
 	BatchRequestLimit = &cli.IntFlag{
-		Name:     "rpc.batch-request-limit",
-		Usage:    "Maximum number of requests in a batch",
-		Value:    node.DefaultConfig.BatchRequestLimit,
+		Name:  "rpc.batch-request-limit",
+		Usage: "Maximum number of requests in a batch",
+		Value: node.DefaultConfig.BatchRequestLimit,
 	}
 	BatchResponseMaxSize = &cli.IntFlag{
-		Name:     "rpc.batch-response-max-size",
-		Usage:    "Maximum number of bytes returned from a batched call",
-		Value:    node.DefaultConfig.BatchResponseMaxSize,
+		Name:  "rpc.batch-response-max-size",
+		Usage: "Maximum number of bytes returned from a batched call",
+		Value: node.DefaultConfig.BatchResponseMaxSize,
 	}
 	ModeFlag = cli.StringFlag{
 		Name:  "mode",
@@ -331,10 +332,10 @@ var (
 		Usage: "Password to unlock validator private key",
 		Value: "",
 	}
-	
+
 	// Consensus
 	SuppressFramePanicFlag = cli.BoolFlag{
-		Name:  "suppress-frame-panic",
+		Name:  "lachesis.suppress-frame-panic",
 		Usage: "Suppress frame missmatch error while importing event files",
 	}
 )

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -331,4 +331,10 @@ var (
 		Usage: "Password to unlock validator private key",
 		Value: "",
 	}
+	
+	// Consensus
+	SuppressFramePanicFlag = cli.BoolFlag{
+		Name:  "suppress-frame-panic",
+		Usage: "Suppress frame missmatch error while importing event files",
+	}
 )

--- a/go.mod
+++ b/go.mod
@@ -133,6 +133,6 @@ require (
 
 replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241016110649-0dd3a9b6f237
 
-replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240823114058-cda038e6d40b
+replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20241018103023-632a59c242f5
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210201043429-a8e90a2a4f88

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10 h1:D7askaA
 github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10/go.mod h1:DtJlv3NCjaFxBKGXR7HQfLhLSu+BY5OILQ/4s7MR6lA=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241016110649-0dd3a9b6f237 h1:9v5ZQuDpRl/d6wlLKzq5zy3mohc/2otrCX+UJmLVYHs=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241016110649-0dd3a9b6f237/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
-github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240823114058-cda038e6d40b h1:oggmwdVb9tJiUJrcFvs5A3JOC1t2I231N4/RW2YXr8w=
-github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240823114058-cda038e6d40b/go.mod h1:YaNcYnDsDooGLKqsrTt+tafplgorZ0l8C1IwmryrIWs=
+github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20241018103023-632a59c242f5 h1:dv1iFhsUfIfixwoNJWWZItWqOfKLV1mLA8eJLA1wceU=
+github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20241018103023-632a59c242f5/go.mod h1:YaNcYnDsDooGLKqsrTt+tafplgorZ0l8C1IwmryrIWs=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=


### PR DESCRIPTION
This PR introduces a new flag used only for `events import` subcommand that instructs Lachesis to suppress the frame check panic. This may be useful for regression testing where the monotonicity fix from https://github.com/Fantom-foundation/lachesis-base-sonic/pull/3 is not important and could obstruct ingestion of historical data.