### PR TITLE
Lint: migrate math/rand to v2

### DIFF
--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -18,7 +18,7 @@ package evmcore
 
 import (
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/types"

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"sync"
 	"time"
@@ -594,7 +594,7 @@ func sampleTxHashes(txListsMap map[common.Address]*txList, max int) (out []commo
 	first := 0
 	last := len(txListsMap) - 1
 	if len(txListsMap) > max {
-		first = rand.Intn(len(txListsMap))
+		first = rand.IntN(len(txListsMap))
 		last = (first + max) % len(txListsMap)
 	}
 

--- a/gossip/dummy_tx_pool.go
+++ b/gossip/dummy_tx_pool.go
@@ -2,7 +2,7 @@ package gossip
 
 import (
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"sync"
 
@@ -134,7 +134,7 @@ func (p *dummyTxPool) SampleHashes(max int) []common.Hash {
 	res := make([]common.Hash, 0, max)
 	skip := 0
 	if len(p.pool) > max {
-		skip = rand.Intn(len(p.pool) - max)
+		skip = rand.IntN(len(p.pool) - max)
 	}
 	for _, tx := range p.pool {
 		if len(res) >= max {

--- a/gossip/emitter/config.go
+++ b/gossip/emitter/config.go
@@ -1,9 +1,10 @@
 package emitter
 
 import (
-	"github.com/Fantom-foundation/go-opera/version"
-	"math/rand"
+	"math/rand/v2"
 	"time"
+
+	"github.com/Fantom-foundation/go-opera/version"
 
 	"github.com/Fantom-foundation/go-opera/inter/validatorpk"
 	"github.com/Fantom-foundation/go-opera/opera"
@@ -79,15 +80,15 @@ func DefaultConfig() Config {
 }
 
 // RandomizeEmitTime and return new config
-func (cfg EmitIntervals) RandomizeEmitTime(r *rand.Rand) EmitIntervals {
+func (cfg EmitIntervals) RandomizeEmitTime(rand *rand.Rand) EmitIntervals {
 	config := cfg
 	// value = value - 0.1 * value + 0.1 * random value
 	if config.Max > 10 {
-		config.Max = config.Max - config.Max/10 + time.Duration(r.Int63n(int64(config.Max/10)))
+		config.Max = config.Max - config.Max/10 + time.Duration(rand.Int64N(int64(config.Max/10)))
 	}
 	// value = value + 0.33 * random value
 	if config.DoublesignProtection > 3 {
-		config.DoublesignProtection = config.DoublesignProtection + time.Duration(r.Int63n(int64(config.DoublesignProtection/3)))
+		config.DoublesignProtection = config.DoublesignProtection + time.Duration(rand.Int64N(int64(config.DoublesignProtection/3)))
 	}
 	return config
 }

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -3,7 +3,7 @@ package emitter
 import (
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"strings"
 	"sync"
@@ -112,8 +112,8 @@ func NewEmitter(
 ) *Emitter {
 	// Randomize event time to decrease chance of 2 parallel instances emitting event at the same time
 	// It increases the chance of detecting parallel instances
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	config.EmitIntervals = config.EmitIntervals.RandomizeEmitTime(r)
+	rand := rand.New(rand.NewPCG(uint64(os.Getpid()), uint64(time.Now().UnixNano())))
+	config.EmitIntervals = config.EmitIntervals.RandomizeEmitTime(rand)
 
 	return &Emitter{
 		config:                   config,

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -19,7 +19,7 @@ package emitter
 import (
 	"crypto/ecdsa"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -61,7 +61,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		count := 25
 		for i := 0; i < 25; i++ {
 			var tx *types.Transaction
-			gasFeeCap := rand.Intn(50)
+			gasFeeCap := rand.IntN(50)
 			if baseFee == nil {
 				tx = types.NewTx(&types.LegacyTx{
 					Nonce:    uint64(start + i),
@@ -78,7 +78,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 					Value:     big.NewInt(100),
 					Gas:       100,
 					GasFeeCap: big.NewInt(int64(gasFeeCap)),
-					GasTipCap: big.NewInt(int64(rand.Intn(gasFeeCap + 1))),
+					GasTipCap: big.NewInt(int64(rand.IntN(gasFeeCap + 1))),
 					Data:      nil,
 				})
 				if count == 25 && int64(gasFeeCap) < baseFee.Int64() {

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"time"
@@ -1024,7 +1024,7 @@ func (h *handler) txBroadcastLoop() {
 			if len(peers) == 0 {
 				continue
 			}
-			randPeer := peers[rand.Intn(len(peers))]
+			randPeer := peers[rand.IntN(len(peers))]
 			h.syncTransactions(randPeer, h.txpool.SampleHashes(h.config.Protocol.MaxRandomTxHashesSend))
 		}
 	}

--- a/gossip/handler_fuzz.go
+++ b/gossip/handler_fuzz.go
@@ -6,7 +6,7 @@ package gossip
 import (
 	"bytes"
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
@@ -123,7 +123,7 @@ func makeFuzzedHandler() (h *handler, err error) {
 
 func randomID() (id enode.ID) {
 	for i := range id {
-		id[i] = byte(rand.Intn(255))
+		id[i] = byte(rand.IntN(255))
 	}
 	return id
 }

--- a/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
+++ b/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
@@ -1,7 +1,7 @@
 package dagstreamleecher
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"time"
 
@@ -140,8 +140,8 @@ func getSessionID(epoch idx.Epoch, try uint32) uint32 {
 }
 
 func (d *Leecher) startSession(candidates []string) {
-	peer := candidates[rand.Intn(len(candidates))]
-	if d.session.try == 0 && rand.Intn(50) != 0 {
+	peer := candidates[rand.IntN(len(candidates))]
+	if d.session.try == 0 && rand.IntN(50) != 0 {
 		// try previous successful peer first
 		if slices.Contains(candidates, d.session.peer) {
 			peer = d.session.peer

--- a/gossip/protocols/dag/dagstream/dagstreamleecher/leecher_test.go
+++ b/gossip/protocols/dag/dagstream/dagstreamleecher/leecher_test.go
@@ -1,7 +1,7 @@
 package dagstreamleecher
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 	"time"
@@ -16,7 +16,7 @@ import (
 
 func TestLeecherNoDeadlocks(t *testing.T) {
 	for try := 0; try < 10; try++ {
-		testLeecherNoDeadlocks(t, 1+rand.Intn(500))
+		testLeecherNoDeadlocks(t, 1+rand.IntN(500))
 	}
 }
 
@@ -34,25 +34,25 @@ func testLeecherNoDeadlocks(t *testing.T, maxPeers int) {
 	config.BaseProgressWatchdog = 3 * time.Millisecond * 5
 	config.Session.RecheckInterval = time.Millisecond
 	epoch := idx.Epoch(1)
-	leecher := New(epoch, rand.Intn(2) == 0, config, Callbacks{
+	leecher := New(epoch, rand.IntN(2) == 0, config, Callbacks{
 		IsProcessed: func(id hash.Event) bool {
-			return rand.Intn(2) == 0
+			return rand.IntN(2) == 0
 		},
 		RequestChunk: func(peer string, r dagstream.Request) error {
 			requests <- peerRequest{peer, r}
 			return nil
 		},
 		Suspend: func(peer string) bool {
-			return rand.Intn(10) == 0
+			return rand.IntN(10) == 0
 		},
 		PeerEpoch: func(peer string) idx.Epoch {
-			return 1 + epoch/2 + idx.Epoch(rand.Intn(int(epoch*2)))
+			return 1 + epoch/2 + idx.Epoch(rand.IntN(int(epoch*2)))
 		},
 	})
 	terminated := false
 	for i := 0; i < maxPeers*2; i++ {
-		peer := strconv.Itoa(rand.Intn(maxPeers))
-		coin := rand.Intn(100)
+		peer := strconv.Itoa(rand.IntN(maxPeers))
+		coin := rand.IntN(100)
 		if coin <= 50 {
 			err := leecher.RegisterPeer(peer)
 			if !terminated {
@@ -73,15 +73,15 @@ func testLeecherNoDeadlocks(t *testing.T, maxPeers int) {
 		}
 		select {
 		case req := <-requests:
-			if rand.Intn(10) != 0 {
-				err := leecher.NotifyChunkReceived(req.request.Session.ID, hash.FakeEvent(), rand.Intn(5) == 0)
+			if rand.IntN(10) != 0 {
+				err := leecher.NotifyChunkReceived(req.request.Session.ID, hash.FakeEvent(), rand.IntN(5) == 0)
 				if !terminated {
 					require.NoError(t, err)
 				}
 			}
 		default:
 		}
-		if !terminated && rand.Intn(maxPeers*2) == 0 {
+		if !terminated && rand.IntN(maxPeers*2) == 0 {
 			terminated = true
 			leecher.Terminate()
 		}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/gossip/sync.go
+++ b/gossip/sync.go
@@ -1,11 +1,12 @@
 package gossip
 
 import (
+	"math/rand/v2"
+	"sync/atomic"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"math/rand"
-	"sync/atomic"
 )
 
 var isMaybeSyncedGauge = metrics.GetOrRegisterGauge("chain/maybeSynced", nil)
@@ -97,7 +98,7 @@ func (h *handler) txsyncLoop() {
 		if len(pending) == 0 {
 			return nil
 		}
-		n := rand.Intn(len(pending)) + 1
+		n := rand.IntN(len(pending)) + 1
 		for _, s := range pending {
 			if n--; n == 0 {
 				return s

--- a/gossip/tx_scrambler_test.go
+++ b/gossip/tx_scrambler_test.go
@@ -3,10 +3,11 @@ package gossip
 import (
 	"cmp"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/rand"
+	"math/rand/v2"
 	"slices"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestTxScrambler_AnalyseEntryList_RemovesDuplicateTransactions(t *testing.T) {
@@ -123,7 +124,7 @@ func TestTxScrambler_ScrambleTransactions_ScrambleIsDeterministic(t *testing.T) 
 	res2 := slices.Clone(res1)
 
 	for i := 0; i < 10; i++ {
-		salt := createRandomSalt(t)
+		salt := createRandomSalt()
 		scrambleTransactions(res1, salt)
 		for j := 0; j < 10; j++ {
 			shuffleEntries(res2)
@@ -633,7 +634,7 @@ func createRandomScramblerTestInput(size int64) []ScramblerEntry {
 	var entries []ScramblerEntry
 	for i := int64(0); i < size; i++ {
 		// same hashes must have same data
-		r := rand.Intn(100 - 1)
+		r := rand.IntN(100 - 1)
 		entries = append(entries, &dummyScramblerEntry{
 			hash:     common.Hash{byte(r)},
 			sender:   common.Address{byte(r)},
@@ -663,10 +664,10 @@ func checkDuplicateHashes(t *testing.T, entries []ScramblerEntry) {
 	}
 }
 
-func createRandomSalt(t *testing.T) [32]byte {
+func createRandomSalt() [32]byte {
 	var salt = [32]byte{}
-	if _, err := rand.Read(salt[:]); err != nil {
-		t.Fatalf("cannot create random salt: %v", err)
+	for i := 0; i < 32; i++ {
+		salt[i] = byte(rand.IntN(256))
 	}
 	return salt
 }

--- a/opera/genesisstore/fileshash/filehash_test.go
+++ b/opera/genesisstore/fileshash/filehash_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path"
 	"testing"
@@ -99,7 +99,7 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 		file, err = os.OpenFile(filePath, os.O_RDONLY, 0600)
 		require.NoError(err)
 		reader := WrapReader(file, maxMemUsage, root)
-		readB := make([]byte, rand.Int63n(int64(len(content))))
+		readB := make([]byte, rand.Int64N(int64(len(content))))
 		err = ioread.ReadAll(reader, readB)
 		require.NoError(err)
 		require.Equal(content[:len(readB)], readB)
@@ -148,7 +148,7 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 		file, err = os.OpenFile(filePath, os.O_RDWR, 0600)
 		require.NoError(err)
 		s := []byte{0}
-		contentPos := rand.Int63n(int64(len(content)))
+		contentPos := rand.Int64N(int64(len(content)))
 		pos := int64(headerOffset) + contentPos
 		_, err = file.ReadAt(s, pos)
 		require.NoError(err)
@@ -180,7 +180,7 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 		// mutate content byte
 		file, err = os.OpenFile(filePath, os.O_RDWR, 0600)
 		require.NoError(err)
-		pos := rand.Int63n(int64(headerOffset))
+		pos := rand.Int64N(int64(headerOffset))
 		s := []byte{0}
 		_, err = file.ReadAt(s, pos)
 		require.NoError(err)

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -2,8 +2,8 @@ package topicsdb
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"os"
 	"runtime/debug"
 	"testing"

--- a/utils/bits/bits_test.go
+++ b/utils/bits/bits_test.go
@@ -2,7 +2,7 @@ package bits
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,36 +37,36 @@ func TestBitArrayV01010101010101010(t *testing.T) {
 }
 
 func TestBitArrayRand1(t *testing.T) {
-	r := rand.New(rand.NewSource(0))
+	rand := rand.New(rand.NewPCG(0, 0))
 	for i := 0; i < 50; i++ {
-		testBitArray(t, genTestWords(r, 24, 1), fmt.Sprintf("1 bit, case#%d", i))
+		testBitArray(t, genTestWords(rand, 24, 1), fmt.Sprintf("1 bit, case#%d", i))
 	}
 }
 
 func TestBitArrayRand8(t *testing.T) {
-	r := rand.New(rand.NewSource(0))
+	rand := rand.New(rand.NewPCG(0, 0))
 	for i := 0; i < 50; i++ {
-		testBitArray(t, genTestWords(r, 100, 8), fmt.Sprintf("8 bits, case#%d", i))
+		testBitArray(t, genTestWords(rand, 100, 8), fmt.Sprintf("8 bits, case#%d", i))
 	}
 }
 
 func TestBitArrayRand17(t *testing.T) {
-	r := rand.New(rand.NewSource(0))
+	rand := rand.New(rand.NewPCG(0, 0))
 	for i := 0; i < 50; i++ {
-		testBitArray(t, genTestWords(r, 50, 17), fmt.Sprintf("17 bits, case#%d", i))
+		testBitArray(t, genTestWords(rand, 50, 17), fmt.Sprintf("17 bits, case#%d", i))
 	}
 }
 
-func genTestWords(r *rand.Rand, maxCount int, maxBits int) []testWord {
-	count := r.Intn(maxCount)
+func genTestWords(rand *rand.Rand, maxCount int, maxBits int) []testWord {
+	count := rand.IntN(maxCount)
 	words := make([]testWord, count)
 	for i := range words {
 		if maxBits == 1 {
 			words[i].bits = 1
 		} else {
-			words[i].bits = 1 + r.Intn(maxBits-1)
+			words[i].bits = 1 + rand.IntN(maxBits-1)
 		}
-		words[i].v = uint(r.Intn(1 << words[i].bits))
+		words[i].v = uint(rand.IntN(1 << words[i].bits))
 	}
 	return words
 }

--- a/utils/cser/binary_test.go
+++ b/utils/cser/binary_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -323,9 +323,8 @@ func TestBadVals(t *testing.T) {
 
 func randBytes(n int) []byte {
 	bb := make([]byte, n)
-	_, err := rand.Read(bb)
-	if err != nil {
-		panic(err)
+	for i := range bb {
+		bb[i] = byte(rand.IntN(256))
 	}
 	return bb
 }

--- a/utils/fast/buffer_test.go
+++ b/utils/fast/buffer_test.go
@@ -2,7 +2,7 @@ package fast
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/utils/num_queue_test.go
+++ b/utils/num_queue_test.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 

--- a/utils/randat/rand_at.go
+++ b/utils/randat/rand_at.go
@@ -1,7 +1,7 @@
 package randat
 
 import (
-	"math/rand"
+	"math/rand/v2"
 )
 
 type cached struct {
@@ -10,7 +10,7 @@ type cached struct {
 }
 
 var (
-	gSeed = rand.Int63()
+	gSeed = rand.Uint64()
 	cache = cached{}
 )
 
@@ -21,6 +21,6 @@ func RandAt(seed uint64) uint64 {
 		return cache.r
 	}
 	cache.seed = seed
-	cache.r = rand.New(rand.NewSource(gSeed ^ int64(seed))).Uint64()
+	cache.r = rand.New(rand.NewPCG(gSeed, seed)).Uint64()
 	return cache.r
 }


### PR DESCRIPTION
Migrate math/rand uses to the v2 version of the API,

This is a non-functional change that replaces the API with its successor. There are 2 main changes:
- Read interface is removed, users of the read functions should use the crypto/rand library. 
- No global Seeding anymore, seed is local to an object and the new Source object requires two uint64 seeds. 

This test migrates all uses to math/rand/v2, and removes uses of Read in tests. Replacing them with loops to reduce the need to include both libraries and having an alias. 

This is one of the 2 deprecated libraries at the moment, the new Carmen API is the other one. 

This PR is part of https://github.com/Fantom-foundation/sonic-admin/issues/25
