### PR TITLE
Lint, Prevent use of nil variable

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -380,6 +380,7 @@ func spillBlockEvents(store *Store, block *inter.Block, network opera.Rules) (*i
 		e := store.GetEventPayload(id)
 		if e == nil {
 			log.Crit("Block event not found", "event", id.String())
+			break
 		}
 		fullEvents[i] = e
 		gasPowerUsedSum += e.GasPowerUsed()


### PR DESCRIPTION
The following code may access the variable `e` member functions when being `nil`

```
	e := store.GetEventPayload(id)
	if e == nil {
		log.Crit("Block event not found", "event", id.String())
	}
	fullEvents[i] = e
	gasPowerUsedSum += e.GasPowerUsed()    // <= nil access
```

part of https://github.com/Fantom-foundation/sonic-admin/issues/25