### PR TITLE
Lint: Enable vet and staticcheck in PR builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Static lints
+        env:
+          GOPRIVATE: github.com/Fantom-foundation
+        run: make lint
+
       - name: Run unit tests
         env:
           GOPRIVATE: github.com/Fantom-foundation

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,12 @@ pipeline {
             }
         }
 
+        stage('Static analysis') {
+            steps {
+                sh 'make lint'
+            }
+        }
+
         stage('Build') {
             steps {
                 sh 'make'

--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,4 @@ errorcheck:
 	errcheck ./...
 
 .PHONY: lint
-lint: vet staticcheck errorcheck
+lint: vet staticcheck # errorcheck  


### PR DESCRIPTION
This PR enables linting as part of the PR verification. 

- go vet will be run unconstrained. 
- staticcheck will run with two ignored rules: defined in `staticcheck.conf` 
```
    "-ST1005", # error string formatting. No capital letter in the first word & no punctuation 
    "-SA1019" # deprecated imports (CARMEN)
```
Imports rue can be enabled once Carmen deprecated API uses are migrated. [TODO](https://github.com/Fantom-foundation/sonic-admin/issues/43)

- errcheck is disabled because of numerous unhandled errors. Manual inspection did not detect any critical issue there, other than the ones already fixed. Nevertheless, it would be convenient to migrate all of them just to be able to enable check automation. 

This PR is part of https://github.com/Fantom-foundation/sonic-admin/issues/25
