### PR TITLE
Fix incorrect test

### DIFF
--- a/gossip/tx_scrambler_test.go
+++ b/gossip/tx_scrambler_test.go
@@ -62,19 +62,40 @@ func TestTxScrambler_AnalyseEntryList_ReportsDuplicateAddresses(t *testing.T) {
 		{
 			name: "has duplicate address",
 			input: []ScramblerEntry{
-				&dummyScramblerEntry{sender: common.Address{1}},
-				&dummyScramblerEntry{sender: common.Address{3}},
-				&dummyScramblerEntry{sender: common.Address{2}},
-				&dummyScramblerEntry{sender: common.Address{3}},
+				&dummyScramblerEntry{
+					hash:   common.Hash{1},
+					sender: common.Address{1},
+				},
+				&dummyScramblerEntry{
+					hash:   common.Hash{2},
+					sender: common.Address{3},
+				},
+				&dummyScramblerEntry{
+					hash:   common.Hash{3},
+					sender: common.Address{2},
+				},
+				&dummyScramblerEntry{
+					hash:   common.Hash{4},
+					sender: common.Address{3},
+				},
 			},
 			hasDuplicate: true,
 		},
 		{
 			name: "has no duplicate address",
 			input: []ScramblerEntry{
-				&dummyScramblerEntry{sender: common.Address{1}},
-				&dummyScramblerEntry{sender: common.Address{2}},
-				&dummyScramblerEntry{sender: common.Address{3}},
+				&dummyScramblerEntry{
+					hash:   common.Hash{1},
+					sender: common.Address{1},
+				},
+				&dummyScramblerEntry{
+					hash:   common.Hash{2},
+					sender: common.Address{2},
+				},
+				&dummyScramblerEntry{
+					hash:   common.Hash{3},
+					sender: common.Address{3},
+				},
 			},
 			hasDuplicate: false,
 		},
@@ -82,7 +103,7 @@ func TestTxScrambler_AnalyseEntryList_ReportsDuplicateAddresses(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, hasDuplicateAddresses := analyseEntryList(test.input)
-			if hasDuplicateAddresses != hasDuplicateAddresses {
+			if hasDuplicateAddresses != test.hasDuplicate {
 				t.Error("wrongly reported duplicate address")
 			}
 		})


### PR DESCRIPTION
This PR fixes incorrectly constructed tests.
Thanks to @LuisPH3 we found that the condition in the test (`hasDuplicateAddresses != hasDuplicateAddresses`) actually tests nothing.

Fixing this condition revealed that the `analyseEntries` removed the entries before the address comparsion happened - the hashes were always same.