### PR TITLE
Cleanup error handling in ApplyTransaction unit test

### DIFF
--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -31,11 +31,17 @@ func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {
 			evm := vm.NewEVM(vm.BlockContext{}, vm.TxContext{}, state, &params.ChainConfig{}, vm.Config{})
 			gp := new(core.GasPool).AddGas(1000000)
 
-			applyTransaction(&core.Message{
+			// The transaction will fail for various reasons, but for this test
+			// this is not relevant. We just want to check if the base fee
+			// configuration flag is updated to match the SkipAccountChecks flag.
+			_, _, _, err := applyTransaction(&core.Message{
 				SkipAccountChecks: internal,
 				GasPrice:          big.NewInt(0),
 				Value:             big.NewInt(0),
 			}, nil, gp, state, nil, common.Hash{}, nil, nil, evm, nil)
+			if err == nil {
+				t.Errorf("expected transaction to fail")
+			}
 
 			if want, got := internal, evm.Config.NoBaseFee; want != got {
 				t.Fatalf("want %v, got %v", want, got)


### PR DESCRIPTION
This PR adds error handling to a unit test where an error was quietly swallowed before.