### PR TITLE
Fix race conditions found in unit tests. 

### DIFF
--- a/gossip/dummy_tx_pool.go
+++ b/gossip/dummy_tx_pool.go
@@ -21,7 +21,7 @@ type dummyTxPool struct {
 
 	signer types.Signer
 
-	lock sync.RWMutex // Protects the transaction pool
+	lock sync.RWMutex
 }
 
 // AddRemotes appends a batch of transactions to the pool, and notifies any
@@ -150,6 +150,8 @@ func (p *dummyTxPool) SampleHashes(max int) []common.Hash {
 }
 
 func (p *dummyTxPool) Count() int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	return len(p.pool)
 }
 

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -158,7 +158,7 @@ func (s *Store) IsCommitNeeded() bool {
 func (s *Store) isCommitNeeded(sc, tc uint64) bool {
 	period := s.cfg.MaxNonFlushedPeriod * time.Duration(sc) / 1000
 	size := (uint64(s.cfg.MaxNonFlushedSize) / 2) * tc / 1000
-	return time.Since(s.prevFlushTime.Load().(time.Time)) > period || // RACE
+	return time.Since(s.prevFlushTime.Load().(time.Time)) > period ||
 		uint64(s.dbs.NotFlushedSizeEst()) > size
 }
 


### PR DESCRIPTION
This PR fixes three race conditions found in unit tests. 

The first 2 issues affected exclusively testing code.
The last commit is a fix for a race condition in gossip/store:
The error can be reproduced in the develop branch with the command: `go test -race  -run ^TestBaseFee_CanReadBaseFeeFromHeadAndBlockAndHistory$ ./tests -v`.
- Last modification timestamp is accessed concurrently
- There is an unused group of mutexes (one as in HEAD but more in the past)  which have not been used for a long time (more than 2 years in history of the repo, dead code on every commit). This struct has been deleted in this PR. 

I do not discard other race conditions arising, therefore it is convenient to merge this PR asap to enable CI tests similar to [Tosca](https://github.com/Fantom-foundation/LaScala/pull/185) just to test this kind of issues as the testing of the project increases. 

This PR is part of https://github.com/Fantom-foundation/sonic-admin/issues/47