### PR TITLE
Segregate integration tests into different processes.

### DIFF
--- a/tests/address_access/address_access_test.go
+++ b/tests/address_access/address_access_test.go
@@ -1,9 +1,10 @@
-package tests
+package address_access_test
 
 import (
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	accessCost "github.com/Fantom-foundation/go-opera/tests/contracts/access_cost"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,13 +14,13 @@ import (
 func TestAddressAccess(t *testing.T) {
 	someAccountAddress := common.Address{1}
 
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
 
-	contract, receipt, err := DeployContract(net, accessCost.DeployAccessCost)
+	contract, receipt, err := tests.DeployContract(net, accessCost.DeployAccessCost)
 	checkTxExecution(t, receipt, err)
 
 	// Execute function on an address, cold access

--- a/tests/basefee/basefee_test.go
+++ b/tests/basefee/basefee_test.go
@@ -1,22 +1,23 @@
-package tests
+package basefee_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/basefee"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 func TestBaseFee_CanReadBaseFeeFromHeadAndBlockAndHistory(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
 
 	// Deploy the base fee contract.
-	contract, _, err := DeployContract(net, basefee.DeployBasefee)
+	contract, _, err := tests.DeployContract(net, basefee.DeployBasefee)
 	if err != nil {
 		t.Fatalf("failed to deploy contract; %v", err)
 	}

--- a/tests/blob_tx/blob_tx_test.go
+++ b/tests/blob_tx/blob_tx_test.go
@@ -1,10 +1,11 @@
-package tests
+package blob_tx_test
 
 import (
 	"context"
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
@@ -106,7 +107,7 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 	chainId, err := ctxt.client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.validator.Address(), nil)
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetValidatorAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	var sidecar *types.BlobTxSidecar
@@ -150,7 +151,7 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 		Sidecar:    sidecar,               // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.validator.PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetValidatorAccount().PrivateKey)
 }
 
 func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*types.Transaction, error) {
@@ -159,7 +160,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 	chainId, err := ctxt.client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.validator.Address(), nil)
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetValidatorAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	// Create and return transaction with the blob data and cryptographic proofs
@@ -176,7 +177,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 		Sidecar:    nil,                   // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.validator.PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetValidatorAccount().PrivateKey)
 }
 
 func checkBlocksSanity(t *testing.T, client *ethclient.Client) {
@@ -194,12 +195,12 @@ func checkBlocksSanity(t *testing.T, client *ethclient.Client) {
 }
 
 type testContext struct {
-	net    *IntegrationTestNet
+	net    *tests.IntegrationTestNet
 	client *ethclient.Client
 }
 
 func MakeTestContext(t *testing.T) *testContext {
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(t, err)
 
 	client, err := net.GetClient()

--- a/tests/blobbasefee/blobbasefee_test.go
+++ b/tests/blobbasefee/blobbasefee_test.go
@@ -1,10 +1,11 @@
-package tests
+package blobbasefeee_test
 
 import (
 	"bytes"
 	"context"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/blobbasefee"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -16,12 +17,12 @@ import (
 
 func TestBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T) {
 	require := require.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(err, "Failed to start the fake network: ", err)
 	defer net.Stop()
 
 	// Deploy the blob base fee contract.
-	contract, _, err := DeployContract(net, blobbasefee.DeployBlobbasefee)
+	contract, _, err := tests.DeployContract(net, blobbasefee.DeployBlobbasefee)
 	require.NoError(err, "failed to deploy contract; ", err)
 
 	// Collect the current blob base fee from the head state.
@@ -69,7 +70,7 @@ func getBlobBaseFeeFrom(header *types.Header) uint64 {
 
 func TestBlobBaseFee_CanReadBlobGasUsed(t *testing.T) {
 	require := require.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(err, "Failed to start the fake network: ", err)
 	defer net.Stop()
 

--- a/tests/block_hash/block_hash_test.go
+++ b/tests/block_hash/block_hash_test.go
@@ -1,10 +1,11 @@
-package tests
+package block_has_test
 
 import (
 	"context"
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/block_hash"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -14,14 +15,14 @@ import (
 
 func TestBlockHash_CorrectBlockHashesAreAccessibleInContracts(t *testing.T) {
 	require := req.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
 
 	// Deploy the block hash observer contract.
-	_, receipt, err := DeployContract(net, block_hash.DeployBlockHash)
+	_, receipt, err := tests.DeployContract(net, block_hash.DeployBlockHash)
 	require.NoError(err, "failed to deploy contract; %v", err)
 	contractAddress := receipt.ContractAddress
 	contractCreationBlock := receipt.BlockNumber.Uint64()
@@ -44,7 +45,7 @@ func TestBlockHash_CorrectBlockHashesAreAccessibleInContracts(t *testing.T) {
 
 func testVisibleBlockHashOnHead(
 	t *testing.T,
-	net *IntegrationTestNet,
+	net *tests.IntegrationTestNet,
 	observerContractAddress common.Address,
 ) {
 	require := req.New(t)
@@ -86,7 +87,7 @@ func testVisibleBlockHashOnHead(
 
 func testVisibleBlockHashesInArchive(
 	t *testing.T,
-	net *IntegrationTestNet,
+	net *tests.IntegrationTestNet,
 	observerContractAddress common.Address,
 	observerCreationBlock uint64,
 ) {

--- a/tests/block_header/block_header_test.go
+++ b/tests/block_header/block_header_test.go
@@ -1,4 +1,4 @@
-package tests
+package blockheader_test
 
 import (
 	"cmp"
@@ -20,6 +20,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/opera/contracts/evmwriter"
 	"github.com/Fantom-foundation/go-opera/opera/contracts/netinit"
 	"github.com/Fantom-foundation/go-opera/opera/contracts/sfc"
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/counter_event_emitter"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -35,7 +36,8 @@ import (
 
 func TestBlockHeader_FakeGenesis_SatisfiesInvariants(t *testing.T) {
 	require := require.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
+
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(err)
 	defer net.Stop()
 	testBlockHeadersOnNetwork(t, net)
@@ -43,19 +45,19 @@ func TestBlockHeader_FakeGenesis_SatisfiesInvariants(t *testing.T) {
 
 func TestBlockHeader_JsonGenesis_SatisfiesInvariants(t *testing.T) {
 	require := require.New(t)
-	net, err := StartIntegrationTestNetFromJsonGenesis(t.TempDir())
+	net, err := tests.StartIntegrationTestNetFromJsonGenesis(t.TempDir())
 	require.NoError(err)
 	defer net.Stop()
 	testBlockHeadersOnNetwork(t, net)
 }
 
-func testBlockHeadersOnNetwork(t *testing.T, net *IntegrationTestNet) {
+func testBlockHeadersOnNetwork(t *testing.T, net *tests.IntegrationTestNet) {
 	const numBlocks = 10
 	require := require.New(t)
 
 	// Produce a few blocks on the network. We use the counter contract since
 	// it is also producing events.
-	counter, receipt, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
+	counter, receipt, err := tests.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(err)
 	for range numBlocks {
 		_, err := net.Apply(counter.Increment)

--- a/tests/counter/counter_test.go
+++ b/tests/counter/counter_test.go
@@ -1,23 +1,24 @@
-package tests
+package counter_test
 
 import (
 	"math"
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/counter"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
 
 	// Deploy the counter contract.
-	contract, _, err := DeployContract(net, counter.DeployCounter)
+	contract, _, err := tests.DeployContract(net, counter.DeployCounter)
 	if err != nil {
 		t.Fatalf("failed to deploy contract; %v", err)
 	}
@@ -41,14 +42,14 @@ func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
 }
 
 func TestCounter_CanReadHistoricCounterValues(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
 
 	// Deploy the counter contract.
-	contract, receipt, err := DeployContract(net, counter.DeployCounter)
+	contract, receipt, err := tests.DeployContract(net, counter.DeployCounter)
 	if err != nil {
 		t.Fatalf("failed to deploy contract; %v", err)
 	}

--- a/tests/gas_price_suggestion/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion/gas_price_suggestion_test.go
@@ -1,4 +1,4 @@
-package tests
+package gas_price_suggestion
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -55,11 +56,11 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.validator.Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetValidatorAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	factory := &txFactory{
-		senderKey: net.validator.PrivateKey,
+		senderKey: net.GetValidatorAccount().PrivateKey,
 		chainId:   chainId,
 	}
 
@@ -92,8 +93,8 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 	require.NoError(send(factory.makeBlobTransactionWithPrice(t, nonce+3, feeCap)))
 }
 
-func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *ethclient.Client) {
-	net, err := StartIntegrationTestNet(t.TempDir())
+func makeNetAndClient(t *testing.T) (*tests.IntegrationTestNet, *ethclient.Client) {
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(t, err)
 	t.Cleanup(func() { net.Stop() })
 

--- a/tests/genesis_import/genesis_import_test.go
+++ b/tests/genesis_import/genesis_import_test.go
@@ -1,9 +1,10 @@
-package tests
+package genesis_import_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +14,7 @@ func TestGenesis_NetworkCanCreateNewBlocksAfterExportImport(t *testing.T) {
 	require := require.New(t)
 
 	tempDir := t.TempDir()
-	net, err := StartIntegrationTestNet(tempDir)
+	net, err := tests.StartIntegrationTestNet(tempDir)
 	require.NoError(err)
 
 	// Produce a few blocks on the network.

--- a/tests/initcode_test/initcode_test.go
+++ b/tests/initcode_test/initcode_test.go
@@ -1,10 +1,11 @@
-package tests
+package initcode_test
 
 import (
 	"context"
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/contractcreator"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -20,11 +21,11 @@ const sufficientGas = uint64(100_000)
 func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	requireBase := require.New(t)
 
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	requireBase.NoError(err)
 	defer net.Stop()
 
-	contract, receipt, err := DeployContract(net, contractcreator.DeployContractcreator)
+	contract, receipt, err := tests.DeployContract(net, contractcreator.DeployContractcreator)
 	requireBase.NoError(err)
 	requireBase.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed to deploy contract")
 
@@ -52,7 +53,7 @@ func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	})
 }
 
-func testForVariant(t *testing.T, net *IntegrationTestNet,
+func testForVariant(t *testing.T, net *tests.IntegrationTestNet,
 	contract *contractcreator.Contractcreator, variant variant,
 	gasForContract, wordCost uint64) {
 
@@ -104,7 +105,7 @@ func testForVariant(t *testing.T, net *IntegrationTestNet,
 	})
 }
 
-func testForTransaction(t *testing.T, net *IntegrationTestNet) {
+func testForTransaction(t *testing.T, net *tests.IntegrationTestNet) {
 	t.Run("charges depending on the init code size", func(t *testing.T) {
 		require := require.New(t)
 		// transactions charge 4 gas for each zero byte in data.
@@ -139,7 +140,7 @@ func testForTransaction(t *testing.T, net *IntegrationTestNet) {
 	})
 }
 
-func createContractSuccessfully(t *testing.T, net *IntegrationTestNet, variant variant, codeLen, gasLimit uint64) *types.Receipt {
+func createContractSuccessfully(t *testing.T, net *tests.IntegrationTestNet, variant variant, codeLen, gasLimit uint64) *types.Receipt {
 	receipt, err := createContractWithCodeLenAndGas(net, variant, codeLen, gasLimit)
 	require := require.New(t)
 	require.NoError(err)
@@ -147,7 +148,7 @@ func createContractSuccessfully(t *testing.T, net *IntegrationTestNet, variant v
 	return receipt
 }
 
-func createContractWithCodeLenAndGas(net *IntegrationTestNet, variant variant, codeLen, gasLimit uint64) (*types.Receipt, error) {
+func createContractWithCodeLenAndGas(net *tests.IntegrationTestNet, variant variant, codeLen, gasLimit uint64) (*types.Receipt, error) {
 	return net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		opts.GasLimit = gasLimit
 		return variant(opts, big.NewInt(int64(codeLen)))
@@ -156,7 +157,7 @@ func createContractWithCodeLenAndGas(net *IntegrationTestNet, variant variant, c
 
 type variant func(opts *bind.TransactOpts, codeSize *big.Int) (*types.Transaction, error)
 
-func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, codeSize, gas uint64) (*types.Receipt, error) {
+func runTransactionWithCodeSizeAndGas(t *testing.T, net *tests.IntegrationTestNet, codeSize, gas uint64) (*types.Receipt, error) {
 	require := require.New(t)
 	// these values are needed for the transaction but are irrelevant for the test
 	client, err := net.GetClient()
@@ -166,7 +167,7 @@ func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, cod
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.validator.Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetValidatorAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	price, err := client.SuggestGasPrice(context.Background())
@@ -180,7 +181,7 @@ func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, cod
 		To:       nil,
 		Nonce:    nonce,
 		Data:     make([]byte, codeSize),
-	}), types.NewLondonSigner(chainId), net.validator.PrivateKey)
+	}), types.NewLondonSigner(chainId), net.GetValidatorAccount().PrivateKey)
 	require.NoError(err, "failed to sign transaction:")
 	return net.Run(transaction)
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -547,6 +547,10 @@ func (n *IntegrationTestNet) GetHeaders() ([]*types.Header, error) {
 	return headers, nil
 }
 
+func (n *IntegrationTestNet) GetValidatorAccount() *Account {
+	return &n.validator
+}
+
 // DeployContract is a utility function handling the deployment of a contract on the network.
 // The contract is deployed with by the network's validator account. The function returns the
 // deployed contract instance and the transaction receipt.

--- a/tests/invalid_start/invalid_start_test.go
+++ b/tests/invalid_start/invalid_start_test.go
@@ -1,9 +1,10 @@
-package tests
+package invalid_start
 
 import (
 	"context"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/invalidstart"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -15,12 +16,12 @@ func TestInvalidStart_IdentifiesInvalidStartContract(t *testing.T) {
 	invalidCode := []byte{0x60, 0xef, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
 	validCode := []byte{0x60, 0xfe, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
 
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	r.NoError(err)
 	defer net.Stop()
 
 	// Deploy the invalid start contract.
-	contract, _, err := DeployContract(net, invalidstart.DeployInvalidstart)
+	contract, _, err := tests.DeployContract(net, invalidstart.DeployInvalidstart)
 	r.NoError(err)
 
 	// -- invalid codes
@@ -62,7 +63,7 @@ func TestInvalidStart_IdentifiesInvalidStartContract(t *testing.T) {
 	r.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on transfer to empty receiver with valid code")
 }
 
-func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net *IntegrationTestNet) (*types.Transaction, error) {
+func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net *tests.IntegrationTestNet) (*types.Transaction, error) {
 	// these values are needed for the transaction but are irrelevant for the test
 	client, err := net.GetClient()
 	r.NoError(err, "failed to connect to the network:")
@@ -71,7 +72,7 @@ func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net
 	chainId, err := client.ChainID(context.Background())
 	r.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.validator.Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetValidatorAccount().Address(), nil)
 	r.NoError(err, "failed to get nonce:")
 
 	price, err := client.SuggestGasPrice(context.Background())
@@ -85,7 +86,7 @@ func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net
 		To:       nil,
 		Nonce:    nonce,
 		Data:     code,
-	}), types.NewLondonSigner(chainId), net.validator.PrivateKey)
+	}), types.NewLondonSigner(chainId), net.GetValidatorAccount().PrivateKey)
 	r.NoError(err, "failed to sign transaction:")
 
 	return transaction, nil

--- a/tests/node_restart/node_restart_test.go
+++ b/tests/node_restart/node_restart_test.go
@@ -1,10 +1,11 @@
-package tests
+package node_restart_test
 
 import (
 	"context"
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,7 @@ func TestNodeRestart_CanRestartAndRestoreItsState(t *testing.T) {
 	const numRestarts = 2
 	require := require.New(t)
 
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(err)
 	defer net.Stop()
 

--- a/tests/prevrandao/prevrandao_test.go
+++ b/tests/prevrandao/prevrandao_test.go
@@ -1,21 +1,23 @@
-package tests
+package prevrandao_test
 
 import (
 	"context"
-	"github.com/Fantom-foundation/go-opera/tests/contracts/prevrandao"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"math/big"
 	"testing"
+
+	"github.com/Fantom-foundation/go-opera/tests"
+	"github.com/Fantom-foundation/go-opera/tests/contracts/prevrandao"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 func TestPrevRandao(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
 	// Deploy the contract.
-	contract, _, err := DeployContract(net, prevrandao.DeployPrevrandao)
+	contract, _, err := tests.DeployContract(net, prevrandao.DeployPrevrandao)
 	if err != nil {
 		t.Fatalf("failed to deploy contract; %v", err)
 	}

--- a/tests/self_destruct/selfdestruct_test.go
+++ b/tests/self_destruct/selfdestruct_test.go
@@ -1,4 +1,4 @@
-package tests
+package selfdestruct_test
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/selfdestruct"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -17,7 +18,7 @@ import (
 func TestSelfDestruct(t *testing.T) {
 	require := require.New(t)
 
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(err, "failed to start test network")
 	defer net.Stop()
 
@@ -30,10 +31,10 @@ func TestSelfDestruct(t *testing.T) {
 	})
 }
 
-func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
+func testSelfDestruct_Constructor(t *testing.T, net *tests.IntegrationTestNet) {
 	contractInitialBalance := int64(1234)
 
-	tests := map[string]struct {
+	cases := map[string]struct {
 		deployTx  deployTxFunction[selfdestruct.SelfDestruct]
 		executeTx executeTxFunction[selfdestruct.SelfDestruct]
 		effects   map[string]effectFunction
@@ -125,7 +126,7 @@ func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
 		},
 	}
 
-	for name, test := range tests {
+	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -134,7 +135,7 @@ func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
 			rand.Read(beneficiaryAddress[:])
 
 			// First transaction deploys contract
-			contract, deployReceipt, err := DeployContract(net,
+			contract, deployReceipt, err := tests.DeployContract(net,
 				func(to *bind.TransactOpts, cb bind.ContractBackend) (common.Address, *types.Transaction, *selfdestruct.SelfDestruct, error) {
 					return test.deployTx(to, cb, beneficiaryAddress)
 				})
@@ -184,10 +185,10 @@ func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
 	}
 }
 
-func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
+func testSelfDestruct_NestedCall(t *testing.T, net *tests.IntegrationTestNet) {
 	contractInitialBalance := int64(1234)
 
-	tests := map[string]struct {
+	cases := map[string]struct {
 		transactions []executeTxFunction[selfdestruct.SelfDestructFactory]
 		effects      map[string]effectFunction
 	}{
@@ -274,7 +275,7 @@ func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
 		},
 	}
 
-	for name, test := range tests {
+	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -283,7 +284,7 @@ func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
 			rand.Read(beneficiaryAddress[:])
 
 			// deploy factory contract
-			factory, receipt, err := DeployContract(net, selfdestruct.DeploySelfDestructFactory)
+			factory, receipt, err := tests.DeployContract(net, selfdestruct.DeploySelfDestructFactory)
 			require.NoError(err)
 			require.Equal(
 				types.ReceiptStatusSuccessful,

--- a/tests/transaction_gas_price/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price/transaction_gas_price_test.go
@@ -1,10 +1,11 @@
-package tests
+package transaction_gas_price
 
 import (
 	"context"
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -17,7 +18,7 @@ const enoughGasPrice = 150_000_000_000
 
 func TestTransactionGasPrice(t *testing.T) {
 
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(t, err)
 	defer net.Stop()
 
@@ -265,9 +266,9 @@ func TestTransactionGasPrice(t *testing.T) {
 
 // makeAccountWithBalance creates a new account and endows it with the given balance.
 // Creating the account this way allows to get access to the private key to sign transactions.
-func makeAccountWithBalance(t *testing.T, net *IntegrationTestNet, balance int64) *Account {
+func makeAccountWithBalance(t *testing.T, net *tests.IntegrationTestNet, balance int64) *tests.Account {
 	t.Helper()
-	account := NewAccount()
+	account := tests.NewAccount()
 	receipt, err := net.EndowAccount(account.Address(), balance)
 	require.NoError(t, err)
 	require.Equal(t,
@@ -296,7 +297,7 @@ func getBalance(t *testing.T, client *ethclient.Client, account common.Address) 
 func makeLegacyTx(t *testing.T,
 	client *ethclient.Client,
 	gasPrice int64,
-	sender *Account,
+	sender *tests.Account,
 ) *types.Transaction {
 	t.Helper()
 
@@ -326,7 +327,7 @@ func makeEip1559Transaction(t *testing.T,
 	client *ethclient.Client,
 	maxFeeCap int64,
 	maxGasTip int64,
-	sender *Account,
+	sender *tests.Account,
 ) *types.Transaction {
 	t.Helper()
 

--- a/tests/transaction_order/transaction_order_test.go
+++ b/tests/transaction_order/transaction_order_test.go
@@ -1,4 +1,4 @@
-package tests
+package transaction_order_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/counter_event_emitter"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -20,18 +21,18 @@ func TestTransactionOrder(t *testing.T) {
 		numBlocks   = uint64(3)
 		numTxs      = numAccounts * numPerAcc
 	)
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	require.NoError(t, err)
 	defer net.Stop()
 
-	contract, _, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
+	contract, _, err := tests.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(t, err)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	accounts := make([]*Account, 0, numAccounts)
+	accounts := make([]*tests.Account, 0, numAccounts)
 
 	// Only transactions from different accounts can change order.
 	for range numAccounts {
@@ -141,9 +142,9 @@ func TestTransactionOrder(t *testing.T) {
 
 // makeAccountWithMaxBalance creates a new account and endows it with math.MaxInt64 balance.
 // Creating the account this way allows to get access to the private key to sign transactions.
-func makeAccountWithMaxBalance(t *testing.T, net *IntegrationTestNet) *Account {
+func makeAccountWithMaxBalance(t *testing.T, net *tests.IntegrationTestNet) *tests.Account {
 	t.Helper()
-	account := NewAccount()
+	account := tests.NewAccount()
 	receipt, err := net.EndowAccount(account.Address(), math.MaxInt64)
 	require.NoError(t, err)
 	require.Equal(t,

--- a/tests/transient_storage/transientstorage_test.go
+++ b/tests/transient_storage/transientstorage_test.go
@@ -1,22 +1,23 @@
-package tests
+package transientstorage_test
 
 import (
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
 
 	// Deploy the transient storage contract
-	contract, _, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	contract, _, err := tests.DeployContract(net, transientstorage.DeployTransientstorage)
 	if err != nil {
 		t.Fatalf("failed to deploy contract; %v", err)
 	}
@@ -33,7 +34,7 @@ func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
 		t.Fatalf("failed to store value; %v", err)
 	}
 
-	// Check that the value was stored during transaction and emited to logs
+	// Check that the value was stored during transaction and emitted to logs
 	if len(receipt.Logs) != 1 {
 		t.Fatalf("unexpected number of logs; expected 1, got %d", len(receipt.Logs))
 	}

--- a/tests/withdrawals/withdrawals_test.go
+++ b/tests/withdrawals/withdrawals_test.go
@@ -1,4 +1,4 @@
-package tests
+package withdrawal_tests
 
 import (
 	"bytes"
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/Fantom-foundation/go-opera/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -16,7 +17,7 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	requireBase := require.New(t)
 
 	// start network.
-	net, err := StartIntegrationTestNet(t.TempDir())
+	net, err := tests.StartIntegrationTestNet(t.TempDir())
 	requireBase.NoErrorf(err, "Failed to start the fake network: ", err)
 	defer net.Stop()
 


### PR DESCRIPTION
This PR segregates the different integration tests into their own package names. Therefore, they will be compiled into separate binaries which `go test` will execute in parallel. 
This is done to speedup execution of unit tests, which during race detection can easily exceed timeout settings. 

In addition:
- Count and test-net-test reuse running integration networks to avoid overhead
- Timeout time for the integration network startup has been increased to 5 minutes. Because race-enabled tests would time-out during initialization of the network, and produce false positives. 

This pr is part of https://github.com/Fantom-foundation/sonic-admin/issues/50
This pr helps towards https://github.com/Fantom-foundation/sonic-admin/issues/47.
