### PR TITLE
Allow execution of Blob transactions as long as the carry no Blobs

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -177,6 +177,15 @@ func applyTransaction(
 	// Skip checking of base fee limits for internal transactions.
 	evm.Config.NoBaseFee = msg.SkipAccountChecks
 
+	// For now, Sonic only supports Blob transactions without blob data.
+	if msg.BlobHashes != nil {
+		if len(msg.BlobHashes) > 0 {
+			return nil, 0, true, fmt.Errorf("blob data is not supported")
+		}
+		// PreCheck requires non-nil blobHashes not to be empty
+		msg.BlobHashes = nil
+	}
+
 	// Apply the transaction to the current state (included in the env).
 	result, err := core.ApplyMessage(evm, msg, gp)
 	if err != nil {

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -119,14 +118,10 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 		copy(blob[:], data)
 
 		blobCommitment, err := kzg4844.BlobToCommitment(&blob)
-		if err != nil {
-			return nil, fmt.Errorf("failed to compute blob commitment: %s", err)
-		}
+		require.NoError(err, "failed to compute blob commitment")
 
 		blobProof, err := kzg4844.ComputeBlobProof(&blob, blobCommitment)
-		if err != nil {
-			return nil, fmt.Errorf("failed to compute blob proof: %s", err)
-		}
+		require.NoError(err, "failed to compute blob proof")
 
 		sidecar.Blobs = append(sidecar.Blobs, blob)
 		sidecar.Commitments = append(sidecar.Commitments, blobCommitment)

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -1,0 +1,202 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBobTransaction(t *testing.T) {
+
+	ctxt := MakeTestContext(t)
+	defer ctxt.Close()
+
+	t.Run("blob tx with non-empty blobs is rejected", func(t *testing.T) {
+		testBlobTx_WithBlobsIsRejected(t, ctxt)
+	})
+
+	t.Run("blob tx with empty blobs is executed", func(t *testing.T) {
+		testBlobTx_WithEmptyBlobsIsExecuted(t, ctxt)
+	})
+
+	t.Run("blob tx with nil sidecar is executed", func(t *testing.T) {
+		testBlobTx_WithNilSidecarIsExecuted(t, ctxt)
+	})
+}
+
+func testBlobTx_WithBlobsIsRejected(t *testing.T, ctxt *testContext) {
+	require := require.New(t)
+	nonZeroNumberOfBlobs := 2
+
+	// Create a new transaction with blob data
+	blobs := make([][]byte, nonZeroNumberOfBlobs)
+	for i := 0; i < nonZeroNumberOfBlobs; i++ {
+		var blob kzg4844.Blob
+		copy(blobs[i], blob[:])
+	}
+
+	tx, err := createTestBlobTransaction(t, ctxt, blobs...)
+	require.NoError(err)
+
+	// attempt to run tx
+	_, err = ctxt.net.Run(tx)
+	require.ErrorContains(err, "transaction type not supported")
+
+	// repeat same tx (regression against reported repeated tx issue)
+	_, err = ctxt.net.Run(tx)
+	require.ErrorContains(err, "transaction type not supported")
+}
+
+func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, ctxt *testContext) {
+	require := require.New(t)
+
+	tx, err := createTestBlobTransaction(t, ctxt)
+	require.NoError(err)
+
+	// run tx
+	receipt, err := ctxt.net.Run(tx)
+	require.NoError(err, "transaction must be accepted")
+	require.Equal(
+		types.ReceiptStatusSuccessful,
+		receipt.Status,
+		"transaction must succeed",
+	)
+
+	// repeat same tx (regression against reported repeated tx issue)
+	_, err = ctxt.net.Run(tx)
+	require.ErrorContains(err,
+		"nonce too low",
+		"transaction must not be accepted again")
+}
+
+func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, ctxt *testContext) {
+	require := require.New(t)
+
+	tx, err := createTestBlobTransactionWithNilSidecar(t, ctxt)
+	require.NoError(err)
+
+	// run tx
+	receipt, err := ctxt.net.Run(tx)
+	require.NoError(err, "transaction must be accepted")
+	require.Equal(
+		types.ReceiptStatusSuccessful,
+		receipt.Status,
+		"transaction must succeed",
+	)
+
+	// repeat same tx (regression against reported repeated tx issue)
+	_, err = ctxt.net.Run(tx)
+	require.ErrorContains(err,
+		"nonce too low",
+		"transaction must not be accepted again")
+}
+
+func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) (*types.Transaction, error) {
+	require := require.New(t)
+
+	chainId, err := ctxt.client.ChainID(context.Background())
+	require.NoError(err, "failed to get chain ID::")
+
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.validator.Address(), nil)
+	require.NoError(err, "failed to get nonce:")
+
+	var sidecar *types.BlobTxSidecar
+	var blobHashes []common.Hash
+
+	if len(data) > 0 {
+		sidecar = new(types.BlobTxSidecar)
+	}
+
+	for _, data := range data {
+		var blob kzg4844.Blob // Define a blob array to hold the large data payload, blobs are 128kb in length
+		copy(blob[:], data)
+
+		blobCommitment, err := kzg4844.BlobToCommitment(&blob)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute blob commitment: %s", err)
+		}
+
+		blobProof, err := kzg4844.ComputeBlobProof(&blob, blobCommitment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute blob proof: %s", err)
+		}
+
+		sidecar.Blobs = append(sidecar.Blobs, blob)
+		sidecar.Commitments = append(sidecar.Commitments, blobCommitment)
+		sidecar.Proofs = append(sidecar.Proofs, blobProof)
+	}
+
+	// Get blob hashes from the sidecar
+	if len(data) > 0 {
+		blobHashes = sidecar.BlobHashes()
+	}
+
+	// Create and return transaction with the blob data and cryptographic proofs
+	tx := types.NewTx(&types.BlobTx{
+		ChainID:    uint256.MustFromBig(chainId),
+		Nonce:      nonce,
+		GasTipCap:  uint256.NewInt(1e10),  // max priority fee per gas
+		GasFeeCap:  uint256.NewInt(50e10), // max fee per gas
+		Gas:        35000,                 // gas limit for the transaction
+		To:         common.Address{},      // recipient's address
+		Value:      uint256.NewInt(0),     // value transferred in the transaction
+		BlobFeeCap: uint256.NewInt(3e10),  // fee cap for the blob data
+		BlobHashes: blobHashes,            // blob hashes in the transaction
+		Sidecar:    sidecar,               // sidecar data in the transaction
+	})
+
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.validator.PrivateKey)
+}
+
+func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*types.Transaction, error) {
+	require := require.New(t)
+
+	chainId, err := ctxt.client.ChainID(context.Background())
+	require.NoError(err, "failed to get chain ID::")
+
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.validator.Address(), nil)
+	require.NoError(err, "failed to get nonce:")
+
+	// Create and return transaction with the blob data and cryptographic proofs
+	tx := types.NewTx(&types.BlobTx{
+		ChainID:    uint256.MustFromBig(chainId),
+		Nonce:      nonce,
+		GasTipCap:  uint256.NewInt(1e10),  // max priority fee per gas
+		GasFeeCap:  uint256.NewInt(50e10), // max fee per gas
+		Gas:        35000,                 // gas limit for the transaction
+		To:         common.Address{},      // recipient's address
+		Value:      uint256.NewInt(0),     // value transferred in the transaction
+		BlobFeeCap: uint256.NewInt(3e10),  // fee cap for the blob data
+		BlobHashes: nil,                   // blob hashes in the transaction
+		Sidecar:    nil,                   // sidecar data in the transaction
+	})
+
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.validator.PrivateKey)
+}
+
+type testContext struct {
+	net    *IntegrationTestNet
+	client *ethclient.Client
+}
+
+func MakeTestContext(t *testing.T) *testContext {
+	net, err := StartIntegrationTestNet(t.TempDir())
+	require.NoError(t, err)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+
+	return &testContext{net, client}
+}
+
+func (tc *testContext) Close() {
+	tc.client.Close()
+	tc.net.Stop()
+}


### PR DESCRIPTION
This PR adds the modifications needed to allow Blob transactions to proceed into the transaction processor, as long as they do not include Blobs.  

Current implementation would ignore any transaction containing an empty `BlobHashes` field here. Never producing a receipt for such.  [Here](https://github.com/Fantom-foundation/Sonic/blob/09c952eaa6fd6b4b72ed33097f4714275b1e7cd6/evmcore/state_processor.go#L183)

The proposed fix utilizes the same ignore mechanism to drop transactions with blob payload, whilst allowing transactions with empty and nil blob lists.

Blobs are currently being filtered out from submission [here](https://github.com/Fantom-foundation/Sonic/blob/09c952eaa6fd6b4b72ed33097f4714275b1e7cd6/evmcore/tx_pool.go#L661). 
To test the correct execution of blob transaction without blobs, and ignore those which contain blobs in the event of a modified validator which does not reject such; the following was tested:
- Remove pool checks that would prevent the transaction from being part of the next block [here](https://github.com/Fantom-foundation/Sonic/blob/09c952eaa6fd6b4b72ed33097f4714275b1e7cd6/evmcore/tx_pool.go#L661).
- Increase Transaction max size [here](https://github.com/Fantom-foundation/Sonic/blob/09c952eaa6fd6b4b72ed33097f4714275b1e7cd6/evmcore/tx_pool.go#L57).
- Re-rurn the unit test yields the error:
`Error "failed to get transaction receipt: timeout" does not contain "transaction type not supported"`
This means that the transaction was ignored and produced no receipt, although it was accepted in the pool and submitted for a block. 


Part of https://github.com/Fantom-foundation/sonic-admin/issues/16