### PR TITLE
Add RPC response size limit for debug and trace namespace

### DIFF
--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -302,6 +302,11 @@ var (
 		Usage: "Maximum number of bytes returned from a batched call",
 		Value: node.DefaultConfig.BatchResponseMaxSize,
 	}
+	MaxResponseSizeFlag = cli.IntFlag{
+		Name:  "rpc.maxresponsesize",
+		Usage: "Limit maximum size in some RPC calls execution",
+		Value: gossip.DefaultConfig(cachescale.Identity).MaxResponseSize,
+	}
 	ModeFlag = cli.StringFlag{
 		Name:  "mode",
 		Usage: `Mode of the node ("rpc" or "validator")`,

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1901,13 +1901,14 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs Transact
 // PublicDebugAPI is the collection of Ethereum APIs exposed over the public
 // debugging endpoint.
 type PublicDebugAPI struct {
-	b Backend
+	b               Backend
+	maxResponseSize int // in bytes
 }
 
 // NewPublicDebugAPI creates a new API definition for the public debug methods
 // of the Ethereum service.
-func NewPublicDebugAPI(b Backend) *PublicDebugAPI {
-	return &PublicDebugAPI{b: b}
+func NewPublicDebugAPI(b Backend, maxResponseSize int) *PublicDebugAPI {
+	return &PublicDebugAPI{b: b, maxResponseSize: maxResponseSize}
 }
 
 // GetBlockRlp retrieves the RLP encoded for of a single block.
@@ -2071,7 +2072,7 @@ func (api *PublicDebugAPI) traceTx(ctx context.Context, tx *types.Transaction, m
 		return nil, err
 	}
 
-	if responseSizeLimit > 0 && len(result) > responseSizeLimit {
+	if api.maxResponseSize > 0 && len(result) > api.maxResponseSize {
 		return nil, ErrMaxResponseSize
 	}
 
@@ -2145,7 +2146,7 @@ func (api *PublicDebugAPI) traceBlock(ctx context.Context, block *evmcore.EvmBlo
 
 		// limit the response size.
 		resultsLength += len(res)
-		if responseSizeLimit > 0 && resultsLength > responseSizeLimit {
+		if api.maxResponseSize > 0 && resultsLength > api.maxResponseSize {
 			return nil, ErrMaxResponseSize
 		}
 

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -135,11 +135,6 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 		}, {
 			Namespace: "debug",
 			Version:   "1.0",
-			Service:   NewPublicDebugAPI(apiBackend),
-			Public:    true,
-		}, {
-			Namespace: "debug",
-			Version:   "1.0",
 			Service:   NewPrivateDebugAPI(apiBackend),
 		}, {
 			Namespace: "eth",
@@ -155,12 +150,6 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Namespace: "abft",
 			Version:   "1.0",
 			Service:   NewPublicAbftAPI(apiBackend),
-			Public:    true,
-		},
-		{
-			Namespace: "trace",
-			Version:   "1.0",
-			Service:   NewPublicTxTraceAPI(apiBackend),
 			Public:    true,
 		},
 	}

--- a/ethapi/limit.go
+++ b/ethapi/limit.go
@@ -68,7 +68,7 @@ func (b *JsonResultBuffer) AddObject(obj interface{}) error {
 			return err
 		}
 	}
-	if err = b.writeString(string(res)); err != nil {
+	if err = b.writeBytes(res); err != nil {
 		return err
 	}
 
@@ -82,6 +82,33 @@ func (b *JsonResultBuffer) writeString(s string) (err error) {
 			err = ErrResponseTooLarge
 		}
 	}()
-	b.WriteString(s)
+
+	if b.Len()+len(s) > b.maxResultSize {
+		return ErrResponseTooLarge
+	}
+
+	if _, err = b.WriteString(s); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeBytes appends the contents of arr to the buffer and handle possible panic
+func (b *JsonResultBuffer) writeBytes(arr []byte) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrResponseTooLarge
+		}
+	}()
+
+	if b.Len()+len(arr) > b.maxResultSize {
+		return ErrResponseTooLarge
+	}
+
+	if _, err = b.Write(arr); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/ethapi/limit.go
+++ b/ethapi/limit.go
@@ -1,0 +1,91 @@
+package ethapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+const (
+	// bufferStartSize default buffer start size in bytes
+	bufferStartSize = 10 * 1024
+)
+
+var (
+	// responseSizeLimit limits maximum size of RPC response
+	responseSizeLimit int
+	// ErrMaxResponseSize is returned if size of the RPC call
+	// response is over defined limit
+	ErrMaxResponseSize = errors.New("response size exceeded")
+	// ErrResponseTooLarge is returned when the result buffer cannot be expanded
+	ErrResponseTooLarge = errors.New("response too large")
+	// ErrCannotInitBuffer is returned when initialization of the buffer failed
+	ErrCannotInitBuffer = errors.New("cannot initialize write buffer")
+)
+
+// SetResponseSizeLimit sets maximum size of RPC response in bytes
+func SetResponseSizeLimit(limit int) {
+	responseSizeLimit = limit
+}
+
+// JsonResultBuffer is a bytes buffer for jsonRawMessage result
+type JsonResultBuffer struct {
+	bytes.Buffer
+}
+
+// NewJsonResultBuffer creates new bytes buffer
+func NewJsonResultBuffer() (b *JsonResultBuffer, err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrCannotInitBuffer
+		}
+	}()
+	b = &JsonResultBuffer{}
+	// grow buffer to default start size
+	b.Grow(bufferStartSize)
+	if err := b.writeString("["); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// GetResult returns finalized byte array
+func (b *JsonResultBuffer) GetResult() ([]byte, error) {
+	if err := b.writeString("]"); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// AddObject marshals and adds object into buffer.
+// In case that buffer size is over defined limit, error is returned
+func (b *JsonResultBuffer) AddObject(obj interface{}) error {
+	res, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if responseSizeLimit > 0 && b.Len()+len(res) > responseSizeLimit {
+		return ErrMaxResponseSize
+	}
+	if b.Len() > 1 {
+		if err := b.writeString(","); err != nil {
+			return err
+		}
+	}
+	if err = b.writeString(string(res)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeString appends the contents of s to the buffer and handle possible panic
+func (b *JsonResultBuffer) writeString(s string) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrResponseTooLarge
+		}
+	}()
+	b.WriteString(s)
+	return nil
+}

--- a/ethapi/limit_test.go
+++ b/ethapi/limit_test.go
@@ -6,15 +6,10 @@ import (
 	"testing"
 )
 
-func TestSetResponseSizeLimit(t *testing.T) {
-	SetResponseSizeLimit(1024)
-	if responseSizeLimit != 1024 {
-		t.Errorf("expected responseSizeLimit to be 1024, got %d", responseSizeLimit)
-	}
-}
+const maxResultSize = 25 * 1024 * 1024
 
 func TestNewJsonResultBuffer(t *testing.T) {
-	b, err := NewJsonResultBuffer()
+	b, err := NewJsonResultBuffer(maxResultSize)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -25,7 +20,7 @@ func TestNewJsonResultBuffer(t *testing.T) {
 }
 
 func TestAddOneObject(t *testing.T) {
-	b, err := NewJsonResultBuffer()
+	b, err := NewJsonResultBuffer(maxResultSize)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -54,7 +49,7 @@ func TestAddOneObject(t *testing.T) {
 }
 
 func TestAddMoreObjects(t *testing.T) {
-	buffer, err := NewJsonResultBuffer()
+	buffer, err := NewJsonResultBuffer(maxResultSize)
 	if err != nil {
 		t.Fatalf("failed to create JsonResultBuffer: %v", err)
 	}
@@ -86,8 +81,7 @@ func TestAddMoreObjects(t *testing.T) {
 }
 
 func TestAddObjectOverLimit(t *testing.T) {
-	SetResponseSizeLimit(10)
-	b, err := NewJsonResultBuffer()
+	b, err := NewJsonResultBuffer(10)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}

--- a/ethapi/limit_test.go
+++ b/ethapi/limit_test.go
@@ -89,8 +89,8 @@ func TestAddObjectOverLimit(t *testing.T) {
 	obj := testStruct{Str: "test string"}
 
 	err = b.AddObject(obj)
-	if err != ErrMaxResponseSize {
-		t.Errorf("expected ErrMaxResponseSize, got %v", err)
+	if err != ErrResponseTooLarge {
+		t.Errorf("expected ErrResponseTooLarge, got %v", err)
 	}
 }
 

--- a/ethapi/limit_test.go
+++ b/ethapi/limit_test.go
@@ -1,0 +1,105 @@
+package ethapi
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+)
+
+func TestSetResponseSizeLimit(t *testing.T) {
+	SetResponseSizeLimit(1024)
+	if responseSizeLimit != 1024 {
+		t.Errorf("expected responseSizeLimit to be 1024, got %d", responseSizeLimit)
+	}
+}
+
+func TestNewJsonResultBuffer(t *testing.T) {
+	b, err := NewJsonResultBuffer()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if b != nil && b.Cap() != bufferStartSize {
+		t.Errorf("expected buffer size to be %d, got %d", bufferStartSize, b.Cap())
+	}
+}
+
+func TestAddOneObject(t *testing.T) {
+	b, err := NewJsonResultBuffer()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	obj := testStruct{Str: "test"}
+
+	err = b.AddObject(obj)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	result, err := b.GetResult()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	var newObj []testStruct
+	err = json.Unmarshal(result, &newObj)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if newObj[0].Str != "test" {
+		t.Errorf("expected str to be test, got %v", newObj[0].Str)
+
+	}
+}
+
+func TestAddMoreObjects(t *testing.T) {
+	buffer, err := NewJsonResultBuffer()
+	if err != nil {
+		t.Fatalf("failed to create JsonResultBuffer: %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		object := testStruct{Str: "test" + strconv.Itoa(i)}
+		if err := buffer.AddObject(object); err != nil {
+			t.Fatalf("failed to add object: %v", err)
+		}
+	}
+
+	result, err := buffer.GetResult()
+	if err != nil {
+		t.Fatalf("failed to get result: %v", err)
+	}
+
+	var objects []testStruct
+	if err := json.Unmarshal(result, &objects); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if len(objects) != 10 {
+		t.Errorf("expected 10 objects, got %v", len(objects))
+	}
+
+	if objects[9].Str != "test9" {
+		t.Errorf("expected last object to be 'test9', got %v", objects[9].Str)
+	}
+}
+
+func TestAddObjectOverLimit(t *testing.T) {
+	SetResponseSizeLimit(10)
+	b, err := NewJsonResultBuffer()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	obj := testStruct{Str: "test string"}
+
+	err = b.AddObject(obj)
+	if err != ErrMaxResponseSize {
+		t.Errorf("expected ErrMaxResponseSize, got %v", err)
+	}
+}
+
+type testStruct struct {
+	Str string
+}

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -27,12 +27,16 @@ import (
 // PublicTxTraceAPI provides an API to access transaction tracing
 // It offers only methods that operate on public data that is freely available to anyone
 type PublicTxTraceAPI struct {
-	b Backend
+	b               Backend
+	maxResponseSize int // in bytes
 }
 
 // NewPublicTxTraceAPI creates a new transaction trace API
-func NewPublicTxTraceAPI(b Backend) *PublicTxTraceAPI {
-	return &PublicTxTraceAPI{b}
+func NewPublicTxTraceAPI(b Backend, maxResponseSize int) *PublicTxTraceAPI {
+	return &PublicTxTraceAPI{
+		b:               b,
+		maxResponseSize: maxResponseSize,
+	}
 }
 
 // Transaction - trace_transaction function returns transaction inner traces
@@ -334,7 +338,7 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (js
 	var traceAdded, traceCount uint
 
 	// resultBuffer is buffer for collecting result traces
-	resultBuffer, err := NewJsonResultBuffer()
+	resultBuffer, err := NewJsonResultBuffer(s.maxResponseSize)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +381,7 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (js
 func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (json.RawMessage, error) {
 
 	// resultBuffer is buffer for collecting result traces
-	resultBuffer, err := NewJsonResultBuffer()
+	resultBuffer, err := NewJsonResultBuffer(s.maxResponseSize)
 	if err != nil {
 		return nil, err
 	}

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -2,6 +2,7 @@ package ethapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -311,7 +312,7 @@ type FilterArgs struct {
 }
 
 // Filter is function for trace_filter rpc call
-func (s *PublicTxTraceAPI) Filter(ctx context.Context, args FilterArgs) (*[]txtrace.ActionTrace, error) {
+func (s *PublicTxTraceAPI) Filter(ctx context.Context, args FilterArgs) (json.RawMessage, error) {
 	// add log after execution
 	defer func(start time.Time) {
 		data := getLogData(args, start)
@@ -328,10 +329,16 @@ func (s *PublicTxTraceAPI) Filter(ctx context.Context, args FilterArgs) (*[]txtr
 }
 
 // Filter specified block range in series
-func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (*[]txtrace.ActionTrace, error) {
+func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (json.RawMessage, error) {
 
 	var traceAdded, traceCount uint
-	callTraces := make([]txtrace.ActionTrace, 0)
+
+	// resultBuffer is buffer for collecting result traces
+	resultBuffer, err := NewJsonResultBuffer()
+	if err != nil {
+		return nil, err
+	}
+
 	// parse arguments
 	fromBlock, toBlock, fromAddresses, toAddresses := parseFilterArguments(s.b, args)
 
@@ -346,11 +353,14 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (*[
 		for _, trace := range traces {
 
 			if traceCount >= args.After {
-				callTraces = append(callTraces, trace)
+				err := resultBuffer.AddObject(&trace)
+				if err != nil {
+					return nil, err
+				}
 				traceAdded++
 			}
 			if traceAdded >= args.Count {
-				return &callTraces, nil
+				return resultBuffer.GetResult()
 			}
 			traceCount++
 		}
@@ -360,14 +370,17 @@ func filterBlocks(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (*[
 			return nil, ctx.Err()
 		}
 	}
-	return &callTraces, nil
+	return resultBuffer.GetResult()
 }
 
 // Filter specified block range in parallel
-func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (*[]txtrace.ActionTrace, error) {
+func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args FilterArgs) (json.RawMessage, error) {
 
-	// struct for collecting result traces
-	callTraces := make([]txtrace.ActionTrace, 0)
+	// resultBuffer is buffer for collecting result traces
+	resultBuffer, err := NewJsonResultBuffer()
+	if err != nil {
+		return nil, err
+	}
 	// parse arguments
 	fromBlock, toBlock, fromAddresses, toAddresses := parseFilterArguments(s.b, args)
 	// add context cancel function
@@ -393,7 +406,12 @@ func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args Filte
 				if res.err != nil {
 					cancelFunc(res.err)
 				} else {
-					callTraces = append(callTraces, res.trace...)
+					for _, trace := range res.trace {
+						err := resultBuffer.AddObject(&trace)
+						if err != nil {
+							cancelFunc(err)
+						}
+					}
 				}
 			case <-ctx.Done():
 				return
@@ -427,7 +445,7 @@ func filterBlocksInParallel(ctx context.Context, s *PublicTxTraceAPI, args Filte
 			return nil, context.Cause(ctx)
 		}
 	}
-	return &callTraces, nil
+	return resultBuffer.GetResult()
 }
 
 // Fills blocks into provided channel for processing and close the channel in the end

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -86,7 +86,7 @@ type (
 		// allows only for EIP155 transactions.
 		AllowUnprotectedTxs bool
 
-		// MaxResponseSize is a limit for maximum response size in some RPC calls
+		// MaxResponseSize is a limit for maximum response size in some RPC calls in bytes
 		MaxResponseSize int
 
 		RPCBlockExt bool

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -86,6 +86,9 @@ type (
 		// allows only for EIP155 transactions.
 		AllowUnprotectedTxs bool
 
+		// MaxResponseSize is a limit for maximum response size in some RPC calls
+		MaxResponseSize int
+
 		RPCBlockExt bool
 	}
 
@@ -192,6 +195,8 @@ func DefaultConfig(scale cachescale.Func) Config {
 		RPCGasCap:   50000000,
 		RPCTxFeeCap: 100, // 100 FTM
 		RPCTimeout:  5 * time.Second,
+
+		MaxResponseSize: 25 * 1024 * 1024,
 	}
 	sessionCfg := cfg.Protocol.DagStreamLeecher.Session
 	cfg.Protocol.DagProcessor.EventsBufferLimit.Num = idx.Event(sessionCfg.ParallelChunksDownload)*

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -258,7 +258,6 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	}
 
 	rpc.SetExecutionTimeLimit(config.RPCTimeout)
-	ethapi.SetResponseSizeLimit(config.MaxResponseSize)
 
 	// create API backend
 	svc.EthAPI = &EthAPIBackend{false, svc, stateReader, txSigner, config.AllowUnprotectedTxs}
@@ -401,6 +400,16 @@ func (s *Service) APIs() []rpc.API {
 			Namespace: "net",
 			Version:   "1.0",
 			Service:   s.netRPCService,
+			Public:    true,
+		}, {
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   ethapi.NewPublicDebugAPI(s.EthAPI, s.config.MaxResponseSize),
+			Public:    true,
+		}, {
+			Namespace: "trace",
+			Version:   "1.0",
+			Service:   ethapi.NewPublicTxTraceAPI(s.EthAPI, s.config.MaxResponseSize),
 			Public:    true,
 		},
 	}...)

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -258,6 +258,7 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	}
 
 	rpc.SetExecutionTimeLimit(config.RPCTimeout)
+	ethapi.SetResponseSizeLimit(config.MaxResponseSize)
 
 	// create API backend
 	svc.EthAPI = &EthAPIBackend{false, svc, stateReader, txSigner, config.AllowUnprotectedTxs}


### PR DESCRIPTION
This PR adds functionality created in PR #193 which was not merged into develop branch yet.

Refers to issue [#56](https://github.com/Fantom-foundation/sonic-admin/issues/56)