### PR TITLE
Add integration test for transaction gas prices.

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -69,7 +69,7 @@ var (
 	// configured for the transaction pool.
 	ErrUnderpriced = errors.New("transaction underpriced")
 
-	// ErrTxPoolOverflow is returned if the transaction pool is full and can't accpet
+	// ErrTxPoolOverflow is returned if the transaction pool is full and can't accept
 	// another remote transaction.
 	ErrTxPoolOverflow = errors.New("txpool is full")
 
@@ -706,8 +706,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Ensure Opera-specific hard bounds
 	if recommendedGasTip, minPrice := pool.chain.EffectiveMinTip(), pool.chain.MinGasPrice(); recommendedGasTip != nil && minPrice != nil {
-		if tx.GasTipCapIntCmp(recommendedGasTip) < 0 {
-			log.Trace("Rejecting underpriced tx: recommendedGasTip", "recommendedGasTip", recommendedGasTip, "tx.GasTipCap", tx.GasTipCap())
+		if tx.GasTipCap().Sign() < 0 {
+			log.Trace("Rejecting underpriced tx: negative tip", "GasTipCap", tx.GasTipCap())
 			return ErrUnderpriced
 		}
 		if tx.GasFeeCapIntCmp(new(big.Int).Add(recommendedGasTip, minPrice)) < 0 {

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// constant large enough to satisfied tx validation checks
+// Constant large enough to satisfied tx validation checks
 // deduced from net rules minimum gas price
 const enoughGasPrice = 150_000_000_000
 
@@ -56,7 +56,7 @@ func TestTransactionGasPrice(t *testing.T) {
 
 		// 3: checks
 		t.Run("Transaction gas price >= BaseFee  ", func(t *testing.T) {
-			basefeeAfter := getBaseFee(t, client)
+			basefeeAfter := getBaseFeeAt(t, receipt.BlockNumber, client)
 			require.GreaterOrEqual(t,
 				receipt.EffectiveGasPrice.Int64(), basefeeAfter,
 				"effective gas price is less than base fee")
@@ -65,9 +65,9 @@ func TestTransactionGasPrice(t *testing.T) {
 		t.Run("Account is charged gas price * gas used + balance transfer", func(t *testing.T) {
 			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
 			balance := getBalance(t, client, account.Address())
-			ballanceDifference := balanceBefore - balance
+			balanceDifference := balanceBefore - balance
 			require.Equal(t,
-				ballanceDifference,
+				balanceDifference,
 				int64(costCharged),
 				"changed wrong balance amount",
 			)
@@ -106,7 +106,7 @@ func TestTransactionGasPrice(t *testing.T) {
 			types.ReceiptStatusSuccessful,
 			"transaction execution failed",
 		)
-		basefeeAfter := getBaseFee(t, client)
+		basefeeAfter := getBaseFeeAt(t, receipt.BlockNumber, client)
 
 		// 3: checks
 		t.Run("BaseFee <= EffectiveGasPrice <= maxGasPrice", func(t *testing.T) {
@@ -123,9 +123,9 @@ func TestTransactionGasPrice(t *testing.T) {
 
 			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
 			balance := getBalance(t, client, account.Address())
-			ballanceDifference := balanceBefore - balance
+			balanceDifference := balanceBefore - balance
 			require.Equal(t,
-				ballanceDifference,
+				balanceDifference,
 				int64(costCharged),
 				"changed wrong balance amount",
 			)
@@ -169,7 +169,7 @@ func TestTransactionGasPrice(t *testing.T) {
 			types.ReceiptStatusSuccessful,
 			"transaction execution failed",
 		)
-		basefeeAfter := getBaseFee(t, client)
+		basefeeAfter := getBaseFeeAt(t, receipt.BlockNumber, client)
 
 		// 3: checks
 		t.Run("BaseFee <= EffectiveGasPrice <= maxGasPrice  ", func(t *testing.T) {
@@ -186,9 +186,9 @@ func TestTransactionGasPrice(t *testing.T) {
 
 			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
 			balance := getBalance(t, client, account.Address())
-			ballanceDifference := balanceBefore - balance
+			balanceDifference := balanceBefore - balance
 			require.Equal(t,
-				ballanceDifference,
+				balanceDifference,
 				int64(costCharged),
 				"changed wrong balance amount",
 			)
@@ -229,7 +229,7 @@ func TestTransactionGasPrice(t *testing.T) {
 			types.ReceiptStatusSuccessful,
 			"transaction execution failed",
 		)
-		basefeeAfter := getBaseFee(t, client)
+		basefeeAfter := getBaseFeeAt(t, receipt.BlockNumber, client)
 
 		// 3: checks
 		t.Run("BaseFee <= EffectiveGasPrice <= maxGasPrice  ", func(t *testing.T) {
@@ -246,9 +246,9 @@ func TestTransactionGasPrice(t *testing.T) {
 
 			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
 			balance := getBalance(t, client, account.Address())
-			ballanceDifference := balanceBefore - balance
+			balanceDifference := balanceBefore - balance
 			require.Equal(t,
-				ballanceDifference,
+				balanceDifference,
 				int64(costCharged),
 				"changed wrong balance amount",
 			)
@@ -276,9 +276,9 @@ func makeAccountWithBalance(t *testing.T, net *IntegrationTestNet, balance int64
 	return account
 }
 
-func getBaseFee(t *testing.T, client *ethclient.Client) int64 {
+func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *ethclient.Client) int64 {
 	t.Helper()
-	block, err := client.BlockByNumber(context.Background(), nil)
+	block, err := client.BlockByNumber(context.Background(), blockNumber)
 	require.NoError(t, err)
 	basefee := block.BaseFee()
 	return basefee.Int64()

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -82,15 +82,14 @@ func TestTransactionGasPrice(t *testing.T) {
 		})
 	})
 
-	t.Run("EIP-1559 transaction max gas price", func(t *testing.T) {
+	t.Run("EIP-1559 transaction no tip", func(t *testing.T) {
 
 		// This test:
 		// 1. Compute a valid maximum gas price
 		// 2. Sends an EIP-1559 transaction with specified gas price (max fee)
 		// 3. Checks:
-		//    - effective gas price is greater or equal than basefee
-		//    - subtracted balance equals gas price * gas used + value transferred
 		//    - effective gas price is equal to the basefee
+		//    - subtracted balance equals gas price * gas used + value transferred
 
 		balanceBefore := getBalance(t, client, account.Address())
 
@@ -110,7 +109,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		basefeeAfter := getBaseFee(t, client)
 
 		// 3: checks
-		t.Run("Transaction gas price X;  BaseFee <= X <= maxGasPrice", func(t *testing.T) {
+		t.Run("BaseFee <= EffectiveGasPrice <= maxGasPrice", func(t *testing.T) {
 
 			require.LessOrEqual(t,
 				basefeeAfter, receipt.EffectiveGasPrice.Int64(),
@@ -173,7 +172,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		basefeeAfter := getBaseFee(t, client)
 
 		// 3: checks
-		t.Run("Transaction gas price X;  BaseFee <= X <= maxGasPrice  ", func(t *testing.T) {
+		t.Run("BaseFee <= EffectiveGasPrice <= maxGasPrice  ", func(t *testing.T) {
 
 			require.LessOrEqual(t,
 				basefeeAfter, receipt.EffectiveGasPrice.Int64(),
@@ -233,7 +232,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		basefeeAfter := getBaseFee(t, client)
 
 		// 3: checks
-		t.Run("Transaction gas price X;  BaseFee <= X <= maxGasPrice  ", func(t *testing.T) {
+		t.Run("BaseFee <= EffectiveGasPrice <= maxGasPrice  ", func(t *testing.T) {
 
 			require.LessOrEqual(t,
 				basefeeAfter, receipt.EffectiveGasPrice.Int64(),

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -1,0 +1,353 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+)
+
+// constant large enough to satisfied tx validation checks
+// deduced from net rules minimum gas price
+const enoughGasPrice = 150_000_000_000
+
+func TestTransactionGasPrice(t *testing.T) {
+
+	net, err := StartIntegrationTestNet(t.TempDir())
+	require.NoError(t, err)
+	defer net.Stop()
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// use a fresh account to send transactions from
+	account := makeAccountWithBalance(t, net, int64(1e18))
+
+	t.Run("Legacy transaction, effectivePrice is equal to requested price", func(t *testing.T) {
+
+		// This test:
+		// 1. Compute a valid gas price
+		// 2. Sends a Legacy transaction with specified gas price
+		// 3. Checks
+		//    - effective gas price is greater or equal than basefee
+		//    - subtracted balance equals gas price * gas used + value transferred
+		//    - effective gas price equals the specified price
+
+		balanceBefore := getBalance(t, client, account.Address())
+
+		// 1: gas price
+		var specifiedPrice int64 = enoughGasPrice
+
+		// 2: make & execute transaction
+		tx := makeLegacyTx(t, client, specifiedPrice, account)
+
+		receipt, err := net.Run(tx)
+		require.NoError(t, err)
+		require.Equal(t,
+			receipt.Status,
+			types.ReceiptStatusSuccessful,
+			"transaction execution failed",
+		)
+
+		// 3: checks
+		t.Run("Transaction gas price >= BaseFee  ", func(t *testing.T) {
+			basefeeAfter := getBaseFee(t, client)
+			require.GreaterOrEqual(t,
+				receipt.EffectiveGasPrice.Int64(), basefeeAfter,
+				"effective gas price is less than base fee")
+		})
+
+		t.Run("Account is charged gas price * gas used + balance transfer", func(t *testing.T) {
+			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
+			balance := getBalance(t, client, account.Address())
+			ballanceDifference := balanceBefore - balance
+			require.Equal(t,
+				ballanceDifference,
+				int64(costCharged),
+				"changed wrong balance amount",
+			)
+		})
+
+		t.Run("effective price equals specified price", func(t *testing.T) {
+			require.Equal(t,
+				specifiedPrice,
+				receipt.EffectiveGasPrice.Int64(),
+				"gas price does not match specified price",
+			)
+		})
+	})
+
+	t.Run("EIP-1559 transaction max gas price", func(t *testing.T) {
+
+		// This test:
+		// 1. Compute a valid maximum gas price
+		// 2. Sends an EIP-1559 transaction with specified gas price (max fee)
+		// 3. Checks:
+		//    - effective gas price is greater or equal than basefee
+		//    - subtracted balance equals gas price * gas used + value transferred
+		//    - effective gas price is equal to the basefee
+
+		balanceBefore := getBalance(t, client, account.Address())
+
+		// 1: gas price
+		const maxGasPrice int64 = enoughGasPrice
+
+		// 2: make & execute transaction
+		tx := makeEip1559Transaction(t, client, maxGasPrice, 0, account)
+
+		receipt, err := net.Run(tx)
+		require.NoError(t, err)
+		require.Equal(t,
+			receipt.Status,
+			types.ReceiptStatusSuccessful,
+			"transaction execution failed",
+		)
+		basefeeAfter := getBaseFee(t, client)
+
+		// 3: checks
+		t.Run("Transaction gas price X;  BaseFee <= X <= maxGasPrice", func(t *testing.T) {
+
+			require.LessOrEqual(t,
+				basefeeAfter, receipt.EffectiveGasPrice.Int64(),
+				"effective gas price is less than base fee")
+			require.LessOrEqual(t,
+				receipt.EffectiveGasPrice.Int64(), maxGasPrice,
+				"effective gas price is greater than maximum requested price")
+		})
+
+		t.Run("Account is charged gas price * gas used + balance transfer", func(t *testing.T) {
+
+			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
+			balance := getBalance(t, client, account.Address())
+			ballanceDifference := balanceBefore - balance
+			require.Equal(t,
+				ballanceDifference,
+				int64(costCharged),
+				"changed wrong balance amount",
+			)
+		})
+
+		t.Run("effective price equals basefee", func(t *testing.T) {
+			require.Equal(t,
+				basefeeAfter, receipt.EffectiveGasPrice.Int64(),
+				"gas price does not match specified price",
+			)
+		})
+
+	})
+
+	t.Run("EIP-1559 transaction with exact tip", func(t *testing.T) {
+
+		// This test:
+		// 1. Compute a valid maximum gas price
+		// 2. Sends an EIP-1559 transaction with specified gas price (max fee) and some priority fee
+		//    that can be charged whole. (basefee + tip <= maxGasPrice)
+		// 3. checks:
+		//    - effective gas price P; basefee <= P <= maxGasPrice
+		//    - subtracted balance equals gas price * gas used + value transferred
+		//    - effective gas price is equal to basefee + tip
+
+		balanceBefore := getBalance(t, client, account.Address())
+
+		// 1: gas price
+		// transaction will be accepted with maxGasPrice == minGasPrice
+		// but there will not be any room to charge the for the tip
+		const maxGasPrice int64 = enoughGasPrice
+		const tip = 17
+
+		// 2: make & execute transaction
+		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account)
+
+		receipt, err := net.Run(tx)
+		require.NoError(t, err)
+		require.Equal(t,
+			receipt.Status,
+			types.ReceiptStatusSuccessful,
+			"transaction execution failed",
+		)
+		basefeeAfter := getBaseFee(t, client)
+
+		// 3: checks
+		t.Run("Transaction gas price X;  BaseFee <= X <= maxGasPrice  ", func(t *testing.T) {
+
+			require.LessOrEqual(t,
+				basefeeAfter, receipt.EffectiveGasPrice.Int64(),
+				"effective gas price is less than base fee")
+			require.LessOrEqual(t,
+				receipt.EffectiveGasPrice.Int64(), maxGasPrice,
+				"effective gas price is greater than maximum requested price")
+		})
+
+		t.Run("Account is charged gas price * gas used + balance transfer", func(t *testing.T) {
+
+			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
+			balance := getBalance(t, client, account.Address())
+			ballanceDifference := balanceBefore - balance
+			require.Equal(t,
+				ballanceDifference,
+				int64(costCharged),
+				"changed wrong balance amount",
+			)
+		})
+
+		t.Run("effective price equals basefee + tip", func(t *testing.T) {
+			require.Equal(t,
+				basefeeAfter+tip, receipt.EffectiveGasPrice.Int64(),
+				"gas price does not match basefee + tip",
+			)
+		})
+	})
+
+	t.Run("EIP-1559 transaction with excessive tip", func(t *testing.T) {
+
+		// This test:
+		// 1. Compute a valid maximum gas price
+		// 2. Sends an EIP-1559 transaction with specified gas price (max fee) and some priority fee
+		//    that cannot be charged whole. (tip > maxGasPrice - basefee)
+		// 3. checks:
+		//    - effective gas price P; basefee <= P <= maxGasPrice
+		//    - subtracted balance equals gas price * gas used + value transferred
+		//    - effective gas price is equal to maxGasPrice (consumed by tip)
+
+		balanceBefore := getBalance(t, client, account.Address())
+
+		// 1: gas price
+		const maxGasPrice int64 = enoughGasPrice
+		const tip = maxGasPrice // tip cannot be larger than max gas price
+
+		// 2: make & execute transaction
+		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account)
+
+		receipt, err := net.Run(tx)
+		require.NoError(t, err)
+		require.Equal(t,
+			receipt.Status,
+			types.ReceiptStatusSuccessful,
+			"transaction execution failed",
+		)
+		basefeeAfter := getBaseFee(t, client)
+
+		// 3: checks
+		t.Run("Transaction gas price X;  BaseFee <= X <= maxGasPrice  ", func(t *testing.T) {
+
+			require.LessOrEqual(t,
+				basefeeAfter, receipt.EffectiveGasPrice.Int64(),
+				"effective gas price is less than base fee")
+			require.LessOrEqual(t,
+				receipt.EffectiveGasPrice.Int64(), maxGasPrice,
+				"effective gas price is greater than maximum requested price")
+		})
+
+		t.Run("Account is charged gas price * gas used + balance transfer", func(t *testing.T) {
+
+			costCharged := receipt.EffectiveGasPrice.Uint64()*receipt.GasUsed + tx.Value().Uint64()
+			balance := getBalance(t, client, account.Address())
+			ballanceDifference := balanceBefore - balance
+			require.Equal(t,
+				ballanceDifference,
+				int64(costCharged),
+				"changed wrong balance amount",
+			)
+		})
+
+		t.Run("effective price equals max gas price", func(t *testing.T) {
+			require.Equal(t,
+				maxGasPrice, receipt.EffectiveGasPrice.Int64(),
+				"gas price does not match expected price",
+			)
+		})
+	})
+}
+
+// makeAccountWithBalance creates a new account and endows it with the given balance.
+// Creating the account this way allows to get access to the private key to sign transactions.
+func makeAccountWithBalance(t *testing.T, net *IntegrationTestNet, balance int64) *Account {
+	t.Helper()
+	account := NewAccount()
+	receipt, err := net.EndowAccount(account.Address(), balance)
+	require.NoError(t, err)
+	require.Equal(t,
+		receipt.Status, types.ReceiptStatusSuccessful,
+		"endowing account failed")
+	return account
+}
+
+func getBaseFee(t *testing.T, client *ethclient.Client) int64 {
+	t.Helper()
+	block, err := client.BlockByNumber(context.Background(), nil)
+	require.NoError(t, err)
+	basefee := block.BaseFee()
+	return basefee.Int64()
+}
+
+func getBalance(t *testing.T, client *ethclient.Client, account common.Address) int64 {
+	t.Helper()
+	balance, err := client.BalanceAt(context.Background(), account, nil)
+	require.NoError(t, err)
+	return balance.Int64()
+}
+
+// makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
+// and gas limit.
+func makeLegacyTx(t *testing.T,
+	client *ethclient.Client,
+	gasPrice int64,
+	sender *Account,
+) *types.Transaction {
+	t.Helper()
+
+	nonce, err := client.NonceAt(context.Background(), sender.Address(), nil)
+	require.NoError(t, err, "failed to get nonce for account", sender.Address())
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    nonce,
+		To:       &common.Address{},
+		Value:    big.NewInt(1),
+		Gas:      1e6,
+		GasPrice: big.NewInt(gasPrice),
+	})
+
+	chainId, err := client.ChainID(context.Background())
+	require.NoError(t, err, "failed to get chain ID")
+
+	signer := types.NewEIP155Signer(chainId)
+	tx, err = types.SignTx(tx, signer, sender.PrivateKey)
+	require.NoError(t, err, "failed to sign transaction")
+	return tx
+}
+
+// makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
+// and gas limit.
+func makeEip1559Transaction(t *testing.T,
+	client *ethclient.Client,
+	maxFeeCap int64,
+	maxGasTip int64,
+	sender *Account,
+) *types.Transaction {
+	t.Helper()
+
+	nonce, err := client.NonceAt(context.Background(), sender.Address(), nil)
+	require.NoError(t, err, "failed to get nonce for account", sender.Address())
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		Nonce:     nonce,
+		To:        &common.Address{},
+		Value:     big.NewInt(1),
+		Gas:       1e6,
+		GasFeeCap: big.NewInt(maxFeeCap),
+		GasTipCap: big.NewInt(maxGasTip),
+	})
+
+	chainId, err := client.ChainID(context.Background())
+	require.NoError(t, err, "failed to get chain ID")
+
+	signer := types.NewLondonSigner(chainId)
+	tx, err = types.SignTx(tx, signer, sender.PrivateKey)
+	require.NoError(t, err, "failed to sign transaction")
+	return tx
+}


### PR DESCRIPTION
This PR adds tests for the fields `max_fee_per_gas`,  `max_priority_fee_per_gas` in dynamic fee transactions (Type 1, eip-1559) and `gasPrice` in legacy transactions (type 0).

All transactions have the following properties:
- balance is reduced by an amount of gas equal to `effectiveGasPrice * transactionGasCost`

Dynamic pricing transactions have the following properties:
- `effectiveGasPrice` is equal to `baseFee + Tip`
- `baseFee <= effectiveGasPrice <= MaxGasFee`
- `baseFee + Tip == MaxGasFee` ⇆  `Tip < MaxTip`  (tipping will not exceed the maximum price allowed) 

Legacy transactions have the following properties: (section Backwards Compatibility in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559))
 - `effectiveGasPrice` is equal to `GasPrice` specified in transaction. 
 - `effectiveGasPrice >= baseFee`. (difference is consumed)
 
#### Modification to tx_pool validation:

The existing transaction validation carried out by the pool contains a policy that makes tipping mandatory under some scenarios. This PR replaces the check with a relaxed constraint:
`EffectiveMinTip()` computes the difference between the last Block basefee and the configured `MinGasPrice()`. If this difference is greater than 0, tip becomes mandatory. [here](https://github.com/Fantom-foundation/Sonic/blob/15cea75195c90aaa44b8c2e8f5fbe025f39e4cde/gossip/evm_state_reader.go#L32)
On the other hand, the transaction submitted can have a `max_fee_per_gas`  large enough to accommodate for price increase without needing to tip. 

The test has been removed with a positive tip instead of completely deleted to remain conservative. This check is somehow redundant because negative big.Int cannot be serialized. I not sure how is the tip treated later or before this line, and negative tipping would have bad consequences.

 This pr is part of https://github.com/Fantom-foundation/sonic-admin/issues/63
