### PR TITLE
Fix race condition in gas-price oracle startup

### DIFF
--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -23,14 +23,6 @@ type EvmStateReader struct {
 	gpo   *gasprice.Oracle
 }
 
-func (s *Service) GetEvmStateReader() *EvmStateReader {
-	return &EvmStateReader{
-		ServiceFeed: &s.feed,
-		store:       s.store,
-		gpo:         s.gpo,
-	}
-}
-
 // MinGasPrice returns current hard lower bound for gas price
 func (r *EvmStateReader) MinGasPrice() *big.Int {
 	return r.store.GetRules().Economy.MinGasPrice

--- a/gossip/gasprice/gasprice.go
+++ b/gossip/gasprice/gasprice.go
@@ -106,20 +106,20 @@ func sanitizeBigInt(val, min, max, _default *big.Int, name string) *big.Int {
 
 // NewOracle returns a new gasprice oracle which can recommend suitable
 // gasprice for newly created transaction.
-func NewOracle(params Config) *Oracle {
+func NewOracle(params Config, backend Reader) *Oracle {
 	params.MaxGasPrice = sanitizeBigInt(params.MaxGasPrice, nil, nil, DefaultMaxGasPrice, "MaxGasPrice")
 	params.MinGasPrice = sanitizeBigInt(params.MinGasPrice, nil, nil, new(big.Int), "MinGasPrice")
 	params.DefaultCertainty = sanitizeBigInt(new(big.Int).SetUint64(params.DefaultCertainty), big.NewInt(0), DecimalUnitBn, big.NewInt(DecimalUnit/2), "DefaultCertainty").Uint64()
 	tCache, _ := lru.New(100)
 	return &Oracle{
-		cfg:    params,
-		tCache: tCache,
-		quit:   make(chan struct{}),
+		cfg:     params,
+		tCache:  tCache,
+		quit:    make(chan struct{}),
+		backend: backend,
 	}
 }
 
-func (gpo *Oracle) Start(backend Reader) {
-	gpo.backend = backend
+func (gpo *Oracle) Start() {
 	gpo.wg.Add(1)
 	go func() {
 		defer gpo.wg.Done()

--- a/gossip/gasprice/gasprice_test.go
+++ b/gossip/gasprice/gasprice_test.go
@@ -70,7 +70,7 @@ func TestOracle_EffectiveMinGasPrice(t *testing.T) {
 		pendingRules:      opera.FakeNetRules(),
 	}
 
-	gpo := NewOracle(Config{})
+	gpo := NewOracle(Config{}, nil)
 	gpo.cfg.MaxGasPrice = math.MaxBig256
 	gpo.cfg.MinGasPrice = new(big.Int)
 
@@ -130,8 +130,7 @@ func TestOracle_constructiveGasPrice(t *testing.T) {
 		pendingRules:      opera.FakeNetRules(),
 	}
 
-	gpo := NewOracle(Config{})
-	gpo.backend = backend
+	gpo := NewOracle(Config{}, backend)
 	gpo.cfg.MaxGasPrice = math.MaxBig256
 	gpo.cfg.MinGasPrice = new(big.Int)
 
@@ -172,8 +171,7 @@ func TestOracle_reactiveGasPrice(t *testing.T) {
 		pendingRules:      opera.FakeNetRules(),
 	}
 
-	gpo := NewOracle(Config{})
-	gpo.backend = backend
+	gpo := NewOracle(Config{}, backend)
 	gpo.cfg.MaxGasPrice = math.MaxBig256
 	gpo.cfg.MinGasPrice = new(big.Int)
 


### PR DESCRIPTION
This PR fixes a race condition in the initialization of the gas-price oracle.

The backend used by the oracle is set as part of the startup procedure of the main sonic server service. However, at this point HTTP service handler may already access the oracle through RPC queries, constituting a race condition.

With this fix, the backend for the gas price oracle is set during construction time.