### PR TITLE
Lint: Replace uses of bytes.Compare with bytes.Equal

### DIFF
--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -5,6 +5,14 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/Fantom-foundation/go-opera/config"
 	"github.com/Fantom-foundation/go-opera/gossip"
 	"github.com/Fantom-foundation/go-opera/gossip/emitter"
@@ -17,13 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/status-im/keycard-go/hexutils"
 	"gopkg.in/urfave/cli.v1"
-	"io"
-	"math"
-	"os"
-	"os/signal"
-	"strings"
-	"syscall"
-	"time"
 )
 
 func EventsImport(ctx *cli.Context, files ...string) error {
@@ -73,13 +74,13 @@ func checkEventsFileHeader(reader io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if bytes.Compare(headerAndVersion[:len(eventsFileHeader)], eventsFileHeader) != 0 {
+	if !bytes.Equal(headerAndVersion[:len(eventsFileHeader)], eventsFileHeader) {
 		return errors.New("expected an events file, mismatched file header")
 	}
-	if bytes.Compare(headerAndVersion[len(eventsFileHeader):], eventsFileVersion) != 0 {
+	if !bytes.Equal(headerAndVersion[len(eventsFileHeader):], eventsFileVersion) {
 		got := hexutils.BytesToHex(headerAndVersion[len(eventsFileHeader):])
 		expected := hexutils.BytesToHex(eventsFileVersion)
-		return errors.New(fmt.Sprintf("wrong version of events file, got=%s, expected=%s", got, expected))
+		return fmt.Errorf("wrong version of events file, got=%s, expected=%s", got, expected)
 	}
 	return nil
 }

--- a/eventcheck/heavycheck/heavy_check.go
+++ b/eventcheck/heavycheck/heavy_check.go
@@ -17,10 +17,10 @@ import (
 )
 
 var (
-	ErrWrongEventSig            = errors.New("event has wrong signature")
-	ErrMalformedTxSig           = errors.New("tx has wrong signature")
-	ErrWrongPayloadHash         = errors.New("event has wrong payload hash")
-	ErrPubkeyChanged            = errors.New("validator pubkey has changed, cannot create BVs/EV for older epochs")
+	ErrWrongEventSig    = errors.New("event has wrong signature")
+	ErrMalformedTxSig   = errors.New("tx has wrong signature")
+	ErrWrongPayloadHash = errors.New("event has wrong payload hash")
+	ErrPubkeyChanged    = errors.New("validator pubkey has changed, cannot create BVs/EV for older epochs")
 
 	errTerminated = errors.New("terminated") // internal err
 )
@@ -133,7 +133,7 @@ func (v *Checker) matchPubkey(creator idx.ValidatorID, epoch idx.Epoch, want []b
 	if !ok {
 		return epochcheck.ErrAuth
 	}
-	if bytes.Compare(pubkey.Bytes(), want) != 0 {
+	if !bytes.Equal(pubkey.Bytes(), want) {
 		return ErrPubkeyChanged
 	}
 	return nil

--- a/opera/genesisstore/disk.go
+++ b/opera/genesisstore/disk.go
@@ -48,13 +48,13 @@ func checkFileHeader(reader io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if bytes.Compare(headerAndVersion[:len(FileHeader)], FileHeader) != 0 {
+	if !bytes.Equal(headerAndVersion[:len(FileHeader)], FileHeader) {
 		return errors.New("expected a genesis file, mismatched file header")
 	}
-	if bytes.Compare(headerAndVersion[len(FileHeader):], FileVersion) != 0 {
+	if !bytes.Equal(headerAndVersion[len(FileHeader):], FileVersion) {
 		got := hexutils.BytesToHex(headerAndVersion[len(FileHeader):])
 		expected := hexutils.BytesToHex(FileVersion)
-		return errors.New(fmt.Sprintf("wrong version of genesis file, got=%s, expected=%s", got, expected))
+		return fmt.Errorf("wrong version of genesis file, got=%s, expected=%s", got, expected)
 	}
 	return nil
 }
@@ -125,8 +125,8 @@ func OpenGenesisStore(rawReader ReadAtSeekerCloser) (*Store, genesis.Hashes, err
 
 		off := offset // standalone variable for each Unit instance
 		units = append(units, readersmap.Unit{
-			Name:   unit.UnitName,
-			ReaderProvider: func () (io.Reader, error) {
+			Name: unit.UnitName,
+			ReaderProvider: func() (io.Reader, error) {
 				unitReader := io.NewSectionReader(rawReader, off+headerSize, off+headerSize+int64(dataCompressedSize))
 				gzipReader, err := gzip.NewReader(unitReader)
 				if err != nil {

--- a/valkeystore/encryption/encryption.go
+++ b/valkeystore/encryption/encryption.go
@@ -57,7 +57,7 @@ func (ks Keystore) ReadKey(wantPubkey validatorpk.PubKey, filename, auth string)
 	// Make sure we're really operating on the requested key (no swap attacks)
 	keySecp256k1 := key.Decoded.(*ecdsa.PrivateKey)
 	gotPubkey := crypto.FromECDSAPub(&keySecp256k1.PublicKey)
-	if bytes.Compare(wantPubkey.Raw, gotPubkey) != 0 {
+	if !bytes.Equal(wantPubkey.Raw, gotPubkey) {
 		return nil, fmt.Errorf("key content mismatch: have public key %X, want %X", gotPubkey, wantPubkey.Raw)
 	}
 	return key, nil


### PR DESCRIPTION
This PR replaces uses of `Compare !=0` with `!bytes.Equal`.
Doing so is not only more idiomatic, but potentially faster. 


This PR is part of https://github.com/Fantom-foundation/sonic-admin/issues/25