### PR TITLE
changes tmp dir creation to avoid too long names

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/state/gostate"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/tests"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -68,7 +69,12 @@ func execStateTest(t *testing.T, st *tests.TestMatcher, test *tests.StateTest) {
 // createCarmenFactory creates a new factory, that initialises
 // carmen implementation of the state database.
 func createCarmenFactory(t *testing.T) carmenFactory {
-	dir := t.TempDir()
+	// ethereum tests creates extensively long test names, which causes t.TempDir fails
+	// on a too long names. For this reason, we use os.MkdirTemp instead.
+	dir, err := os.MkdirTemp("", "eth-tests-carmen-*")
+	if err != nil {
+		t.Fatalf("cannot create temp dir: %v", err)
+	}
 	parameters := carmen.Parameters{
 		Variant:   gostate.VariantGoMemory,
 		Schema:    carmen.Schema(5),
@@ -83,6 +89,9 @@ func createCarmenFactory(t *testing.T) carmenFactory {
 	t.Cleanup(func() {
 		if err := st.Close(); err != nil {
 			t.Fatalf("cannot close state: %v", err)
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("cannot remove temp dir: %v", err)
 		}
 	})
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -75,6 +75,12 @@ func createCarmenFactory(t *testing.T) carmenFactory {
 	if err != nil {
 		t.Fatalf("cannot create temp dir: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("cannot remove temp dir: %v", err)
+		}
+	})
+
 	parameters := carmen.Parameters{
 		Variant:   gostate.VariantGoMemory,
 		Schema:    carmen.Schema(5),
@@ -89,9 +95,6 @@ func createCarmenFactory(t *testing.T) carmenFactory {
 	t.Cleanup(func() {
 		if err := st.Close(); err != nil {
 			t.Fatalf("cannot close state: %v", err)
-		}
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatalf("cannot remove temp dir: %v", err)
 		}
 	})
 


### PR DESCRIPTION
This PR updates ethereum tests to create temp directory by `os.MkdirTemp` instead of standard `t.TempDir`. The reason is that ethereum tests produce extensively long names of tests. When `t.TempDir` is called on such a test, it fails on `file name too long` e.g.:

```
19:02:15                  state_test.go:71: TempDir: mkdir /tmp/TestStatePyspecscancuneip4844_blobspoint_evaluation_precompile_external_vectors.jsonsrcGeneralStateTestsFillerPyspecscancuneip4844_blobstest_point_evaluation_precompile.pytest_point_evaluation_precompile_external_vectorsfork_Cancun-state_test-versioned_hash_None-verify_kzg_proof_case_correct_proof_83e53423a2dd93feCancun03556998538: file name too long
```