### PR TITLE
Add debug_traceCall RPC function

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2231,6 +2231,15 @@ func (api *PublicDebugAPI) stateAtTransaction(ctx context.Context, block *evmcor
 	return nil, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash)
 }
 
+// TraceCallConfig is the config for traceCall API. It holds one more
+// field to override the state for tracing.
+type TraceCallConfig struct {
+	tracers.TraceConfig
+	StateOverrides *StateOverride
+	TxIndex        *hexutil.Uint
+}
+
+
 // PrivateDebugAPI is the collection of Ethereum APIs exposed over the private
 // debugging endpoint.
 type PrivateDebugAPI struct {

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -145,9 +145,12 @@ func ApplyTransactionWithEVM(msg *core.Message, config *params.ChainConfig, gp *
 		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 	}
 
-	// Set the receipt logs and create the bloom filter.
-	receipt.Logs = statedb.GetLogs(tx.Hash(), blockHash)
-	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	// Tracing doesn't need logs and bloom.
+	if evm.Config.Tracer == nil {
+		// Set the receipt logs and create the bloom filter.
+		receipt.Logs = statedb.GetLogs(tx.Hash(), blockHash) // don't store logs when tracing
+		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	}
 	receipt.BlockHash = blockHash
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())


### PR DESCRIPTION
This PR adds possibility to debug **non historical** transactions. Similar to `eth_call` function, `debug_traceCall` function can run a transaction with EVM and obtain result and traces of the EVM run.

Added function:
- `debug_traceCall`

Refers to https://github.com/Fantom-foundation/sonic-admin/issues/54