### PR TITLE
Withdrawals verification test

### DIFF
--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -87,9 +87,9 @@ func ToEvmHeader(block *inter.Block, index idx.Block, prevHash hash.Event, rules
 		prevRandao.SetBytes([]byte{1}) // TODO provide pseudorandom data?
 	}
 
-	withdrawalsHash := common.Hash{}
+	var withdrawalsHash *common.Hash = nil
 	if rules.Upgrades.Sonic {
-		withdrawalsHash = types.EmptyWithdrawalsHash
+		withdrawalsHash = &types.EmptyWithdrawalsHash
 	}
 
 	return &EvmHeader{
@@ -102,7 +102,7 @@ func ToEvmHeader(block *inter.Block, index idx.Block, prevHash hash.Event, rules
 		GasUsed:         block.GasUsed,
 		BaseFee:         baseFee,
 		PrevRandao:      prevRandao,
-		WithdrawalsHash: &withdrawalsHash,
+		WithdrawalsHash: withdrawalsHash,
 	}
 }
 

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -143,28 +143,29 @@ func (h *EvmHeader) EthHeader() *types.Header {
 
 // EvmHeaderJson is simplified version of types.Header, but allowing setting custom hash
 type EvmHeaderJson struct {
-	ParentHash    common.Hash      `json:"parentHash"       gencodec:"required"`
-	UncleHash     common.Hash      `json:"sha3Uncles"       gencodec:"required"`
-	Miner         common.Address   `json:"miner"`
-	Root          common.Hash      `json:"stateRoot"        gencodec:"required"`
-	TxHash        common.Hash      `json:"transactionsRoot" gencodec:"required"`
-	ReceiptHash   common.Hash      `json:"receiptsRoot"     gencodec:"required"`
-	Bloom         types.Bloom      `json:"logsBloom"        gencodec:"required"`
-	Difficulty    *hexutil.Big     `json:"difficulty"       gencodec:"required"`
-	Number        *hexutil.Big     `json:"number"           gencodec:"required"`
-	GasLimit      hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
-	GasUsed       hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
-	Time          hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
-	TimeNano      hexutil.Uint64   `json:"timestampNano"`
-	Extra         hexutil.Bytes    `json:"extraData"        gencodec:"required"`
-	PrevRandao    common.Hash      `json:"mixHash"`
-	Nonce         types.BlockNonce `json:"nonce"`
-	BaseFee       *hexutil.Big     `json:"baseFeePerGas"`
-	Hash          *common.Hash     `json:"hash"`
-	Epoch         hexutil.Uint64   `json:"epoch"`
-	TotalDiff     *hexutil.Big     `json:"totalDifficulty"`
-	BlobGasUsed   *hexutil.Uint64  `json:"blobGasUsed"`
-	ExcessBlobGas *hexutil.Uint64  `json:"excessBlobGas"`
+	ParentHash      common.Hash      `json:"parentHash"       gencodec:"required"`
+	UncleHash       common.Hash      `json:"sha3Uncles"       gencodec:"required"`
+	Miner           common.Address   `json:"miner"`
+	Root            common.Hash      `json:"stateRoot"        gencodec:"required"`
+	TxHash          common.Hash      `json:"transactionsRoot" gencodec:"required"`
+	ReceiptHash     common.Hash      `json:"receiptsRoot"     gencodec:"required"`
+	Bloom           types.Bloom      `json:"logsBloom"        gencodec:"required"`
+	Difficulty      *hexutil.Big     `json:"difficulty"       gencodec:"required"`
+	Number          *hexutil.Big     `json:"number"           gencodec:"required"`
+	GasLimit        hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
+	GasUsed         hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
+	Time            hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
+	TimeNano        hexutil.Uint64   `json:"timestampNano"`
+	Extra           hexutil.Bytes    `json:"extraData"        gencodec:"required"`
+	PrevRandao      common.Hash      `json:"mixHash"`
+	Nonce           types.BlockNonce `json:"nonce"`
+	BaseFee         *hexutil.Big     `json:"baseFeePerGas"`
+	Hash            *common.Hash     `json:"hash"`
+	Epoch           hexutil.Uint64   `json:"epoch"`
+	TotalDiff       *hexutil.Big     `json:"totalDifficulty"`
+	WithdrawalsHash *common.Hash     `json:"withdrawalsRoot"`
+	BlobGasUsed     *hexutil.Uint64  `json:"blobGasUsed"`
+	ExcessBlobGas   *hexutil.Uint64  `json:"excessBlobGas"`
 }
 
 type EvmBlockJson struct {
@@ -176,24 +177,25 @@ type EvmBlockJson struct {
 
 func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
 	enc := &EvmHeaderJson{
-		Number:        (*hexutil.Big)(h.Number),
-		Miner:         h.Coinbase,
-		GasLimit:      0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
-		GasUsed:       hexutil.Uint64(h.GasUsed),
-		Root:          h.Root,
-		TxHash:        h.TxHash,
-		ParentHash:    h.ParentHash,
-		UncleHash:     types.EmptyUncleHash,
-		Time:          hexutil.Uint64(h.Time.Unix()),
-		TimeNano:      hexutil.Uint64(h.Time),
-		BaseFee:       (*hexutil.Big)(h.BaseFee),
-		Difficulty:    new(hexutil.Big),
-		PrevRandao:    h.PrevRandao,
-		TotalDiff:     new(hexutil.Big),
-		Hash:          &h.Hash,
-		Epoch:         hexutil.Uint64(hash.Event(h.Hash).Epoch()),
-		BlobGasUsed:   (*hexutil.Uint64)(new(uint64)),
-		ExcessBlobGas: (*hexutil.Uint64)(new(uint64)),
+		Number:          (*hexutil.Big)(h.Number),
+		Miner:           h.Coinbase,
+		GasLimit:        0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
+		GasUsed:         hexutil.Uint64(h.GasUsed),
+		Root:            h.Root,
+		TxHash:          h.TxHash,
+		ParentHash:      h.ParentHash,
+		UncleHash:       types.EmptyUncleHash,
+		Time:            hexutil.Uint64(h.Time.Unix()),
+		TimeNano:        hexutil.Uint64(h.Time),
+		BaseFee:         (*hexutil.Big)(h.BaseFee),
+		Difficulty:      new(hexutil.Big),
+		PrevRandao:      h.PrevRandao,
+		TotalDiff:       new(hexutil.Big),
+		Hash:            &h.Hash,
+		Epoch:           hexutil.Uint64(hash.Event(h.Hash).Epoch()),
+		WithdrawalsHash: &types.EmptyWithdrawalsHash,
+		BlobGasUsed:     (*hexutil.Uint64)(new(uint64)),
+		ExcessBlobGas:   (*hexutil.Uint64)(new(uint64)),
 	}
 	if receipts != nil { // if receipts resolution fails, don't set ReceiptsHash at all
 		if receipts.Len() != 0 {

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -73,17 +73,24 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 	if p.net.Upgrades.Sonic {
 		prevRandao.SetBytes([]byte{1}) // TODO provide pseudorandom data?
 	}
+
+	withdrawalsHash := common.Hash{}
+	if p.net.Upgrades.Sonic {
+		withdrawalsHash = types.EmptyWithdrawalsHash
+	}
+
 	h := &evmcore.EvmHeader{
-		Number:     p.blockIdx,
-		Hash:       common.Hash(p.block.Atropos),
-		ParentHash: p.prevBlockHash,
-		Root:       common.Hash{},
-		Time:       p.block.Time,
-		Coinbase:   common.Address{},
-		GasLimit:   math.MaxUint64,
-		GasUsed:    p.gasUsed,
-		BaseFee:    baseFee,
-		PrevRandao: prevRandao,
+		Number:          p.blockIdx,
+		Hash:            common.Hash(p.block.Atropos),
+		ParentHash:      p.prevBlockHash,
+		Root:            common.Hash{},
+		Time:            p.block.Time,
+		Coinbase:        common.Address{},
+		GasLimit:        math.MaxUint64,
+		GasUsed:         p.gasUsed,
+		BaseFee:         baseFee,
+		PrevRandao:      prevRandao,
+		WithdrawalsHash: &withdrawalsHash,
 	}
 
 	return evmcore.NewEvmBlock(h, txs)

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -74,9 +74,9 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 		prevRandao.SetBytes([]byte{1}) // TODO provide pseudorandom data?
 	}
 
-	withdrawalsHash := common.Hash{}
+	var withdrawalsHash *common.Hash = nil
 	if p.net.Upgrades.Sonic {
-		withdrawalsHash = types.EmptyWithdrawalsHash
+		withdrawalsHash = &types.EmptyWithdrawalsHash
 	}
 
 	h := &evmcore.EvmHeader{
@@ -90,7 +90,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 		GasUsed:         p.gasUsed,
 		BaseFee:         baseFee,
 		PrevRandao:      prevRandao,
-		WithdrawalsHash: &withdrawalsHash,
+		WithdrawalsHash: withdrawalsHash,
 	}
 
 	return evmcore.NewEvmBlock(h, txs)

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -36,7 +36,7 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 		latest, err := client.BlockNumber(context.Background())
 		require.NoError(err, "Failed to get the latest block number: ", err)
 
-		// we check from block 1 onwards because node zero does not consider Sonic Upgrade.
+		// we check from block 1 onward because block 0 does not consider Sonic Upgrade.
 		for i := int64(1); i <= int64(latest); i++ {
 			block, err := client.BlockByNumber(context.Background(), big.NewInt(i))
 			require.NoError(err, "Failed to get the block: ", err)

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -54,37 +54,3 @@ func TestWithdrawalsCanBeRLPEncodedAndDecoded(t *testing.T) {
 		require.Equal(types.EmptyWithdrawalsHash, *block.Header().WithdrawalsHash)
 	})
 }
-
-func TestFetchingBlockByNumberAndHashReturnsSameBlock(t *testing.T) {
-	require := require.New(t)
-
-	// start network.
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoErrorf(err, "Failed to start the fake network: ", err)
-	defer net.Stop()
-
-	// run endowment to ensure at least one block exists
-	receipt, err := net.EndowAccount(common.Address{42}, 1)
-	require.NoError(err)
-	require.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
-
-	// get client and block
-	client, err := net.GetClient()
-	require.NoError(err, "Failed to get the client: ", err)
-	defer client.Close()
-	blockFromNumber, err := client.BlockByNumber(context.Background(), big.NewInt(1))
-	require.NoError(err, "Failed to get the block: ", err)
-
-	// get block's hash
-	blockHash := blockFromNumber.Hash()
-
-	// get block by hash
-	blockFromHash, err := client.BlockByHash(context.Background(), blockHash)
-	require.NoError(err, "Failed to get the block by hash: ", err)
-
-	// check that the block fetched by number and hash are the same
-	require.Equal(blockFromNumber.Hash(), blockFromHash.Hash())
-	require.Equal(blockFromNumber.Header(), blockFromHash.Header())
-	require.Equal(blockFromNumber.Transactions(), blockFromHash.Transactions())
-	require.Equal(blockFromNumber.UncleHash(), blockFromHash.UncleHash())
-}

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithdrawalsCanBeRLPEncodedAndDecoded(t *testing.T) {
+	require := require.New(t)
+
+	// start network.
+	net, err := StartIntegrationTestNet(t.TempDir())
+	require.NoErrorf(err, "Failed to start the fake network: %v", err)
+	defer net.Stop()
+
+	// run endowment to ensure at least one block exists
+	receipt, err := net.EndowAccount(common.Address{42}, 1)
+	require.NoError(err)
+	require.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
+
+	// get client and block
+	client, err := net.GetClient()
+	require.NoError(err, "Failed to get the client: %v", err)
+	defer client.Close()
+	block, err := client.BlockByNumber(context.Background(), big.NewInt(0))
+	require.NoError(err, "Failed to get the block: %v", err)
+
+	// check that if no withdrawals are made, then the block withdrawals hash is the empty hash
+	require.Empty(block.Withdrawals())
+	require.Empty(block.Header().WithdrawalsHash)
+
+	// create a new block with an empty list of withdrawals
+	newBody := types.Body{Withdrawals: []*types.Withdrawal{}}
+	newBlock := types.NewBlock(block.Header(), &newBody, nil, trie.NewStackTrie(nil))
+
+	// encode block
+	buffer := bytes.NewBuffer(make([]byte, 0))
+	err = newBlock.EncodeRLP(buffer)
+	require.NoError(err, "failed to encode block %v", err)
+
+	// decode block
+	stream := rlp.NewStream(buffer, 0)
+	err = newBlock.DecodeRLP(stream)
+	require.NoError(err, "failed to decode block header; %v", err)
+
+	// make empty string hash
+	err = rlp.Encode(buffer, "")
+	require.NoError(err)
+	newHash := common.Hash(crypto.Keccak256(buffer.Bytes()))
+	require.Equal(types.EmptyWithdrawalsHash, newHash)
+
+	// check that the block has an empty list of withdrawals
+	require.Equal(types.Withdrawals{}, newBlock.Withdrawals())
+	require.Equal(newHash, *newBlock.Header().WithdrawalsHash)
+}

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -24,22 +25,35 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	requireBase.NoError(err)
 	requireBase.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
 
-	// get client and block
+	// get client
 	client, err := net.GetClient()
 	requireBase.NoError(err, "Failed to get the client: ", err)
 	defer client.Close()
-	block, err := client.BlockByNumber(context.Background(), receipt.BlockNumber)
-	requireBase.NoError(err, "Failed to get the block: ", err)
 
 	t.Run("verify default values of block's Withdrawals list and hash", func(t *testing.T) {
 		require := require.New(t)
-		// check that if no withdrawals are made, then the block withdrawals hash is the empty hash
-		require.Equal(types.EmptyWithdrawalsHash, *block.Header().WithdrawalsHash)
-		require.Empty(block.Withdrawals())
+
+		latest, err := client.BlockNumber(context.Background())
+		require.NoError(err, "Failed to get the latest block number: ", err)
+
+		// we check from block 1 onwards because node zero does not consider Sonic Upgrade.
+		for i := int64(1); i <= int64(latest); i++ {
+			block, err := client.BlockByNumber(context.Background(), big.NewInt(i))
+			require.NoError(err, "Failed to get the block: ", err)
+
+			// check that the block has an empty list of withdrawals
+			require.Empty(block.Withdrawals())
+			require.Equal(types.EmptyWithdrawalsHash, *block.Header().WithdrawalsHash, "block %d", i)
+		}
 	})
 
-	t.Run("encode and decode works properly", func(t *testing.T) {
+	t.Run("blocks are healthy to be RLP encoded and decoded", func(t *testing.T) {
 		require := require.New(t)
+
+		// get block
+		block, err := client.BlockByNumber(context.Background(), nil)
+		requireBase.NoError(err, "Failed to get the block: ", err)
+
 		// encode block
 		buffer := bytes.NewBuffer(make([]byte, 0))
 		err = block.EncodeRLP(buffer)

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -39,6 +39,7 @@ func TestWithdrawalsCanBeRLPEncodedAndDecoded(t *testing.T) {
 	})
 
 	t.Run("encode and decode works properly", func(t *testing.T) {
+		// encode block
 		buffer := bytes.NewBuffer(make([]byte, 0))
 		err = block.EncodeRLP(buffer)
 		require.NoError(err, "failed to encode block ", err)
@@ -49,7 +50,7 @@ func TestWithdrawalsCanBeRLPEncodedAndDecoded(t *testing.T) {
 		require.NoError(err, "failed to decode block header; ", err)
 
 		// check that the block has an empty list of withdrawals
-		require.Equal(types.Withdrawals{}, block.Withdrawals())
+		require.Empty(block.Withdrawals())
 		require.Equal(types.EmptyWithdrawalsHash, *block.Header().WithdrawalsHash)
 	})
 }

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"bytes"
 	"context"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -12,33 +11,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithdrawalsCanBeRLPEncodedAndDecoded(t *testing.T) {
-	require := require.New(t)
+func TestWithdrawalFieldsInBlocks(t *testing.T) {
+	requireBase := require.New(t)
 
 	// start network.
 	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoErrorf(err, "Failed to start the fake network: ", err)
+	requireBase.NoErrorf(err, "Failed to start the fake network: ", err)
 	defer net.Stop()
 
 	// run endowment to ensure at least one block exists
 	receipt, err := net.EndowAccount(common.Address{42}, 1)
-	require.NoError(err)
-	require.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
+	requireBase.NoError(err)
+	requireBase.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
 
 	// get client and block
 	client, err := net.GetClient()
-	require.NoError(err, "Failed to get the client: ", err)
+	requireBase.NoError(err, "Failed to get the client: ", err)
 	defer client.Close()
-	block, err := client.BlockByNumber(context.Background(), big.NewInt(0))
-	require.NoError(err, "Failed to get the block: ", err)
+	block, err := client.BlockByNumber(context.Background(), receipt.BlockNumber)
+	requireBase.NoError(err, "Failed to get the block: ", err)
 
 	t.Run("verify default values of block's Withdrawals list and hash", func(t *testing.T) {
+		require := require.New(t)
 		// check that if no withdrawals are made, then the block withdrawals hash is the empty hash
 		require.Equal(types.EmptyWithdrawalsHash, *block.Header().WithdrawalsHash)
 		require.Empty(block.Withdrawals())
 	})
 
 	t.Run("encode and decode works properly", func(t *testing.T) {
+		require := require.New(t)
 		// encode block
 		buffer := bytes.NewBuffer(make([]byte, 0))
 		err = block.EncodeRLP(buffer)


### PR DESCRIPTION
This PR adds a test that aims to verify the `Withdrawals` field added by ([EIP-4895](https://eips.ethereum.org/EIPS/eip-4895)).

The test:
- sets up a network, looks at the first block and checks that both, the `Withdrawals` list and the Header's `WithdrawalsHash` are empty or nil.
- creates a new block with an empty list of `Withdrawals`, runs RLP enconde/decode and then checks that the decoded list exists but is nil, and the `WithdrawalsHash` is the same as hashing an empty string. 

NOTE: during the development of this test I realized that by default blocks have a `nil` `Withdrawals` slice, which means that the header's `WithdrawalsHash` will be `nil` as well, and this is generates an error when decoding the field, since it expects a `[32]byte` but instead finds an empty string. Should we make it so that the default value for `Withdrawals` is not `nil`, but rather an empty list ? 

This PR contributes to [#57](https://github.com/Fantom-foundation/sonic-admin/issues/57).