### PR TITLE
Add linting automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ sonic-image:
 
 .PHONY: test
 test:
-	go test ./...
+	go test -cover ./...
 
 .PHONY: coverage
 coverage:
@@ -48,3 +48,20 @@ fuzz:
 .PHONY: clean
 clean:
 	rm -fr ./build/*
+
+# Linting
+
+STATICCHECK_VERSION = 2024.1.1
+.PHONY: staticcheck
+staticcheck: 
+	@go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
+	staticcheck ./...
+
+ERRCHECK_VERSION = v1.7.0
+.PHONY: errcheck
+errorcheck:
+	@go install github.com/kisielk/errcheck@$(ERRCHECK_VERSION)
+	errcheck ./...
+
+.PHONY: lint
+lint: staticcheck errorcheck

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,11 @@
+checks = [
+    "all",
+    # default ignored checks
+    "-SA9003", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023",
+    # # ignored for Sonic
+    "-ST1005", # error string formatting. No capital letter in the first word & no punctuation 
+    "-SA1019" # deprecated imports (CARMEN)
+] 
+initialisms = []
+dot_import_whitelist = []
+http_status_code_whitelist = []


### PR DESCRIPTION
This PR adds a script to run code linting from the make command: `make lint`
This command analyzes the code using [staticcheck](https://staticcheck.dev/) and [errcheck](https://github.com/kisielk/errcheck).

The execution of this command is not supposed to yield a satisfactory execution, as the code is currently containing some issues. For this reason, this script is not yet included in any CI nor nightly testing pipelines. 

This PR is part of [#25](https://github.com/orgs/Fantom-foundation/projects/18/views/1?pane=issue&itemId=83653545&issue=Fantom-foundation%7Csonic-admin%7C25)