### PR TITLE
Lint: Prevent copy of mutexes

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -3,13 +3,14 @@ package gossip
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	"math"
 	"math/rand"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/Fantom-foundation/go-opera/eventcheck"
 	"github.com/Fantom-foundation/go-opera/eventcheck/epochcheck"
@@ -613,14 +614,14 @@ func (h *handler) handleEventHashes(p *peer, announces hash.Events) {
 	_ = h.dagFetcher.NotifyAnnounces(p.id, eventIDsToInterfaces(notTooHigh), time.Now(), requestEvents)
 }
 
-func (h *handler) handleEvents(p *peer, events dag.Events, ordered bool) {
+func (h *handler) handleEvents(peer *peer, events dag.Events, ordered bool) {
 	// Mark the hashes as present at the remote node
 	now := time.Now()
 	for _, e := range events {
 		for _, tx := range e.(inter.EventPayloadI).Txs() {
 			txtime.Saw(tx.Hash(), now)
 		}
-		p.MarkEvent(e.ID())
+		peer.MarkEvent(e.ID())
 	}
 	// filter too high events
 	notTooHigh := make(dag.Events, 0, len(events))
@@ -641,7 +642,6 @@ func (h *handler) handleEvents(p *peer, events dag.Events, ordered bool) {
 		return
 	}
 	// Schedule all the events for connection
-	peer := *p
 	requestEvents := func(ids []interface{}) error {
 		return peer.RequestEvents(interfacesToEventIDs(ids))
 	}

--- a/utils/dbutil/threads/pool_test.go
+++ b/utils/dbutil/threads/pool_test.go
@@ -16,9 +16,11 @@ func TestMain(m *testing.M) {
 
 func TestThreadPool(t *testing.T) {
 
-	for name, pool := range map[string]ThreadPool{
-		"global": GlobalPool,
-		"local":  ThreadPool{},
+	pool := ThreadPool{}
+
+	for name, pool := range map[string]*ThreadPool{
+		"global": &GlobalPool,
+		"local":  &pool,
 	} {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)

--- a/utils/dbutil/threads/pool_test.go
+++ b/utils/dbutil/threads/pool_test.go
@@ -16,11 +16,9 @@ func TestMain(m *testing.M) {
 
 func TestThreadPool(t *testing.T) {
 
-	pool := ThreadPool{}
-
 	for name, pool := range map[string]*ThreadPool{
 		"global": &GlobalPool,
-		"local":  &pool,
+		"local":  {},
 	} {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
@@ -44,6 +42,7 @@ func TestThreadPool(t *testing.T) {
 			require.Equal(8, gotB)
 
 			// don't releaseB(gotB) to check pools isolation
+			_ = releaseB
 		})
 	}
 }


### PR DESCRIPTION
When passing an object by value, content member variables are copied into a new memory address. This includes the content of a mutex lock, effectively cloning the mutex into a new instance. 

This PR introduces fixes for two scenarios detected, where mutexes are being copied. 

Part of https://github.com/Fantom-foundation/sonic-admin/issues/25