### PR TITLE
Add configurable structured logs limit for RPC debug

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -131,6 +131,8 @@ func initFlags() {
 		flags.RPCGlobalTimeoutFlag,
 		flags.BatchRequestLimit,
 		flags.BatchResponseMaxSize,
+		flags.MaxResponseSizeFlag,
+		flags.StructLogLimitFlag,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/config/config.go
+++ b/config/config.go
@@ -176,7 +176,12 @@ func gossipConfigWithFlags(ctx *cli.Context, src gossip.Config) gossip.Config {
 	if ctx.GlobalIsSet(flags.RPCGlobalTimeoutFlag.Name) {
 		cfg.RPCTimeout = ctx.GlobalDuration(flags.RPCGlobalTimeoutFlag.Name)
 	}
-
+	if ctx.GlobalIsSet(flags.MaxResponseSizeFlag.Name) {
+		cfg.MaxResponseSize = ctx.GlobalInt(flags.MaxResponseSizeFlag.Name)
+	}
+	if ctx.IsSet(flags.StructLogLimitFlag.Name) {
+		cfg.StructLogLimit = ctx.GlobalInt(flags.StructLogLimitFlag.Name)
+	}
 	return cfg
 }
 

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -309,7 +309,7 @@ var (
 	}
 	StructLogLimitFlag = cli.IntFlag{
 		Name:  "rpc.structloglimit",
-		Usage: "Limit maximum number of debug logs for structured EVM logs",
+		Usage: "Limit maximum number of debug logs for structured EVM logs, 0=unlimited, negative value means no log results",
 		Value: gossip.DefaultConfig(cachescale.Identity).StructLogLimit,
 	}
 	ModeFlag = cli.StringFlag{

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -307,6 +307,11 @@ var (
 		Usage: "Limit maximum size in some RPC calls execution",
 		Value: gossip.DefaultConfig(cachescale.Identity).MaxResponseSize,
 	}
+	StructLogLimitFlag = cli.IntFlag{
+		Name:  "rpc.structloglimit",
+		Usage: "Limit maximum number of debug logs for structured EVM logs",
+		Value: gossip.DefaultConfig(cachescale.Identity).StructLogLimit,
+	}
 	ModeFlag = cli.StringFlag{
 		Name:  "mode",
 		Usage: `Mode of the node ("rpc" or "validator")`,

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2045,7 +2045,9 @@ func (api *PublicDebugAPI) traceTx(ctx context.Context, tx *types.Transaction, m
 		if config.Config == nil {
 			config.Config = &logger.Config{Limit: api.structLogLimit}
 		} else {
-			if api.structLogLimit > 0 && config.Config.Limit > api.structLogLimit {
+			if api.structLogLimit > 0 &&
+				(config.Config.Limit == 0 || config.Config.Limit > api.structLogLimit) {
+
 				config.Config.Limit = api.structLogLimit
 			}
 		}

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -89,6 +89,9 @@ type (
 		// MaxResponseSize is a limit for maximum response size in some RPC calls in bytes
 		MaxResponseSize int
 
+		// StructLogLimit is a limit for maximum number of logs in structured EVM debug log
+		StructLogLimit int
+
 		RPCBlockExt bool
 	}
 
@@ -197,6 +200,7 @@ func DefaultConfig(scale cachescale.Func) Config {
 		RPCTimeout:  5 * time.Second,
 
 		MaxResponseSize: 25 * 1024 * 1024,
+		StructLogLimit:  2000,
 	}
 	sessionCfg := cfg.Protocol.DagStreamLeecher.Session
 	cfg.Protocol.DagProcessor.EventsBufferLimit.Num = idx.Event(sessionCfg.ParallelChunksDownload)*

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -404,7 +404,7 @@ func (s *Service) APIs() []rpc.API {
 		}, {
 			Namespace: "debug",
 			Version:   "1.0",
-			Service:   ethapi.NewPublicDebugAPI(s.EthAPI, s.config.MaxResponseSize),
+			Service:   ethapi.NewPublicDebugAPI(s.EthAPI, s.config.MaxResponseSize, s.config.StructLogLimit),
 			Public:    true,
 		}, {
 			Namespace: "trace",


### PR DESCRIPTION
This PR introduces configurable limit for number of logs, created during debug of EVM with debug namespace
Parameter:
- `rpc.structloglimit `

Default set to 2000 logs