### PR TITLE
Replace deprecated math/rand with pgregory.net/rand

### DIFF
--- a/cmd/sonictool/app/validator.go
+++ b/cmd/sonictool/app/validator.go
@@ -2,13 +2,14 @@ package app
 
 import (
 	"crypto/ecdsa"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/go-opera/config"
 	"github.com/Fantom-foundation/go-opera/inter/validatorpk"
@@ -38,7 +39,7 @@ func validatorKeyCreate(ctx *cli.Context) error {
 		return fmt.Errorf("failed to get passphrase: %w", err)
 	}
 
-	privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), rand.New())
 	if err != nil {
 		return fmt.Errorf("failed to create account: %w", err)
 	}

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -18,8 +18,9 @@ package evmcore
 
 import (
 	"math/big"
-	"math/rand"
 	"testing"
+
+	"pgregory.net/rand"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -20,10 +20,11 @@ import (
 	"errors"
 	"math"
 	"math/big"
-	"math/rand"
 	"sort"
 	"sync"
 	"time"
+
+	"pgregory.net/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"math/rand"
 	"os"
 	"testing"
 	"time"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/go-opera/utils"
 	"github.com/ethereum/go-ethereum/common"

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	golang.org/x/sys v0.25.0
 	gopkg.in/urfave/cli.v1 v1.20.0
+	pgregory.net/rand v1.0.2
 )
 
 require (

--- a/gossip/dummy_tx_pool.go
+++ b/gossip/dummy_tx_pool.go
@@ -2,9 +2,10 @@ package gossip
 
 import (
 	"math/big"
-	"math/rand"
 	"sort"
 	"sync"
+
+	"pgregory.net/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/gossip/emitter/config.go
+++ b/gossip/emitter/config.go
@@ -1,9 +1,11 @@
 package emitter
 
 import (
-	"github.com/Fantom-foundation/go-opera/version"
-	"math/rand"
 	"time"
+
+	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/go-opera/version"
 
 	"github.com/Fantom-foundation/go-opera/inter/validatorpk"
 	"github.com/Fantom-foundation/go-opera/opera"

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -3,11 +3,12 @@ package emitter
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/go-opera/utils"
 	"github.com/Fantom-foundation/go-opera/utils/txtime"
@@ -112,7 +113,7 @@ func NewEmitter(
 ) *Emitter {
 	// Randomize event time to decrease chance of 2 parallel instances emitting event at the same time
 	// It increases the chance of detecting parallel instances
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(uint64(time.Now().UnixNano()))
 	config.EmitIntervals = config.EmitIntervals.RandomizeEmitTime(r)
 
 	return &Emitter{

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -19,9 +19,10 @@ package emitter
 import (
 	"crypto/ecdsa"
 	"math/big"
-	"math/rand"
 	"testing"
 	"time"
+
+	"pgregory.net/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -3,13 +3,15 @@ package gossip
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	"math"
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/go-opera/eventcheck"
 	"github.com/Fantom-foundation/go-opera/eventcheck/epochcheck"
@@ -248,7 +250,7 @@ func (h *handler) makeDagProcessor(checkers *eventcheck.Checkers) *dagprocessor.
 		}
 		var selfParent inter.EventI
 		if e.SelfParent() != nil {
-			selfParent = parents[0].(inter.EventI)
+			selfParent = parents[0]
 		}
 		if err := checkers.Parentscheck.Validate(e, parents); err != nil {
 			return err

--- a/gossip/handler_fuzz.go
+++ b/gossip/handler_fuzz.go
@@ -6,8 +6,9 @@ package gossip
 import (
 	"bytes"
 	"errors"
-	"math/rand"
 	"sync"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	_ "github.com/dvyukov/go-fuzz/go-fuzz-defs"

--- a/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
+++ b/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
@@ -1,9 +1,10 @@
 package dagstreamleecher
 
 import (
-	"math/rand"
 	"slices"
 	"time"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/lachesis-base/gossip/basestream/basestreamleecher"
 	"github.com/Fantom-foundation/lachesis-base/gossip/basestream/basestreamleecher/basepeerleecher"

--- a/gossip/protocols/dag/dagstream/dagstreamleecher/leecher_test.go
+++ b/gossip/protocols/dag/dagstream/dagstreamleecher/leecher_test.go
@@ -1,10 +1,11 @@
 package dagstreamleecher
 
 import (
-	"math/rand"
 	"strconv"
 	"testing"
 	"time"
+
+	"pgregory.net/rand"
 
 	"github.com/stretchr/testify/require"
 

--- a/gossip/randselect.go
+++ b/gossip/randselect.go
@@ -1,7 +1,7 @@
 package gossip
 
 import (
-	"math/rand"
+	"pgregory.net/rand"
 )
 
 // wrsItem interface should be implemented by any entries that are to be selected from
@@ -149,5 +149,5 @@ func (n *wrsNode) choose(val int64) (wrsItem, int64) {
 		}
 		val -= w
 	}
-	panic(nil)
+	panic("no item to choose from")
 }

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"

--- a/gossip/sync.go
+++ b/gossip/sync.go
@@ -1,11 +1,13 @@
 package gossip
 
 import (
+	"sync/atomic"
+
+	"pgregory.net/rand"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"math/rand"
-	"sync/atomic"
 )
 
 var isMaybeSyncedGauge = metrics.GetOrRegisterGauge("chain/maybeSynced", nil)

--- a/inter/event_serializer_test.go
+++ b/inter/event_serializer_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"math"
 	"math/big"
-	"math/rand"
 	"testing"
+
+	"pgregory.net/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -72,10 +73,10 @@ func TestEventPayloadSerialization(t *testing.T) {
 	max.SetTxs(txs)
 
 	ee := map[string]EventPayload{
-		"empty0": emptyEvent(0),
-		"empty1": emptyEvent(1),
-		"empty2": emptyEvent(2),
-		"max":    *max.Build(),
+		"empty0":  emptyEvent(0),
+		"empty1":  emptyEvent(1),
+		"empty2":  emptyEvent(2),
+		"max":     *max.Build(),
 		"random1": *FakeEvent(1, 12, 1, 1, true),
 		"random2": *FakeEvent(2, 12, 0, 0, false),
 	}
@@ -266,7 +267,7 @@ func randAccessList(r *rand.Rand, maxAddrs, maxKeys int) types.AccessList {
 
 // FakeEvent generates random event for testing purpose.
 func FakeEvent(version uint8, txsNum, mpsNum, bvsNum int, ersNum bool) *EventPayload {
-	r := rand.New(rand.NewSource(int64(0)))
+	r := rand.New(0)
 	random := &MutableEventPayload{}
 	random.SetVersion(version)
 	random.SetNetForkID(uint16(r.Uint32() >> 16))

--- a/opera/genesisstore/fileshash/filehash_test.go
+++ b/opera/genesisstore/fileshash/filehash_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path"
 	"testing"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/stretchr/testify/require"

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -3,10 +3,11 @@ package topicsdb
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"runtime/debug"
 	"testing"
+
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"

--- a/utils/cser/binary_test.go
+++ b/utils/cser/binary_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"math"
 	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/go-opera/utils/fast"
 )

--- a/utils/fast/buffer_test.go
+++ b/utils/fast/buffer_test.go
@@ -2,8 +2,9 @@ package fast
 
 import (
 	"bytes"
-	"math/rand"
 	"testing"
+
+	"pgregory.net/rand"
 
 	"github.com/stretchr/testify/require"
 )

--- a/utils/num_queue_test.go
+++ b/utils/num_queue_test.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"math/rand"
 	"sync"
 	"testing"
+
+	"pgregory.net/rand"
 
 	"github.com/stretchr/testify/require"
 )
@@ -32,9 +33,9 @@ func TestNumQueue(t *testing.T) {
 
 		q := NewNumQueue(0)
 		output := make(chan uint64, 10)
-		nums := rand.Perm(N)
+		numbers := rand.Perm(N)
 
-		for _, n := range nums {
+		for _, n := range numbers {
 			go func(n uint64) {
 				q.WaitFor(n - 1)
 				output <- n

--- a/utils/randat/rand_at.go
+++ b/utils/randat/rand_at.go
@@ -1,7 +1,7 @@
 package randat
 
 import (
-	"math/rand"
+	"pgregory.net/rand"
 )
 
 type cached struct {
@@ -21,6 +21,6 @@ func RandAt(seed uint64) uint64 {
 		return cache.r
 	}
 	cache.seed = seed
-	cache.r = rand.New(rand.NewSource(gSeed ^ int64(seed))).Uint64()
+	cache.r = rand.New(uint64(gSeed ^ int64(seed))).Uint64()
 	return cache.r
 }


### PR DESCRIPTION
This PR replaces `math/rand` with `pgregrory/rand`, Documentation [here](https://github.com/flyingmutant/rand)
This library was chosen, instead of `math/rand/v2` because of the extensive use of `rand.Read`. Rand read [has not been keep in V2](https://go.dev/blog/randv2) and a migration to `crypto/rand` would be needed.  Please notice that both libraries have incompatible API, each of them satisfying a subset of the functions existing in the deprecated `math/rand`.

`pgregrory/rand` has a compatible API except for the seeding mechanism, and migration was easier. This library has been used for quite some time in Tosca as well. 

This PR is part of https://github.com/Fantom-foundation/sonic-admin/issues/25