### PR TITLE
Integration of Sonic's per-block base-fee adjustment

### DIFF
--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -17,7 +17,6 @@
 package evmcore
 
 import (
-	"encoding/binary"
 	"math"
 	"math/big"
 	"time"
@@ -135,9 +134,6 @@ func (h *EvmHeader) EthHeader() *types.Header {
 	if h == nil {
 		return nil
 	}
-	extra := make([]byte, 16)
-	binary.BigEndian.PutUint64(extra[:8], uint64(h.Time))
-	binary.BigEndian.PutUint64(extra[8:], uint64(h.Duration))
 	// NOTE: incomplete conversion
 	ethHeader := &types.Header{
 		Number:     h.Number,
@@ -148,7 +144,7 @@ func (h *EvmHeader) EthHeader() *types.Header {
 		TxHash:     h.TxHash,
 		ParentHash: h.ParentHash,
 		Time:       uint64(h.Time.Unix()),
-		Extra:      extra,
+		Extra:      inter.EncodeExtraData(h.Time.Time(), h.Duration),
 		BaseFee:    h.BaseFee,
 
 		Difficulty: new(big.Int),
@@ -195,7 +191,6 @@ type EvmBlockJson struct {
 }
 
 func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
-	ethHeader := h.EthHeader()
 	enc := &EvmHeaderJson{
 		Number:          (*hexutil.Big)(h.Number),
 		Miner:           h.Coinbase,
@@ -207,7 +202,7 @@ func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
 		UncleHash:       types.EmptyUncleHash,
 		Time:            hexutil.Uint64(h.Time.Unix()),
 		TimeNano:        hexutil.Uint64(h.Time),
-		Extra:           ethHeader.Extra,
+		Extra:           inter.EncodeExtraData(h.Time.Time(), h.Duration),
 		BaseFee:         (*hexutil.Big)(h.BaseFee),
 		Difficulty:      new(hexutil.Big),
 		PrevRandao:      h.PrevRandao,

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -102,6 +102,7 @@ func ToEvmHeader(block *inter.Block, prevHash common.Hash, rules opera.Rules) *E
 		Root:            block.StateRoot,
 		Number:          big.NewInt(int64(block.Number)),
 		Time:            block.Time,
+		Duration:        time.Duration(block.Duration) * time.Nanosecond,
 		GasLimit:        block.GasLimit,
 		GasUsed:         block.GasUsed,
 		BaseFee:         baseFee,

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -65,7 +65,7 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 		WithTime(evmcore.FakeGenesisTime-1). // TODO: extend genesis generator to provide time
 		WithGasLimit(gasLimit).
 		WithStateRoot(common.Hash{}). // TODO: get proper state root from genesis data
-		WithBaseFee(big.NewInt(0)).   // TODO: set initial base fee according to the rules
+		WithBaseFee(gasprice.GetInitialBaseFee(rules.Economy)).
 		Build(),
 	)
 

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -77,14 +77,11 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 		if rules.Upgrades.Sonic {
 			block := s.GetBlock(br.Idx - 1)
 			if block == nil {
-				block = &inter.Block{
-					BaseFee: big.NewInt(0),
-				}
+				block = &inter.Block{BaseFee: new(big.Int)}
 			}
 			header := &evmcore.EvmHeader{
-				GasUsed:  block.GasUsed,
-				GasLimit: block.GasLimit,
-				BaseFee:  block.BaseFee,
+				GasUsed: block.GasUsed,
+				BaseFee: block.BaseFee,
 			}
 			baseFee = gasprice.GetBaseFeeForNextBlock(header, rules.Economy)
 			duration = time.Duration(br.Time-block.Time) * time.Nanosecond

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip/blockproc"
+	"github.com/Fantom-foundation/go-opera/gossip/gasprice"
 	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/inter/state"
 	"github.com/Fantom-foundation/go-opera/opera"
@@ -32,8 +33,13 @@ func (p *EVMModule) Start(
 	prevrandao common.Hash,
 ) blockproc.EVMProcessor {
 	var prevBlockHash common.Hash
-	if block.Idx != 0 {
-		prevBlockHash = reader.GetHeader(common.Hash{}, uint64(block.Idx-1)).Hash
+	var baseFee *big.Int
+	if block.Idx == 0 {
+		baseFee = gasprice.GetInitialBaseFee(net.Economy)
+	} else {
+		header := reader.GetHeader(common.Hash{}, uint64(block.Idx-1))
+		prevBlockHash = header.Hash
+		baseFee = gasprice.GetBaseFeeForNextBlock(header, net.Economy)
 	}
 
 	// Start block
@@ -49,6 +55,7 @@ func (p *EVMModule) Start(
 		blockIdx:      utils.U64toBig(uint64(block.Idx)),
 		prevBlockHash: prevBlockHash,
 		prevRandao:    prevrandao,
+		gasBaseFee:    baseFee,
 	}
 }
 
@@ -62,6 +69,7 @@ type OperaEVMProcessor struct {
 
 	blockIdx      *big.Int
 	prevBlockHash common.Hash
+	gasBaseFee    *big.Int
 
 	gasUsed uint64
 
@@ -75,6 +83,8 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 	baseFee := p.net.Economy.MinGasPrice
 	if !p.net.Upgrades.London {
 		baseFee = nil
+	} else if p.net.Upgrades.Sonic {
+		baseFee = p.gasBaseFee
 	}
 
 	prevRandao := common.Hash{}

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -50,14 +50,14 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 		nil,
 		nil,
 		opera.Rules{
+			Blocks: opera.BlocksRules{
+				MaxBlockGas: 1e10,
+			},
 			Economy: opera.EconomyRules{
 				MinGasPrice: big.NewInt(12), // > than 0 offered by the internal transactions
 			},
 			Upgrades: opera.Upgrades{
 				London: true,
-			},
-			Blocks: opera.BlocksRules{
-				MaxBlockGas: 1e12,
 			},
 		},
 		&params.ChainConfig{

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -50,14 +50,14 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 		nil,
 		nil,
 		opera.Rules{
-			Blocks: opera.BlocksRules{
-				MaxBlockGas: 1e10,
-			},
 			Economy: opera.EconomyRules{
 				MinGasPrice: big.NewInt(12), // > than 0 offered by the internal transactions
 			},
 			Upgrades: opera.Upgrades{
 				London: true,
+			},
+			Blocks: opera.BlocksRules{
+				MaxBlockGas: 1e12,
 			},
 		},
 		&params.ChainConfig{

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -227,13 +227,15 @@ func consensusCallbackBeginBlockFn(
 					number := uint64(blockCtx.Idx)
 					lastBlockHeader := evmStateReader.GetHeaderByNumber(number - 1)
 					maxBlockGas := es.Rules.Blocks.MaxBlockGas
+					blockDuration := time.Duration(blockCtx.Time - bs.LastBlock.Time)
 					blockBuilder := inter.NewBlockBuilder().
 						WithEpoch(es.Epoch).
 						WithNumber(number).
 						WithParentHash(lastBlockHeader.Hash).
 						WithTime(blockCtx.Time).
 						WithPrevRandao(prevRandao).
-						WithGasLimit(maxBlockGas)
+						WithGasLimit(maxBlockGas).
+						WithDuration(blockDuration)
 
 					for i := range preInternalTxs {
 						blockBuilder.AddTransaction(
@@ -348,6 +350,7 @@ func consensusCallbackBeginBlockFn(
 
 					block := blockBuilder.Build()
 					evmBlock.Hash = block.Hash()
+					evmBlock.Duration = blockDuration
 
 					for _, tx := range blockBuilder.GetTransactions() {
 						store.evm.SetTx(tx.Hash(), tx)

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -2,12 +2,13 @@ package gossip
 
 import (
 	"fmt"
-	"github.com/Fantom-foundation/go-opera/utils/signers/gsignercache"
 	"math/big"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Fantom-foundation/go-opera/utils/signers/gsignercache"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"
@@ -381,17 +382,13 @@ func consensusCallbackBeginBlockFn(
 						feed.newLogs.Send(logs)
 					}
 
-					lastBlockTime := evmStateReader.GetHeader(common.Hash{}, uint64(blockCtx.Idx-1)).Time.Time()
-					thisBlockTime := block.Time.Time()
-					blockTime := thisBlockTime.Sub(lastBlockTime)
-
 					now := time.Now()
 					blockAge := now.Sub(block.Time.Time())
 					log.Info("New block",
 						"index", blockCtx.Idx,
 						"id", block.Hash(),
 						"gas_used", evmBlock.GasUsed,
-						"gas_rate", float64(evmBlock.GasUsed)/blockTime.Seconds(),
+						"gas_rate", float64(evmBlock.GasUsed)/blockDuration.Seconds(),
 						"base_fee", evmBlock.BaseFee.String(),
 						"txs", fmt.Sprintf("%d/%d", len(evmBlock.Transactions), len(skippedTxs)),
 						"age", utils.PrettyDuration(blockAge),

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -25,7 +26,7 @@ func indexRawReceipts(s *Store, receiptsForStorage []*types.ReceiptForStorage, t
 	}
 }
 
-func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, gasLimit uint64, br ibr.LlrIdxFullBlockRecord) {
+func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, gasLimit uint64, duration time.Duration, br ibr.LlrIdxFullBlockRecord) {
 	for _, tx := range br.Txs {
 		s.EvmStore().SetTx(tx.Hash(), tx)
 	}
@@ -56,6 +57,7 @@ func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, ga
 		WithGasUsed(br.GasUsed).
 		WithBaseFee(baseFee).
 		WithPrevRandao(common.Hash{1})
+		// TODO: add duration
 
 	for i := range br.Txs {
 		copy := types.Receipt(*br.Receipts[i])

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -56,8 +56,8 @@ func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, ga
 		WithGasLimit(gasLimit).
 		WithGasUsed(br.GasUsed).
 		WithBaseFee(baseFee).
-		WithPrevRandao(common.Hash{1})
-		// TODO: add duration
+		WithPrevRandao(common.Hash{1}).
+		WithDuration(duration)
 
 	for i := range br.Txs {
 		copy := types.Receipt(*br.Receipts[i])

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -136,7 +136,9 @@ type dummyHeaderReturner struct {
 }
 
 func (d dummyHeaderReturner) GetHeader(common.Hash, uint64) *evmcore.EvmHeader {
-	return &evmcore.EvmHeader{}
+	return &evmcore.EvmHeader{
+		BaseFee: big.NewInt(0),
+	}
 }
 
 func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types.Transactions) error {

--- a/tests/address_access_test.go
+++ b/tests/address_access_test.go
@@ -53,6 +53,8 @@ func TestAddressAccess(t *testing.T) {
 			"origin":   contract.TouchOrigin,
 			"access list": func(ops *bind.TransactOpts) (*types.Transaction, error) {
 				ops.GasPrice = nil // < transactions with gas price cannot have access list
+				ops.GasFeeCap = big.NewInt(1e12)
+				ops.GasTipCap = big.NewInt(1000)
 				ops.AccessList = types.AccessList{
 					{Address: someAccountAddress},
 				}


### PR DESCRIPTION
This PR integrates Sonic's base-fee adjustment algorithm into the Sonic client. After this PR, base-fees are updated with each block and no longer determined at the epoch boundary.

To integrate this feature, two additional values need to be stored in blocks:
- the nano-second part of the block **time**, using 4 bytes
- the **block duration**, defined as the duration in nanoseconds between the a block's predecessor and the block itself (8 bytes)

Both values are required for the computation of base-fee prices. Since fields can not be arbitrarily added to blocks, a pre-existing, previously unused 32-byte "extra-data" fields was used. The two new values are stored in big endian format in the first 12 bytes of this value.

Besides these changes, this PR also fixes the handling of the `GasLimit` field in blocks, which previously was filled with `math.MaxUint64` but presented to RPC clients as the 6-byte value `0xffffffffffff` presumably in order to avoid parsing or overflow errors for client code using signed 64-bit integers. With this change, an actual value -- the `rules.Blocks.MaxBlockGas` of the network configuration rules -- is used as the Gas limit per block.