### PR TITLE
Use higher MaxCodeSize for Sonic network

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible
+	go.uber.org/mock v0.4.0
 	golang.org/x/sys v0.25.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
@@ -117,7 +118,6 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/net v0.29.0 // indirect
@@ -131,7 +131,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241022121122-7063a6b506bd
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241023152715-a72591e69026
 
 replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20241018103023-632a59c242f5
 

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,11 @@
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241021085109-e8dc12374917 h1:NisjazAL9OL1n51CRXpUtkrfz/zzkcEEnA39wO0pcXM=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241021085109-e8dc12374917/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8 h1:uDlLl/ZbGUM7FHxDjmzHxMnJkSvOt8mLV9+O41pROGA=
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10 h1:D7askaARHcrcXDVZHweaxxz2wKvo/ipvjA/qooyEkNM=
 github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10/go.mod h1:DtJlv3NCjaFxBKGXR7HQfLhLSu+BY5OILQ/4s7MR6lA=
-github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241022121122-7063a6b506bd h1:WoAkgzLLlyh3Zpnd/3gW8Ym5sHtugLCA4rQdT5udVF8=
-github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241022121122-7063a6b506bd/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
+github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241023152715-a72591e69026 h1:JflnF8ql7Po4Nujo4wIiR6Bxwap3EQ7QAiolAa5tiyI=
+github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241023152715-a72591e69026/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
 github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20241018103023-632a59c242f5 h1:dv1iFhsUfIfixwoNJWWZItWqOfKLV1mLA8eJLA1wceU=
 github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20241018103023-632a59c242f5/go.mod h1:YaNcYnDsDooGLKqsrTt+tafplgorZ0l8C1IwmryrIWs=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -21,6 +21,7 @@ const (
 	TestNetworkID   uint64 = 0xfa2
 	FakeNetworkID   uint64 = 0xfa3
 	DefaultEventGas uint64 = 28000
+	SonicMaxCodeSize   int = 0xB000
 	berlinBit              = 1 << 0
 	londonBit              = 1 << 1
 	llrBit                 = 1 << 2
@@ -208,6 +209,7 @@ func (r Rules) EvmChainConfig(hh []UpgradeHeight) *ethparams.ChainConfig {
 		if cfg.CancunTime == nil && h.Upgrades.Sonic {
 			cfg.ShanghaiTime = timestamp
 			cfg.CancunTime = timestamp
+			cfg.MaxCodeSize = SonicMaxCodeSize
 		}
 		if !h.Upgrades.Sonic {
 			// disabling upgrade breaks the history replay - should be never used


### PR DESCRIPTION
This depends on https://github.com/Fantom-foundation/go-ethereum-sonic/pull/11

When "Sonic" flag is on, increases the MaxCodeSize on the network from **24576** (0x6000) to **45056** (0xB000)
(maximum given by MaxInitCodeSize is 49152/0xC000)