### PR TITLE
Add eth_blobBaseFee RPC function

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -155,7 +155,10 @@ func (s *PublicEthereumAPI) EffectiveBaseFee(ctx context.Context) *hexutil.Big {
 }
 
 func (s *PublicEthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
-	return (*hexutil.Big)(big.NewInt(0))
+	// As blobs are not supported yet, blob base fee is equal to min blob gas price
+	// because calculation of blob base fee is based on the blob gas price and
+	// excess blob gas and that is always 0 for now
+	return (*hexutil.Big)(big.NewInt(params.BlobTxMinBlobGasprice))
 }
 
 // Syncing returns true if node is syncing

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -154,6 +154,10 @@ func (s *PublicEthereumAPI) EffectiveBaseFee(ctx context.Context) *hexutil.Big {
 	return (*hexutil.Big)(s.b.EffectiveMinGasPrice(ctx))
 }
 
+func (s *PublicEthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
+	return (*hexutil.Big)(big.NewInt(0))
+}
+
 // Syncing returns true if node is syncing
 func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
 	progress := s.b.Progress()

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -166,9 +166,9 @@ type EvmHeaderJson struct {
 
 type EvmBlockJson struct {
 	*EvmHeaderJson
-	Txs         []interface{}    `json:"transactions"`
-	Size        *hexutil.Uint64  `json:"size"` // RLP encoded storage size of the block
-	Uncles      []common.Hash    `json:"uncles"`
+	Txs    []interface{}   `json:"transactions"`
+	Size   *hexutil.Uint64 `json:"size"` // RLP encoded storage size of the block
+	Uncles []common.Hash   `json:"uncles"`
 }
 
 func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -17,9 +17,10 @@
 package evmcore
 
 import (
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -142,26 +143,28 @@ func (h *EvmHeader) EthHeader() *types.Header {
 
 // EvmHeaderJson is simplified version of types.Header, but allowing setting custom hash
 type EvmHeaderJson struct {
-	ParentHash  common.Hash      `json:"parentHash"       gencodec:"required"`
-	UncleHash   common.Hash      `json:"sha3Uncles"       gencodec:"required"`
-	Miner       common.Address   `json:"miner"`
-	Root        common.Hash      `json:"stateRoot"        gencodec:"required"`
-	TxHash      common.Hash      `json:"transactionsRoot" gencodec:"required"`
-	ReceiptHash common.Hash      `json:"receiptsRoot"     gencodec:"required"`
-	Bloom       types.Bloom      `json:"logsBloom"        gencodec:"required"`
-	Difficulty  *hexutil.Big     `json:"difficulty"       gencodec:"required"`
-	Number      *hexutil.Big     `json:"number"           gencodec:"required"`
-	GasLimit    hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
-	GasUsed     hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
-	Time        hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
-	TimeNano    hexutil.Uint64   `json:"timestampNano"`
-	Extra       hexutil.Bytes    `json:"extraData"        gencodec:"required"`
-	PrevRandao  common.Hash      `json:"mixHash"`
-	Nonce       types.BlockNonce `json:"nonce"`
-	BaseFee     *hexutil.Big     `json:"baseFeePerGas"`
-	Hash        *common.Hash     `json:"hash"`
-	Epoch       hexutil.Uint64   `json:"epoch"`
-	TotalDiff   *hexutil.Big     `json:"totalDifficulty"`
+	ParentHash    common.Hash      `json:"parentHash"       gencodec:"required"`
+	UncleHash     common.Hash      `json:"sha3Uncles"       gencodec:"required"`
+	Miner         common.Address   `json:"miner"`
+	Root          common.Hash      `json:"stateRoot"        gencodec:"required"`
+	TxHash        common.Hash      `json:"transactionsRoot" gencodec:"required"`
+	ReceiptHash   common.Hash      `json:"receiptsRoot"     gencodec:"required"`
+	Bloom         types.Bloom      `json:"logsBloom"        gencodec:"required"`
+	Difficulty    *hexutil.Big     `json:"difficulty"       gencodec:"required"`
+	Number        *hexutil.Big     `json:"number"           gencodec:"required"`
+	GasLimit      hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
+	GasUsed       hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
+	Time          hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
+	TimeNano      hexutil.Uint64   `json:"timestampNano"`
+	Extra         hexutil.Bytes    `json:"extraData"        gencodec:"required"`
+	PrevRandao    common.Hash      `json:"mixHash"`
+	Nonce         types.BlockNonce `json:"nonce"`
+	BaseFee       *hexutil.Big     `json:"baseFeePerGas"`
+	Hash          *common.Hash     `json:"hash"`
+	Epoch         hexutil.Uint64   `json:"epoch"`
+	TotalDiff     *hexutil.Big     `json:"totalDifficulty"`
+	BlobGasUsed   *hexutil.Uint64  `json:"blobGasUsed"`
+	ExcessBlobGas *hexutil.Uint64  `json:"excessBlobGas"`
 }
 
 type EvmBlockJson struct {
@@ -173,22 +176,24 @@ type EvmBlockJson struct {
 
 func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
 	enc := &EvmHeaderJson{
-		Number:     (*hexutil.Big)(h.Number),
-		Miner:      h.Coinbase,
-		GasLimit:   0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
-		GasUsed:    hexutil.Uint64(h.GasUsed),
-		Root:       h.Root,
-		TxHash:     h.TxHash,
-		ParentHash: h.ParentHash,
-		UncleHash:  types.EmptyUncleHash,
-		Time:       hexutil.Uint64(h.Time.Unix()),
-		TimeNano:   hexutil.Uint64(h.Time),
-		BaseFee:    (*hexutil.Big)(h.BaseFee),
-		Difficulty: new(hexutil.Big),
-		PrevRandao: h.PrevRandao,
-		TotalDiff:  new(hexutil.Big),
-		Hash:       &h.Hash,
-		Epoch:      hexutil.Uint64(hash.Event(h.Hash).Epoch()),
+		Number:        (*hexutil.Big)(h.Number),
+		Miner:         h.Coinbase,
+		GasLimit:      0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
+		GasUsed:       hexutil.Uint64(h.GasUsed),
+		Root:          h.Root,
+		TxHash:        h.TxHash,
+		ParentHash:    h.ParentHash,
+		UncleHash:     types.EmptyUncleHash,
+		Time:          hexutil.Uint64(h.Time.Unix()),
+		TimeNano:      hexutil.Uint64(h.Time),
+		BaseFee:       (*hexutil.Big)(h.BaseFee),
+		Difficulty:    new(hexutil.Big),
+		PrevRandao:    h.PrevRandao,
+		TotalDiff:     new(hexutil.Big),
+		Hash:          &h.Hash,
+		Epoch:         hexutil.Uint64(hash.Event(h.Hash).Epoch()),
+		BlobGasUsed:   (*hexutil.Uint64)(new(uint64)),
+		ExcessBlobGas: (*hexutil.Uint64)(new(uint64)),
 	}
 	if receipts != nil { // if receipts resolution fails, don't set ReceiptsHash at all
 		if receipts.Len() != 0 {


### PR DESCRIPTION
This PR adds an RPC function eth_blobBaseFee

For now, it only returns 1 as blobs are not implemented in Sonic client
As blobs are not supported yet, blob base fee is equal to min blob gas price, because calculation of blob base fee is based on the blob gas price and excess blob gas which is always 0