### PR TITLE
Make `suppress-frame-panic` flag available for `sonicd`

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -54,6 +54,7 @@ func initFlags() {
 	// Flags for testing purpose.
 	testFlags = []cli.Flag{
 		config.FakeNetFlag,
+		flags.SuppressFramePanicFlag,
 	}
 
 	// Flags that configure the node.

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -336,6 +336,6 @@ var (
 	// Consensus
 	SuppressFramePanicFlag = cli.BoolFlag{
 		Name:  "lachesis.suppress-frame-panic",
-		Usage: "Suppress frame missmatch error while importing event files",
+		Usage: "Suppress frame missmatch error (when testing on historical imported/synced events)",
 	}
 )


### PR DESCRIPTION
Adding the suppression flag to client run command to be used in testing when syncing over the network, which same as importing the event files, results in historical events being indexed and checked, thus requiring the frame panic suppression for the `sonicd` command.
Flag grouping and introducing is inconsistent between `sonictool` and `sonicd` so I decided to group it with test flags as it's exclusively used for regression testing. Let me know if something else makes more sense.