### PR TITLE
Lint: Remove use of deprecated standard tools.

### DIFF
--- a/cmd/cmdtest/test_cmd.go
+++ b/cmd/cmdtest/test_cmd.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -79,7 +78,7 @@ func (tt *TestCmd) Run(name string, args ...string) {
 // InputLine writes the given text to the childs stdin.
 // This method can also be called from an expect template, e.g.:
 //
-//     cli.expect(`Passphrase: {{.InputLine "password"}}`)
+//	cli.expect(`Passphrase: {{.InputLine "password"}}`)
 func (tt *TestCmd) InputLine(s string) string {
 	io.WriteString(tt.stdin, s+"\n")
 	return ""
@@ -171,7 +170,7 @@ func (tt *TestCmd) ExpectRegexp(regex string) (*regexp.Regexp, []string) {
 // printing any additional text on stdout.
 func (tt *TestCmd) ExpectExit() {
 	var output []byte
-	output, _ = ioutil.ReadAll(tt.stdout)
+	output, _ = io.ReadAll(tt.stdout)
 	tt.WaitExit()
 	if tt.Cleanup != nil {
 		tt.Cleanup()

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -2481,7 +2480,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary journal: %v", err)
 	}

--- a/gossip/filters/filter_test.go
+++ b/gossip/filters/filter_test.go
@@ -18,7 +18,6 @@ package filters
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path"
@@ -55,7 +54,7 @@ func makeReceipt(addr common.Address) *types.Receipt {
 }
 
 func BenchmarkFilters(b *testing.B) {
-	dir, err := ioutil.TempDir("", "filtertest")
+	dir, err := os.MkdirTemp("", "filtertest")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -272,16 +271,16 @@ func getGenesisBlockForTesting(db ethdb.Database, address common.Address, balanc
 		Alloc:   types.GenesisAlloc{address: {Balance: balance}},
 		BaseFee: big.NewInt(params.InitialBaseFee),
 		Config: &params.ChainConfig{
-			BerlinBlock:   new(big.Int),
-			LondonBlock:   new(big.Int),
-			IstanbulBlock: new(big.Int),
-			PetersburgBlock: new(big.Int),
+			BerlinBlock:         new(big.Int),
+			LondonBlock:         new(big.Int),
+			IstanbulBlock:       new(big.Int),
+			PetersburgBlock:     new(big.Int),
 			ConstantinopleBlock: new(big.Int),
-			ByzantiumBlock:  new(big.Int),
-			EIP158Block: new(big.Int),
-			EIP155Block: new(big.Int),
-			EIP150Block: new(big.Int),
-			HomesteadBlock: new(big.Int),
+			ByzantiumBlock:      new(big.Int),
+			EIP158Block:         new(big.Int),
+			EIP155Block:         new(big.Int),
+			EIP150Block:         new(big.Int),
+			HomesteadBlock:      new(big.Int),
 		},
 	}
 	return genesis.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))

--- a/gossip/filters/filter_test.go
+++ b/gossip/filters/filter_test.go
@@ -19,7 +19,6 @@ package filters
 import (
 	"context"
 	"math/big"
-	"os"
 	"path"
 	"testing"
 
@@ -54,11 +53,7 @@ func makeReceipt(addr common.Address) *types.Receipt {
 }
 
 func BenchmarkFilters(b *testing.B) {
-	dir, err := os.MkdirTemp("", "filtertest")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	backend := newTestBackend()
 	ldb, err := rawdb.NewLevelDBDatabase(path.Join(dir, "backend-db"), 100, 1000, "", false)

--- a/opera/genesisstore/fileshash/filehash_test.go
+++ b/opera/genesisstore/fileshash/filehash_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -71,10 +70,10 @@ func TestFileHash_ReadWrite(t *testing.T) {
 
 func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pieceSize uint64) {
 	require := require.New(t)
-	tmpDirPath, err := ioutil.TempDir("", "filehash*")
+	tmpDirPath, err := os.MkdirTemp("", "filehash*")
 	defer os.RemoveAll(tmpDirPath)
 	require.NoError(err)
-	f, err := ioutil.TempFile(tmpDirPath, "testnet.g")
+	f, err := os.CreateTemp(tmpDirPath, "testnet.g")
 	filePath := f.Name()
 	require.NoError(err)
 	writer := WrapWriter(f, pieceSize, func(i int) TmpWriter {

--- a/opera/genesisstore/fileshash/filehash_test.go
+++ b/opera/genesisstore/fileshash/filehash_test.go
@@ -70,13 +70,11 @@ func TestFileHash_ReadWrite(t *testing.T) {
 
 func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pieceSize uint64) {
 	require := require.New(t)
-	tmpDirPath, err := os.MkdirTemp("", "filehash*")
-	defer os.RemoveAll(tmpDirPath)
+	tmpDirPath := t.TempDir()
+	file, err := os.CreateTemp(tmpDirPath, "testnet.g")
+	filePath := file.Name()
 	require.NoError(err)
-	f, err := os.CreateTemp(tmpDirPath, "testnet.g")
-	filePath := f.Name()
-	require.NoError(err)
-	writer := WrapWriter(f, pieceSize, func(i int) TmpWriter {
+	writer := WrapWriter(file, pieceSize, func(i int) TmpWriter {
 		tmpFh, err := os.OpenFile(path.Join(tmpDirPath, fmt.Sprintf("genesis%d.dat", i)), os.O_CREATE|os.O_RDWR, os.ModePerm)
 		require.NoError(err)
 		return dropableFile{
@@ -92,15 +90,15 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 	root, err := writer.Flush()
 	require.NoError(err)
 	require.Equal(expRoot.Hex(), root.Hex())
-	f.Close()
+	file.Close()
 
 	maxMemUsage := memUsageOf(pieceSize, getPiecesNum(uint64(len(content)), pieceSize))
 
 	// normal case: correct root hash and content after reading file partially
 	if len(content) > 0 {
-		f, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
 		require.NoError(err)
-		reader := WrapReader(f, maxMemUsage, root)
+		reader := WrapReader(file, maxMemUsage, root)
 		readB := make([]byte, rand.Int63n(int64(len(content))))
 		err = ioread.ReadAll(reader, readB)
 		require.NoError(err)
@@ -110,9 +108,9 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 
 	// normal case: correct root hash and content after reading the whole file
 	{
-		f, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
 		require.NoError(err)
-		reader := WrapReader(f, maxMemUsage, root)
+		reader := WrapReader(file, maxMemUsage, root)
 		readB := make([]byte, len(content))
 		err = ioread.ReadAll(reader, readB)
 		require.NoError(err)
@@ -124,9 +122,9 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 
 	// correct root hash and reading too much content
 	{
-		f, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
 		require.NoError(err)
-		reader := WrapReader(f, maxMemUsage, root)
+		reader := WrapReader(file, maxMemUsage, root)
 		readB := make([]byte, len(content)+1)
 		require.Error(ioread.ReadAll(reader, readB), io.EOF)
 		reader.Close()
@@ -134,9 +132,9 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 
 	// passing the wrong root hash to reader
 	{
-		f, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
 		require.NoError(err)
-		maliciousReader := WrapReader(f, maxMemUsage, hash.HexToHash("0x00"))
+		maliciousReader := WrapReader(file, maxMemUsage, hash.HexToHash("0x00"))
 		data := make([]byte, 1)
 		err = ioread.ReadAll(maliciousReader, data)
 		require.Contains(err.Error(), ErrInit.Error())
@@ -147,21 +145,21 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 	headerOffset := 4 + 8 + getPiecesNum(uint64(len(content)), pieceSize)*32
 	if len(content) > 0 {
 		// mutate content byte
-		f, err = os.OpenFile(filePath, os.O_RDWR, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDWR, 0600)
 		require.NoError(err)
 		s := []byte{0}
 		contentPos := rand.Int63n(int64(len(content)))
 		pos := int64(headerOffset) + contentPos
-		_, err = f.ReadAt(s, pos)
+		_, err = file.ReadAt(s, pos)
 		require.NoError(err)
 		s[0]++
-		_, err = f.WriteAt(s, pos)
+		_, err = file.WriteAt(s, pos)
 		require.NoError(err)
-		require.NoError(f.Close())
+		require.NoError(file.Close())
 
 		// try to read
-		f, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
-		maliciousReader := WrapReader(f, maxMemUsage, root)
+		file, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
+		maliciousReader := WrapReader(file, maxMemUsage, root)
 		data := make([]byte, contentPos+1)
 		err = ioread.ReadAll(maliciousReader, data)
 		require.Contains(err.Error(), ErrHashMismatch.Error())
@@ -169,30 +167,30 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 
 		// restore
 		s[0]--
-		f, err = os.OpenFile(filePath, os.O_RDWR, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDWR, 0600)
 		require.NoError(err)
-		_, err = f.WriteAt(s, pos)
+		_, err = file.WriteAt(s, pos)
 		require.NoError(err)
-		require.NoError(f.Close())
+		require.NoError(file.Close())
 	}
 
 	// modify a piece hash in file to make the wrong one
 	{
 		// mutate content byte
-		f, err = os.OpenFile(filePath, os.O_RDWR, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDWR, 0600)
 		require.NoError(err)
 		pos := rand.Int63n(int64(headerOffset))
 		s := []byte{0}
-		_, err = f.ReadAt(s, pos)
+		_, err = file.ReadAt(s, pos)
 		require.NoError(err)
 		s[0]++
-		_, err = f.WriteAt(s, pos)
+		_, err = file.WriteAt(s, pos)
 		require.NoError(err)
-		require.NoError(f.Close())
+		require.NoError(file.Close())
 
 		// try to read
-		f, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
-		maliciousReader := WrapReader(f, maxMemUsage*2, root)
+		file, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
+		maliciousReader := WrapReader(file, maxMemUsage*2, root)
 		data := make([]byte, 1)
 		err = ioread.ReadAll(maliciousReader, data)
 		require.Contains(err.Error(), ErrInit.Error())
@@ -200,18 +198,18 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 
 		// restore
 		s[0]--
-		f, err = os.OpenFile(filePath, os.O_RDWR, 0600)
+		file, err = os.OpenFile(filePath, os.O_RDWR, 0600)
 		require.NoError(err)
-		_, err = f.WriteAt(s, pos)
+		_, err = file.WriteAt(s, pos)
 		require.NoError(err)
-		require.NoError(f.Close())
+		require.NoError(file.Close())
 	}
 
 	// hashed file requires too much memory
 	{
-		f, err = os.OpenFile(filePath, os.O_WRONLY, 0600)
+		file, err = os.OpenFile(filePath, os.O_WRONLY, 0600)
 		require.NoError(err)
-		oomReader := WrapReader(f, maxMemUsage-1, root)
+		oomReader := WrapReader(file, maxMemUsage-1, root)
 		data := make([]byte, 1)
 		err = ioread.ReadAll(oomReader, data)
 		require.Errorf(err, "hashed file requires too much memory")

--- a/utils/dbutil/compactdb/keys_test.go
+++ b/utils/dbutil/compactdb/keys_test.go
@@ -1,7 +1,7 @@
 package compactdb
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -14,7 +14,7 @@ import (
 )
 
 func tmpDir(name string) string {
-	dir, err := ioutil.TempDir("", name)
+	dir, err := os.MkdirTemp("", name)
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,6 @@ func TestTrimAfterDiff(t *testing.T) {
 	a, b := trimAfterDiff([]byte{}, []byte{}, 1)
 	require.Equal(t, []byte{}, a)
 	require.Equal(t, []byte{}, b)
-
 
 	a, b = trimAfterDiff([]byte{1, 2}, []byte{1, 3}, 1)
 	require.Equal(t, []byte{1, 2}, a)

--- a/utils/dbutil/compactdb/keys_test.go
+++ b/utils/dbutil/compactdb/keys_test.go
@@ -1,7 +1,6 @@
 package compactdb
 
 import (
-	"os"
 	"path"
 	"testing"
 
@@ -13,17 +12,9 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
-func tmpDir(name string) string {
-	dir, err := os.MkdirTemp("", name)
-	if err != nil {
-		panic(err)
-	}
-	return dir
-}
-
 func TestLastKey(t *testing.T) {
 	testLastKey(t, memorydb.New())
-	dir := tmpDir("test-last-key")
+	dir := t.TempDir()
 	ldb, err := leveldb.New(path.Join(dir, "ldb"), 16*opt.MiB, 64, nil, nil)
 	require.NoError(t, err)
 	defer ldb.Close()

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -49,6 +49,6 @@ func FileGet(path string) []byte {
 		log.Crit("Failed to open file", "file", path, "err", err)
 	}
 	defer fh.Close()
-	res, _ := ioutil.ReadAll(fh)
+	res, _ := io.ReadAll(fh)
 	return res
 }

--- a/valkeystore/encryption/encryption.go
+++ b/valkeystore/encryption/encryption.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -46,7 +45,7 @@ func New(scryptN int, scryptP int) *Keystore {
 
 func (ks Keystore) ReadKey(wantPubkey validatorpk.PubKey, filename, auth string) (*PrivateKey, error) {
 	// Load the key from the keystore and decrypt its contents
-	keyjson, err := ioutil.ReadFile(filename)
+	keyjson, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/valkeystore/encryption/io.go
+++ b/valkeystore/encryption/io.go
@@ -1,7 +1,6 @@
 package encryption
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -15,7 +14,7 @@ func writeTemporaryKeyFile(file string, content []byte) (string, error) {
 	}
 	// Atomic write: create a temporary hidden file first
 	// then move it into place. TempFile assigns mode 0600.
-	f, err := ioutil.TempFile(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
+	f, err := os.CreateTemp(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
 	if err != nil {
 		return "", err
 	}

--- a/valkeystore/encryption/migration.go
+++ b/valkeystore/encryption/migration.go
@@ -2,7 +2,6 @@ package encryption
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -19,7 +18,7 @@ type encryptedAccountKeyJSONV3 struct {
 }
 
 func MigrateAccountToValidatorKey(acckeypath string, valkeypath string, pubkey validatorpk.PubKey) error {
-	acckeyjson, err := ioutil.ReadFile(acckeypath)
+	acckeyjson, err := os.ReadFile(acckeypath)
 	if err != nil {
 		return err
 	}

--- a/valkeystore/files_test.go
+++ b/valkeystore/files_test.go
@@ -12,11 +12,7 @@ import (
 )
 
 func TestFileKeystoreAdd(t *testing.T) {
-	dir, err := os.MkdirTemp("", "valkeystore_test")
-	if err != nil {
-		return
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	require := require.New(t)
 	keystore := NewFileKeystore(dir, encryption.New(keystore.LightScryptN, keystore.LightScryptP))
@@ -47,12 +43,7 @@ func TestFileKeystoreAdd(t *testing.T) {
 }
 
 func TestFileKeystoreRead(t *testing.T) {
-	dir, err := os.MkdirTemp("", "valkeystore_test")
-	if err != nil {
-		return
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	require := require.New(t)
 	keystore := NewFileKeystore(dir, encryption.New(keystore.LightScryptN, keystore.LightScryptP))
 

--- a/valkeystore/files_test.go
+++ b/valkeystore/files_test.go
@@ -1,7 +1,6 @@
 package valkeystore
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestFileKeystoreAdd(t *testing.T) {
-	dir, err := ioutil.TempDir("", "valkeystore_test")
+	dir, err := os.MkdirTemp("", "valkeystore_test")
 	if err != nil {
 		return
 	}
@@ -48,7 +47,7 @@ func TestFileKeystoreAdd(t *testing.T) {
 }
 
 func TestFileKeystoreRead(t *testing.T) {
-	dir, err := ioutil.TempDir("", "valkeystore_test")
+	dir, err := os.MkdirTemp("", "valkeystore_test")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR removes the use of `ioutils`.
- `ioutil` replaced with a mix of `io` and `os`  symbols. [notes](https://stackoverflow.com/questions/75206234/for-go-ioutil-readall-ioutil-readfile-ioutil-readdir-deprecated)

This PR is part of https://github.com/Fantom-foundation/sonic-admin/issues/25
