### PR TITLE
Use block-header hashes to address blocks

### DIFF
--- a/cmd/sonictool/check/archive.go
+++ b/cmd/sonictool/check/archive.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/io"
 	carmen "github.com/Fantom-foundation/Carmen/go/state"
+	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/ethereum/go-ethereum/log"
@@ -47,7 +48,7 @@ func checkArchiveBlockRoots(dataDir string, cacheRatio cachescale.Func) error {
 		if block == nil {
 			return fmt.Errorf("verification failed - unable to get block %d from gdb", i)
 		}
-		err = gdb.EvmStore().CheckArchiveStateHash(i, block.Root)
+		err = gdb.EvmStore().CheckArchiveStateHash(i, hash.Hash(block.StateRoot))
 		if err != nil {
 			log.Error("Block root verification failed", "block", i, "err", err)
 			invalidBlocks++

--- a/cmd/sonictool/check/live.go
+++ b/cmd/sonictool/check/live.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/io"
 	carmen "github.com/Fantom-foundation/Carmen/go/state"
+	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -44,7 +45,7 @@ func checkLiveBlockRoot(dataDir string, cacheRatio cachescale.Func) error {
 	if lastBlock == nil {
 		return fmt.Errorf("verification failed - unable to get the last block (%d) from gdb", lastBlockIdx)
 	}
-	err = gdb.EvmStore().CheckLiveStateHash(lastBlockIdx, lastBlock.Root)
+	err = gdb.EvmStore().CheckLiveStateHash(lastBlockIdx, hash.Hash(lastBlock.StateRoot))
 	if err != nil {
 		return fmt.Errorf("checking live state failed: %w", err)
 	}

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -799,7 +799,7 @@ func (s *PublicBlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.H
 
 func (s *PublicBlockChainAPI) getBlockReceipts(ctx context.Context, blkNumber rpc.BlockNumber) (types.Receipts, error) {
 	if blkNumber == rpc.EarliestBlockNumber {
-		return nil, nil
+		return types.Receipts{}, nil
 	}
 	return s.b.GetReceiptsByNumber(ctx, blkNumber)
 }

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -99,7 +99,7 @@ func ToEvmHeader(block *inter.Block, prevHash common.Hash, rules opera.Rules) *E
 		Root:            block.StateRoot,
 		Number:          big.NewInt(int64(block.Number)),
 		Time:            block.Time,
-		GasLimit:        math.MaxUint64,
+		GasLimit:        block.GasLimit,
 		GasUsed:         block.GasUsed,
 		BaseFee:         baseFee,
 		PrevRandao:      prevRandao,
@@ -191,7 +191,7 @@ func (h *EvmHeader) ToJson(receipts types.Receipts) *EvmHeaderJson {
 	enc := &EvmHeaderJson{
 		Number:          (*hexutil.Big)(h.Number),
 		Miner:           h.Coinbase,
-		GasLimit:        0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
+		GasLimit:        hexutil.Uint64(h.GasLimit),
 		GasUsed:         hexutil.Uint64(h.GasUsed),
 		Root:            h.Root,
 		TxHash:          h.TxHash,

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -85,6 +85,7 @@ func (p *StateProcessor) Process(
 		receipt, _, skip, err = applyTransaction(msg, p.config, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, onNewLog)
 		if skip {
 			skipped = append(skipped, uint32(i))
+			receipts = append(receipts, nil)
 			err = nil
 			continue
 		}

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -95,7 +95,7 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 		}
 	} else { // no S5 section in the genesis file
 		// Import legacy EVM genesis section
-		err = s.evm.ImportLegacyEvmData(g.RawEvmItems, uint64(lastBlock.Idx), common.Hash(lastBlock.Root))
+		err = s.evm.ImportLegacyEvmData(g.RawEvmItems, uint64(lastBlock.Idx), common.Hash(lastBlock.StateRoot))
 		if err != nil {
 			return fmt.Errorf("import of legacy genesis data into StateDB failed; %v", err)
 		}
@@ -104,10 +104,10 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 	if err := s.evm.Open(); err != nil {
 		return fmt.Errorf("unable to open EvmStore to check imported state: %w", err)
 	}
-	if err := s.evm.CheckLiveStateHash(lastBlock.Idx, lastBlock.Root); err != nil {
+	if err := s.evm.CheckLiveStateHash(lastBlock.Idx, lastBlock.StateRoot); err != nil {
 		return fmt.Errorf("checking imported live state failed: %w", err)
 	} else {
-		s.Log.Info("StateDB imported successfully, stateRoot matches", "index", lastBlock.Idx, "root", lastBlock.Root)
+		s.Log.Info("StateDB imported successfully, stateRoot matches", "index", lastBlock.Idx, "root", lastBlock.StateRoot)
 	}
 
 	s.SetGenesisID(g.GenesisID)

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -56,11 +56,11 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 	gasLimit := rules.Blocks.MaxBlockGas
 
 	s.SetBlock(0, inter.NewBlockBuilder().
-		SetNumber(0).
-		SetTime(evmcore.FakeGenesisTime-1). // TODO: extend genesis generator to provide time
-		SetGasLimit(gasLimit).
-		SetStateRoot(common.Hash{}). // TODO: get proper state root from genesis data
-		SetBaseFee(big.NewInt(0)).   // TODO: set initial base fee according to the rules
+		WithNumber(0).
+		WithTime(evmcore.FakeGenesisTime-1). // TODO: extend genesis generator to provide time
+		WithGasLimit(gasLimit).
+		WithStateRoot(common.Hash{}). // TODO: get proper state root from genesis data
+		WithBaseFee(big.NewInt(0)).   // TODO: set initial base fee according to the rules
 		Build(),
 	)
 

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -59,8 +59,8 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 		SetNumber(0).
 		SetTime(evmcore.FakeGenesisTime-1). // TODO: extend genesis generator to provide time
 		SetGasLimit(gasLimit).
-		SetStateRoot(common.Hash{}). // TODO: get proper has from genesis data
-		SetBaseFee(big.NewInt(0)).
+		SetStateRoot(common.Hash{}). // TODO: get proper state root from genesis data
+		SetBaseFee(big.NewInt(0)).   // TODO: set initial base fee according to the rules
 		Build(),
 	)
 

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -66,7 +66,7 @@ func InternalTxBuilder(statedb state.StateDB) func(calldata []byte, addr common.
 		if nonce == math.MaxUint64 {
 			nonce = statedb.GetNonce(common.Address{})
 		}
-		tx := types.NewTransaction(nonce, addr, common.Big0, 1e10, common.Big0, calldata)
+		tx := types.NewTransaction(nonce, addr, common.Big0, 1e6, common.Big0, calldata)
 		nonce++
 		return tx
 	}

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip/blockproc"
-	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/inter/state"
 	"github.com/Fantom-foundation/go-opera/opera"
@@ -127,13 +126,19 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions) types.Receipts {
 			skipped[i] = n + uint32(txsOffset)
 		}
 		for _, r := range receipts {
-			r.TransactionIndex += txsOffset
+			if receipts != nil {
+				r.TransactionIndex += txsOffset
+			}
 		}
 	}
 
 	p.incomingTxs = append(p.incomingTxs, txs...)
 	p.skippedTxs = append(p.skippedTxs, skipped...)
-	p.receipts = append(p.receipts, receipts...)
+	for _, receipt := range receipts {
+		if receipt != nil {
+			p.receipts = append(p.receipts, receipt)
+		}
+	}
 
 	return receipts
 }
@@ -141,7 +146,7 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions) types.Receipts {
 func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs []uint32, receipts types.Receipts) {
 	evmBlock = p.evmBlockWith(
 		// Filter skipped transactions. Receipts are filtered already
-		inter.FilterSkippedTxs(p.incomingTxs, p.skippedTxs),
+		filterSkippedTxs(p.incomingTxs, p.skippedTxs),
 	)
 	skippedTxs = p.skippedTxs
 	receipts = p.receipts
@@ -153,4 +158,22 @@ func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs [
 	evmBlock.Root = p.statedb.GetStateHash()
 
 	return
+}
+
+func filterSkippedTxs(txs types.Transactions, skippedTxs []uint32) types.Transactions {
+	if len(skippedTxs) == 0 {
+		// short circuit if nothing to skip
+		return txs
+	}
+	skipCount := 0
+	filteredTxs := make(types.Transactions, 0, len(txs))
+	for i, tx := range txs {
+		if skipCount < len(skippedTxs) && skippedTxs[skipCount] == uint32(i) {
+			skipCount++
+		} else {
+			filteredTxs = append(filteredTxs, tx)
+		}
+	}
+
+	return filteredTxs
 }

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -1,7 +1,6 @@
 package evmmodule
 
 import (
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -96,7 +95,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 		Root:            common.Hash{},
 		Time:            p.block.Time,
 		Coinbase:        common.Address{},
-		GasLimit:        math.MaxUint64,
+		GasLimit:        p.net.Blocks.MaxBlockGas,
 		GasUsed:         p.gasUsed,
 		BaseFee:         baseFee,
 		PrevRandao:      prevRandao,
@@ -126,7 +125,7 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions) types.Receipts {
 			skipped[i] = n + uint32(txsOffset)
 		}
 		for _, r := range receipts {
-			if receipts != nil {
+			if r != nil {
 				r.TransactionIndex += txsOffset
 			}
 		}

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -56,6 +56,9 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 			Upgrades: opera.Upgrades{
 				London: true,
 			},
+			Blocks: opera.BlocksRules{
+				MaxBlockGas: 1e12,
+			},
 		},
 		&params.ChainConfig{
 			LondonBlock: big.NewInt(0),
@@ -73,6 +76,9 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 
 	if len(receipts) != 1 {
 		t.Fatalf("Expected 1 receipt, got %d", len(receipts))
+	}
+	if receipts[0] == nil {
+		t.Fatalf("Transaction was skipped")
 	}
 	if want, got := types.ReceiptStatusSuccessful, receipts[0].Status; want != got {
 		t.Errorf("Expected status %v, got %v", want, got)

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -333,9 +333,6 @@ func consensusCallbackBeginBlockFn(
 							}
 						}
 					}
-					for _, tx := range append(preInternalTxs, internalTxs...) {
-						store.evm.SetTx(tx.Hash(), tx)
-					}
 
 					bs.LastBlock = blockCtx
 					bs.CheatersWritten = uint32(bs.EpochCheaters.Len())
@@ -346,6 +343,10 @@ func consensusCallbackBeginBlockFn(
 
 					block := blockBuilder.Build()
 					evmBlock.Hash = block.Hash()
+
+					for _, tx := range blockBuilder.GetTransactions() {
+						store.evm.SetTx(tx.Hash(), tx)
+					}
 
 					store.SetBlock(blockCtx.Idx, block)
 					store.SetBlockIndex(block.Hash(), blockCtx.Idx)

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -276,7 +276,8 @@ func consensusCallbackBeginBlockFn(
 					// Add results of the transaction processing to the block.
 					blockBuilder.
 						SetStateRoot(common.Hash(evmBlock.Root)).
-						SetGasUsed(evmBlock.GasUsed)
+						SetGasUsed(evmBlock.GasUsed).
+						SetBaseFee(evmBlock.BaseFee)
 
 					// memorize event position of each tx
 					txPositions := make(map[common.Hash]ExtendedTxPosition)

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -424,7 +424,6 @@ func spillBlockEvents(store *Store, events hash.OrderedEvents, maxBlockGas uint6
 		if gasPowerUsedSum > maxBlockGas {
 			// spill
 			spilledEventsMeter.Mark(int64(len(fullEvents) - (i + 1)))
-			events = events[i+1:]
 			fullEvents = fullEvents[i+1:]
 			break
 		}

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -48,14 +48,14 @@ func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, ga
 	}
 
 	builder := inter.NewBlockBuilder().
-		SetNumber(uint64(br.Idx)).
-		SetTime(br.Time).
-		SetParentHash(parentHash).
-		SetStateRoot(common.Hash(br.StateRoot)).
-		SetGasLimit(gasLimit).
-		SetGasUsed(br.GasUsed).
-		SetBaseFee(baseFee).
-		SetPrevRandao(common.Hash{1})
+		WithNumber(uint64(br.Idx)).
+		WithTime(br.Time).
+		WithParentHash(parentHash).
+		WithStateRoot(common.Hash(br.StateRoot)).
+		WithGasLimit(gasLimit).
+		WithGasUsed(br.GasUsed).
+		WithBaseFee(baseFee).
+		WithPrevRandao(common.Hash{1})
 
 	for i := range br.Txs {
 		copy := types.Receipt(*br.Receipts[i])

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -25,10 +25,8 @@ func indexRawReceipts(s *Store, receiptsForStorage []*types.ReceiptForStorage, t
 	}
 }
 
-func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, br ibr.LlrIdxFullBlockRecord) {
-	txHashes := make([]common.Hash, 0, len(br.Txs))
+func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, gasLimit uint64, br ibr.LlrIdxFullBlockRecord) {
 	for _, tx := range br.Txs {
-		txHashes = append(txHashes, tx.Hash())
 		s.EvmStore().SetTx(tx.Hash(), tx)
 	}
 
@@ -55,7 +53,9 @@ func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, br
 		SetTime(br.Time).
 		SetParentHash(parentHash).
 		SetStateRoot(common.Hash(br.StateRoot)).
-		SetGasUsed(br.GasUsed)
+		SetGasLimit(gasLimit).
+		SetGasUsed(br.GasUsed).
+		SetBaseFee(baseFee)
 
 	for i := range br.Txs {
 		copy := types.Receipt(*br.Receipts[i])

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -47,7 +47,6 @@ func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, ga
 		parentHash = parent.Hash()
 	}
 
-	// TODO: add bloom log and other fields
 	builder := inter.NewBlockBuilder().
 		SetNumber(uint64(br.Idx)).
 		SetTime(br.Time).
@@ -55,7 +54,8 @@ func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, ga
 		SetStateRoot(common.Hash(br.StateRoot)).
 		SetGasLimit(gasLimit).
 		SetGasUsed(br.GasUsed).
-		SetBaseFee(baseFee)
+		SetBaseFee(baseFee).
+		SetPrevRandao(common.Hash{1})
 
 	for i := range br.Txs {
 		copy := types.Receipt(*br.Receipts[i])

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -44,10 +44,16 @@ func (s *Store) WriteFullBlockRecord(baseFee *big.Int, blobGasPrice *big.Int, br
 		})
 	}
 
+	parentHash := common.Hash{}
+	if parent := s.GetBlock(br.Idx - 1); parent != nil {
+		parentHash = parent.Hash()
+	}
+
 	// TODO: add bloom log and other fields
 	builder := inter.NewBlockBuilder().
 		SetNumber(uint64(br.Idx)).
 		SetTime(br.Time).
+		SetParentHash(parentHash).
 		SetStateRoot(common.Hash(br.StateRoot)).
 		SetGasUsed(br.GasUsed)
 

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -57,13 +56,13 @@ func (r *EvmStateReader) Config() *params.ChainConfig {
 func (r *EvmStateReader) CurrentBlock() *evmcore.EvmBlock {
 	n := r.store.GetLatestBlockIndex()
 
-	return r.getBlock(hash.Event{}, n, true)
+	return r.getBlock(common.Hash{}, n, true)
 }
 
 func (r *EvmStateReader) CurrentHeader() *evmcore.EvmHeader {
 	n := r.store.GetLatestBlockIndex()
 
-	return r.getBlock(hash.Event{}, n, false).Header()
+	return r.getBlock(common.Hash{}, n, false).Header()
 }
 
 func (r *EvmStateReader) LastHeaderWithArchiveState() (*evmcore.EvmHeader, error) {
@@ -78,23 +77,27 @@ func (r *EvmStateReader) LastHeaderWithArchiveState() (*evmcore.EvmHeader, error
 		latestBlock = idx.Block(latestArchiveBlock)
 	}
 
-	return r.getBlock(hash.Event{}, latestBlock, false).Header(), nil
+	return r.getBlock(common.Hash{}, latestBlock, false).Header(), nil
+}
+
+func (r *EvmStateReader) GetHeaderByNumber(n uint64) *evmcore.EvmHeader {
+	return r.GetHeader(common.Hash{}, n)
 }
 
 func (r *EvmStateReader) GetHeader(h common.Hash, n uint64) *evmcore.EvmHeader {
-	return r.getBlock(hash.Event(h), idx.Block(n), false).Header()
+	return r.getBlock(h, idx.Block(n), false).Header()
 }
 
 func (r *EvmStateReader) GetBlock(h common.Hash, n uint64) *evmcore.EvmBlock {
-	return r.getBlock(hash.Event(h), idx.Block(n), true)
+	return r.getBlock(h, idx.Block(n), true)
 }
 
-func (r *EvmStateReader) getBlock(h hash.Event, n idx.Block, readTxs bool) *evmcore.EvmBlock {
+func (r *EvmStateReader) getBlock(h common.Hash, n idx.Block, readTxs bool) *evmcore.EvmBlock {
 	block := r.store.GetBlock(n)
 	if block == nil {
 		return nil
 	}
-	if (h != hash.Event{}) && (h != block.Atropos) {
+	if (h != common.Hash{}) && (h != block.Hash()) {
 		return nil
 	}
 	if readTxs {
@@ -111,20 +114,28 @@ func (r *EvmStateReader) getBlock(h hash.Event, n idx.Block, readTxs bool) *evmc
 	}
 
 	// find block rules
-	epoch := block.Atropos.Epoch()
+	epoch := block.Epoch
 	es := r.store.GetHistoryEpochState(epoch)
 	var rules opera.Rules
 	if es != nil {
 		rules = es.Rules
 	}
-	var prev hash.Event
+
+	// There is no epoch state for epoch 0 comprising block 0.
+	// For this epoch, London and Sonic upgrades are enabled.
+	if epoch == 0 {
+		rules.Upgrades.London = true
+		rules.Upgrades.Sonic = true
+	}
+
+	var prev common.Hash
 	if n != 0 {
 		block := r.store.GetBlock(n - 1)
 		if block != nil {
-			prev = block.Atropos
+			prev = block.Hash()
 		}
 	}
-	evmHeader := evmcore.ToEvmHeader(block, n, prev, rules)
+	evmHeader := evmcore.ToEvmHeader(block, prev, rules)
 
 	var evmBlock *evmcore.EvmBlock
 	if readTxs {

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -123,6 +123,9 @@ func (r *EvmStateReader) getBlock(h common.Hash, n idx.Block, readTxs bool) *evm
 
 	// There is no epoch state for epoch 0 comprising block 0.
 	// For this epoch, London and Sonic upgrades are enabled.
+	// TODO: instead of hard-coding these values here, a corresponding
+	// epoch state should be included in the genesis procedure to be
+	// consistent. See issue #72.
 	if epoch == 0 {
 		rules.Upgrades.London = true
 		rules.Upgrades.Sonic = true

--- a/gossip/evmstore/store_tx.go
+++ b/gossip/evmstore/store_tx.go
@@ -1,40 +1,17 @@
 package evmstore
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
-
-	"github.com/Fantom-foundation/go-opera/inter"
 )
 
-// SetTx stores non-event transaction.
+// SetTx stores transaction.
 func (s *Store) SetTx(txid common.Hash, tx *types.Transaction) {
 	s.rlp.Set(s.table.Txs, txid.Bytes(), tx)
 }
 
-// GetTx returns stored non-event transaction.
+// GetTx returns stored transaction.
 func (s *Store) GetTx(txid common.Hash) *types.Transaction {
 	tx, _ := s.rlp.Get(s.table.Txs, txid.Bytes(), &types.Transaction{}).(*types.Transaction)
 	return tx
-}
-
-func (s *Store) GetBlockTxs(n idx.Block, block inter.Block, getEventPayload func(hash.Event) *inter.EventPayload) types.Transactions {
-	if cached := s.GetCachedEvmBlock(n); cached != nil {
-		return cached.Transactions
-	}
-
-	transactions := make(types.Transactions, 0, len(block.TransactionHashes))
-	for _, txid := range block.TransactionHashes {
-		tx := s.GetTx(txid)
-		if tx == nil {
-			log.Crit("Internal tx not found", "tx", txid.String())
-			continue
-		}
-		transactions = append(transactions, tx)
-	}
-
-	return transactions
 }

--- a/gossip/evmstore/store_tx.go
+++ b/gossip/evmstore/store_tx.go
@@ -26,8 +26,8 @@ func (s *Store) GetBlockTxs(n idx.Block, block inter.Block, getEventPayload func
 		return cached.Transactions
 	}
 
-	transactions := make(types.Transactions, 0, len(block.Txs)+len(block.InternalTxs)+len(block.Events)*10)
-	for _, txid := range block.InternalTxs {
+	transactions := make(types.Transactions, 0, len(block.TransactionHashes))
+	for _, txid := range block.TransactionHashes {
 		tx := s.GetTx(txid)
 		if tx == nil {
 			log.Crit("Internal tx not found", "tx", txid.String())
@@ -35,24 +35,6 @@ func (s *Store) GetBlockTxs(n idx.Block, block inter.Block, getEventPayload func
 		}
 		transactions = append(transactions, tx)
 	}
-	for _, txid := range block.Txs {
-		tx := s.GetTx(txid)
-		if tx == nil {
-			log.Crit("Tx not found", "tx", txid.String())
-			continue
-		}
-		transactions = append(transactions, tx)
-	}
-	for _, id := range block.Events {
-		e := getEventPayload(id)
-		if e == nil {
-			log.Crit("Block event not found", "event", id.String())
-			continue
-		}
-		transactions = append(transactions, e.Txs()...)
-	}
-
-	transactions = inter.FilterSkippedTxs(transactions, block.SkippedTxs)
 
 	return transactions
 }

--- a/gossip/prevrandao.go
+++ b/gossip/prevrandao.go
@@ -1,7 +1,8 @@
-package inter
+package gossip
 
 import (
 	"crypto/sha256"
+
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/gossip/prevrandao_test.go
+++ b/gossip/prevrandao_test.go
@@ -1,10 +1,11 @@
-package inter
+package gossip
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
 	"math/rand"
 	"strings"
 	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
 )
 
 func TestComputePrevRandao_ComputationIsDeterministic(t *testing.T) {

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -167,19 +167,16 @@ func (s *Store) SetEpochBlock(b idx.Block, e idx.Epoch) {
 }
 
 func (s *Store) FindBlockEpoch(b idx.Block) idx.Epoch {
-	panic("not implemented") // <check whether this function is actually needed
-	/*
-		if c, ok := s.cache.Blocks.Get(b); ok {
-			return c.(*inter.Block).Atropos.Epoch()
-		}
+	if c, ok := s.cache.Blocks.Get(b); ok {
+		return c.(*inter.Block).Epoch
+	}
 
-		it := s.table.EpochBlocks.NewIterator(nil, (math.MaxUint64 - b).Bytes())
-		defer it.Release()
-		if !it.Next() {
-			return 0
-		}
-		return idx.BytesToEpoch(it.Value())
-	*/
+	it := s.table.EpochBlocks.NewIterator(nil, (math.MaxUint64 - b).Bytes())
+	defer it.Release()
+	if !it.Next() {
+		return 0
+	}
+	return idx.BytesToEpoch(it.Value())
 }
 
 func (s *Store) GetBlockTxs(n idx.Block, block *inter.Block) types.Transactions {

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 
-	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/inter"
 )
 
@@ -57,12 +56,6 @@ func (s *Store) SetBlock(n idx.Block, b *inter.Block) {
 
 // GetBlock returns stored block.
 func (s *Store) GetBlock(n idx.Block) *inter.Block {
-	if n == 0 {
-		// fake genesis block for compatibility with web3
-		return &inter.Block{
-			Time: evmcore.FakeGenesisTime - 1,
-		}
-	}
 	// Get block from LRU cache first.
 	if c, ok := s.cache.Blocks.Get(n); ok {
 		return c.(*inter.Block)

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -188,7 +188,7 @@ func (s *Store) GetBlockTxs(n idx.Block, block *inter.Block) types.Transactions 
 	for _, txHash := range block.TransactionHashes {
 		tx := s.evm.GetTx(txHash)
 		if tx == nil {
-			log.Crit("Internal tx not found", "tx", txHash.String())
+			log.Crit("Referenced transaction not found", "tx", txHash.String())
 			continue
 		}
 		transactions = append(transactions, tx)

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -49,9 +49,6 @@ func (s *Store) SetGenesisID(val hash.Hash) {
 
 // SetBlock stores chain block.
 func (s *Store) SetBlock(n idx.Block, b *inter.Block) {
-	if n != idx.Block(b.Number) {
-		panic("block number mismatch")
-	}
 	s.rlp.Set(s.table.Blocks, n.Bytes(), b)
 
 	// Add to LRU cache.

--- a/gossip/store_llr_block.go
+++ b/gossip/store_llr_block.go
@@ -19,12 +19,12 @@ func (s *Store) GetFullBlockRecord(n idx.Block) *ibr.LlrFullBlockRecord {
 		receipts = []*types.ReceiptForStorage{}
 	}
 	return &ibr.LlrFullBlockRecord{
-		Atropos:  block.Atropos,
-		Root:     block.Root,
-		Txs:      txs,
-		Receipts: receipts,
-		Time:     block.Time,
-		GasUsed:  block.GasUsed,
+		BlockHash: hash.Hash(block.Hash()),
+		StateRoot: hash.Hash(block.StateRoot),
+		Txs:       txs,
+		Receipts:  receipts,
+		Time:      block.Time,
+		GasUsed:   block.GasUsed,
 	}
 }
 

--- a/integration/makefakegenesis/genesis.go
+++ b/integration/makefakegenesis/genesis.go
@@ -140,7 +140,7 @@ func FakeGenesisStoreWithRulesAndStart(num idx.Validator, balance, stake *big.In
 func txBuilder() func(calldata []byte, addr common.Address) *types.Transaction {
 	nonce := uint64(0)
 	return func(calldata []byte, addr common.Address) *types.Transaction {
-		tx := types.NewTransaction(nonce, addr, common.Big0, 1e10, common.Big0, calldata)
+		tx := types.NewTransaction(nonce, addr, common.Big0, 3e6, common.Big0, calldata)
 		nonce++
 		return tx
 	}

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -195,7 +195,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 
 	bs.LastBlock = blockCtx
 
-	prettyHash := func(root hash.Hash) hash.Event {
+	prettyHash := func(root hash.Hash) hash.Hash {
 		e := inter.MutableEventPayload{}
 		// for nice-looking ID
 		e.SetEpoch(es.Epoch)
@@ -203,7 +203,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 		// actual data hashed
 		e.SetExtra(root[:])
 
-		return e.Build().ID()
+		return hash.Hash(e.Build().ID())
 	}
 	receiptsStorage := make([]*types.ReceiptForStorage, len(receipts))
 	for i, r := range receipts {
@@ -212,12 +212,12 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	// add block
 	b.blocks = append(b.blocks, ibr.LlrIdxFullBlockRecord{
 		LlrFullBlockRecord: ibr.LlrFullBlockRecord{
-			Atropos:  prettyHash(bs.FinalizedStateRoot),
-			Root:     bs.FinalizedStateRoot,
-			Txs:      evmBlock.Transactions,
-			Receipts: receiptsStorage,
-			Time:     blockCtx.Time,
-			GasUsed:  evmBlock.GasUsed,
+			BlockHash: prettyHash(bs.FinalizedStateRoot),
+			StateRoot: bs.FinalizedStateRoot,
+			Txs:       evmBlock.Transactions,
+			Receipts:  receiptsStorage,
+			Time:      blockCtx.Time,
+			GasUsed:   evmBlock.GasUsed,
 		},
 		Idx: blockCtx.Idx,
 	})

--- a/inter/block.go
+++ b/inter/block.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/holiman/uint256"
 )
 
 // Block represents the on-disk storage format of a block. It contains all
@@ -32,7 +31,7 @@ type Block struct {
 	Difficulty           uint64
 	GasLimit             uint64
 	GasUsed              uint64
-	BaseFee              uint256.Int
+	BaseFee              *big.Int
 	PrevRandao           common.Hash
 	TransactionsHashRoot common.Hash
 	ReceiptsHashRoot     common.Hash
@@ -80,7 +79,7 @@ func (b *Block) GetEthereumHeader() *types.Header {
 		Extra:       nil, // TODO: fill in extra data required for gas computation
 		MixDigest:   b.PrevRandao,
 		Nonce:       types.BlockNonce{}, // constant 0 in Ethereum
-		BaseFee:     b.BaseFee.ToBig(),
+		BaseFee:     b.BaseFee,
 
 		// Sonic does not have a beacon chain and no withdrawals.
 		WithdrawalsHash: &types.EmptyWithdrawalsHash,
@@ -155,7 +154,7 @@ func (b *BlockBuilder) SetGasUsed(gasUsed uint64) *BlockBuilder {
 	return b
 }
 
-func (b *BlockBuilder) SetBaseFee(baseFee uint256.Int) *BlockBuilder {
+func (b *BlockBuilder) SetBaseFee(baseFee *big.Int) *BlockBuilder {
 	b.block.BaseFee = baseFee
 	return b
 }

--- a/inter/block.go
+++ b/inter/block.go
@@ -2,6 +2,7 @@ package inter
 
 import (
 	"math/big"
+	"slices"
 	"unsafe"
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -123,6 +124,10 @@ func (b *BlockBuilder) SetParentHash(hash common.Hash) *BlockBuilder {
 func (b *BlockBuilder) SetStateRoot(hash common.Hash) *BlockBuilder {
 	b.block.StateRoot = hash
 	return b
+}
+
+func (b *BlockBuilder) GetTransactions() types.Transactions {
+	return slices.Clone(b.transactions)
 }
 
 func (b *BlockBuilder) AddTransaction(

--- a/inter/block.go
+++ b/inter/block.go
@@ -13,7 +13,7 @@ import (
 
 // Block represents the on-disk storage format of a block. It contains all
 // fields required to reconstruct the block header, as well as a list of
-// hashes of the transactions been executed as part of the represented block.
+// hashes of the transactions being executed as part of the represented block.
 //
 // This struct should be considered immutable. No fields should be modified,
 // directly or indirectly. Ideally, all fields should be private, but that

--- a/inter/block.go
+++ b/inter/block.go
@@ -155,7 +155,7 @@ func (b *BlockBuilder) SetGasUsed(gasUsed uint64) *BlockBuilder {
 }
 
 func (b *BlockBuilder) SetBaseFee(baseFee *big.Int) *BlockBuilder {
-	b.block.BaseFee = baseFee
+	b.block.BaseFee = new(big.Int).Set(baseFee)
 	return b
 }
 

--- a/inter/block.go
+++ b/inter/block.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -56,17 +55,11 @@ func (b *Block) Hash() common.Hash {
 	return b.hash
 }
 
-// uncleHash is the hash to be used for the uncle field in Ethereum headers if
-// there are no uncles. See https://eips.ethereum.org/EIPS/eip-4844.
-var uncleHash = common.BytesToHash(hexutil.MustDecode(
-	"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-))
-
 // GetEthereumHeader returns the Ethereum header corresponding to this block.
 func (b *Block) GetEthereumHeader() *types.Header {
 	return &types.Header{
 		ParentHash:  b.ParentHash,
-		UncleHash:   uncleHash,
+		UncleHash:   types.EmptyUncleHash,
 		Coinbase:    common.Address{}, // < in Sonic, the coinbase is always 0
 		Root:        b.StateRoot,
 		TxHash:      b.TransactionsHashRoot,
@@ -111,17 +104,17 @@ func NewBlockBuilder() *BlockBuilder {
 	return &BlockBuilder{}
 }
 
-func (b *BlockBuilder) SetNumber(number uint64) *BlockBuilder {
+func (b *BlockBuilder) WithNumber(number uint64) *BlockBuilder {
 	b.block.Number = number
 	return b
 }
 
-func (b *BlockBuilder) SetParentHash(hash common.Hash) *BlockBuilder {
+func (b *BlockBuilder) WithParentHash(hash common.Hash) *BlockBuilder {
 	b.block.ParentHash = hash
 	return b
 }
 
-func (b *BlockBuilder) SetStateRoot(hash common.Hash) *BlockBuilder {
+func (b *BlockBuilder) WithStateRoot(hash common.Hash) *BlockBuilder {
 	b.block.StateRoot = hash
 	return b
 }
@@ -139,37 +132,37 @@ func (b *BlockBuilder) AddTransaction(
 	return b
 }
 
-func (b *BlockBuilder) SetTime(time Timestamp) *BlockBuilder {
+func (b *BlockBuilder) WithTime(time Timestamp) *BlockBuilder {
 	b.block.Time = time
 	return b
 }
 
-func (b *BlockBuilder) SetDifficulty(difficulty uint64) *BlockBuilder {
+func (b *BlockBuilder) WithDifficulty(difficulty uint64) *BlockBuilder {
 	b.block.Difficulty = difficulty
 	return b
 }
 
-func (b *BlockBuilder) SetGasLimit(gasLimit uint64) *BlockBuilder {
+func (b *BlockBuilder) WithGasLimit(gasLimit uint64) *BlockBuilder {
 	b.block.GasLimit = gasLimit
 	return b
 }
 
-func (b *BlockBuilder) SetGasUsed(gasUsed uint64) *BlockBuilder {
+func (b *BlockBuilder) WithGasUsed(gasUsed uint64) *BlockBuilder {
 	b.block.GasUsed = gasUsed
 	return b
 }
 
-func (b *BlockBuilder) SetBaseFee(baseFee *big.Int) *BlockBuilder {
+func (b *BlockBuilder) WithBaseFee(baseFee *big.Int) *BlockBuilder {
 	b.block.BaseFee = new(big.Int).Set(baseFee)
 	return b
 }
 
-func (b *BlockBuilder) SetPrevRandao(prevRandao common.Hash) *BlockBuilder {
+func (b *BlockBuilder) WithPrevRandao(prevRandao common.Hash) *BlockBuilder {
 	b.block.PrevRandao = prevRandao
 	return b
 }
 
-func (b *BlockBuilder) SetEpoch(epoch idx.Epoch) *BlockBuilder {
+func (b *BlockBuilder) WithEpoch(epoch idx.Epoch) *BlockBuilder {
 	b.block.Epoch = epoch
 	return b
 }

--- a/inter/block.go
+++ b/inter/block.go
@@ -1,45 +1,189 @@
 package inter
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
+	"math/big"
+	"unsafe"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/holiman/uint256"
 )
 
+// Block represents the on-disk storage format of a block. It contains all
+// fields required to reconstruct the block header, as well as a list of
+// hashes of the transactions been executed as part of the represented block.
+//
+// This struct should be considered immutable. No fields should be modified,
+// directly or indirectly. Ideally, all fields should be private, but that
+// would invalidate support for RLP encoding as it is used to store instances
+// on the disk. However, future updates may make fields inaccessible.
+//
+// To create a new block, use the BlockBuilder, handling the computation of
+// key properties implicitly.
 type Block struct {
-	Time        Timestamp
-	Atropos     hash.Event
-	Events      hash.Events
-	Txs         []common.Hash // non event txs (received via genesis or LLR)
-	InternalTxs []common.Hash // DEPRECATED in favor of using only Txs fields and method internal.IsInternal
-	SkippedTxs  []uint32      // indexes of skipped txs, starting from first tx of first event, ending with last tx of last event
-	GasUsed     uint64
-	Root        hash.Hash
+	// Fields required for the block header.
+	Number               uint64
+	ParentHash           common.Hash
+	StateRoot            common.Hash
+	Time                 Timestamp
+	Difficulty           uint64
+	GasLimit             uint64
+	GasUsed              uint64
+	BaseFee              uint256.Int
+	PrevRandao           common.Hash
+	TransactionsHashRoot common.Hash
+	ReceiptsHashRoot     common.Hash
+	LogBloom             types.Bloom
+
+	// Fields required for linking blocks to contained transactions.
+	TransactionHashes []common.Hash
+
+	// Fields required for linking the block internally to a lachesis epoch.
+	Epoch idx.Epoch
+
+	// The hash of this block, cached on first access.
+	hash common.Hash
+}
+
+// Hash computes the hash of this block, committing all its fields.
+func (b *Block) Hash() common.Hash {
+	if b.hash == (common.Hash{}) {
+		b.hash = b.GetEthereumHeader().Hash()
+	}
+	return b.hash
+}
+
+// uncleHash is the hash to be used for the uncle field in Ethereum headers if
+// there are no uncles. See https://eips.ethereum.org/EIPS/eip-4844.
+var uncleHash = common.BytesToHash(hexutil.MustDecode(
+	"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+))
+
+// GetEthereumHeader returns the Ethereum header corresponding to this block.
+func (b *Block) GetEthereumHeader() *types.Header {
+	return &types.Header{
+		ParentHash:  b.ParentHash,
+		UncleHash:   uncleHash,
+		Coinbase:    common.Address{}, // < in Sonic, the coinbase is always 0
+		Root:        b.StateRoot,
+		TxHash:      b.TransactionsHashRoot,
+		ReceiptHash: b.ReceiptsHashRoot,
+		Bloom:       b.LogBloom,
+		Difficulty:  big.NewInt(int64(b.Difficulty)),
+		Number:      big.NewInt(int64(b.Number)),
+		GasLimit:    b.GasLimit,
+		GasUsed:     b.GasUsed,
+		Time:        uint64(b.Time.Time().Unix()),
+		Extra:       nil, // TODO: fill in extra data required for gas computation
+		MixDigest:   b.PrevRandao,
+		Nonce:       types.BlockNonce{}, // constant 0 in Ethereum
+		BaseFee:     b.BaseFee.ToBig(),
+
+		// Sonic does not have a beacon chain and no withdrawals.
+		WithdrawalsHash: &types.EmptyWithdrawalsHash,
+
+		// Sonic does not support blobs, so no blob gas is used and there is
+		// no excess blob gas.
+		BlobGasUsed:   new(uint64), // = 0
+		ExcessBlobGas: new(uint64), // = 0
+	}
 }
 
 func (b *Block) EstimateSize() int {
-	return (len(b.Events)+len(b.InternalTxs)+len(b.Txs)+1+1)*32 + len(b.SkippedTxs)*4 + 8 + 8
+	return int(unsafe.Sizeof(*b)) +
+		len(b.TransactionHashes)*int(unsafe.Sizeof(common.Hash{}))
 }
 
-// GetPrevRandao computes prevrandao if not already computed and returns it.
-func (b *Block) GetPrevRandao() common.Hash {
-	return computePrevRandao(b.Events)
+// ----------------------------------------------------------------------------
+// BlockBuilder
+// ----------------------------------------------------------------------------
+
+type BlockBuilder struct {
+	block        Block
+	transactions types.Transactions
+	receipts     types.Receipts
 }
 
-func FilterSkippedTxs(txs types.Transactions, skippedTxs []uint32) types.Transactions {
-	if len(skippedTxs) == 0 {
-		// short circuit if nothing to skip
-		return txs
-	}
-	skipCount := 0
-	filteredTxs := make(types.Transactions, 0, len(txs))
-	for i, tx := range txs {
-		if skipCount < len(skippedTxs) && skippedTxs[skipCount] == uint32(i) {
-			skipCount++
-		} else {
-			filteredTxs = append(filteredTxs, tx)
-		}
+func NewBlockBuilder() *BlockBuilder {
+	return &BlockBuilder{}
+}
+
+func (b *BlockBuilder) SetNumber(number uint64) *BlockBuilder {
+	b.block.Number = number
+	return b
+}
+
+func (b *BlockBuilder) SetParentHash(hash common.Hash) *BlockBuilder {
+	b.block.ParentHash = hash
+	return b
+}
+
+func (b *BlockBuilder) SetStateRoot(hash common.Hash) *BlockBuilder {
+	b.block.StateRoot = hash
+	return b
+}
+
+func (b *BlockBuilder) AddTransaction(
+	transaction *types.Transaction,
+	receipt *types.Receipt,
+) *BlockBuilder {
+	b.transactions = append(b.transactions, transaction)
+	b.receipts = append(b.receipts, receipt)
+	return b
+}
+
+func (b *BlockBuilder) SetTime(time Timestamp) *BlockBuilder {
+	b.block.Time = time
+	return b
+}
+
+func (b *BlockBuilder) SetDifficulty(difficulty uint64) *BlockBuilder {
+	b.block.Difficulty = difficulty
+	return b
+}
+
+func (b *BlockBuilder) SetGasLimit(gasLimit uint64) *BlockBuilder {
+	b.block.GasLimit = gasLimit
+	return b
+}
+
+func (b *BlockBuilder) SetGasUsed(gasUsed uint64) *BlockBuilder {
+	b.block.GasUsed = gasUsed
+	return b
+}
+
+func (b *BlockBuilder) SetBaseFee(baseFee uint256.Int) *BlockBuilder {
+	b.block.BaseFee = baseFee
+	return b
+}
+
+func (b *BlockBuilder) SetPrevRandao(prevRandao common.Hash) *BlockBuilder {
+	b.block.PrevRandao = prevRandao
+	return b
+}
+
+func (b *BlockBuilder) SetEpoch(epoch idx.Epoch) *BlockBuilder {
+	b.block.Epoch = epoch
+	return b
+}
+
+func (b *BlockBuilder) Build() *Block {
+	res := new(Block)
+	*res = b.block
+
+	res.TransactionsHashRoot = types.DeriveSha(
+		b.transactions,
+		trie.NewStackTrie(nil),
+	)
+	res.ReceiptsHashRoot = types.DeriveSha(b.receipts, trie.NewStackTrie(nil))
+	res.LogBloom = types.CreateBloom(b.receipts)
+
+	for _, tx := range b.transactions {
+		res.TransactionHashes = append(res.TransactionHashes, tx.Hash())
 	}
 
-	return filteredTxs
+	return res
 }

--- a/inter/block_test.go
+++ b/inter/block_test.go
@@ -1,1 +1,0 @@
-package inter

--- a/inter/block_test.go
+++ b/inter/block_test.go
@@ -1,13 +1,1 @@
 package inter
-
-import (
-	"github.com/ethereum/go-ethereum/common"
-	"testing"
-)
-
-func TestBlock_GetPrevRandao_IsNeverZero(t *testing.T) {
-	blk := Block{}
-	if h := blk.GetPrevRandao(); h == (common.Hash{}) {
-		t.Error("prevrandao must never be zero")
-	}
-}

--- a/inter/ibr/inter_block_records.go
+++ b/inter/ibr/inter_block_records.go
@@ -10,8 +10,8 @@ import (
 )
 
 type LlrBlockVote struct {
-	Atropos      hash.Event
-	Root         hash.Hash
+	BlockHash    hash.Hash
+	StateRoot    hash.Hash
 	TxHash       hash.Hash
 	ReceiptsHash hash.Hash
 	Time         inter.Timestamp
@@ -19,12 +19,12 @@ type LlrBlockVote struct {
 }
 
 type LlrFullBlockRecord struct {
-	Atropos  hash.Event
-	Root     hash.Hash
-	Txs      types.Transactions
-	Receipts []*types.ReceiptForStorage
-	Time     inter.Timestamp
-	GasUsed  uint64
+	BlockHash hash.Hash
+	StateRoot hash.Hash
+	Txs       types.Transactions
+	Receipts  []*types.ReceiptForStorage
+	Time      inter.Timestamp
+	GasUsed   uint64
 }
 
 type LlrIdxFullBlockRecord struct {
@@ -33,13 +33,13 @@ type LlrIdxFullBlockRecord struct {
 }
 
 func (bv LlrBlockVote) Hash() hash.Hash {
-	return hash.Of(bv.Atropos.Bytes(), bv.Root.Bytes(), bv.TxHash.Bytes(), bv.ReceiptsHash.Bytes(), bv.Time.Bytes(), bigendian.Uint64ToBytes(bv.GasUsed))
+	return hash.Of(bv.BlockHash.Bytes(), bv.StateRoot.Bytes(), bv.TxHash.Bytes(), bv.ReceiptsHash.Bytes(), bv.Time.Bytes(), bigendian.Uint64ToBytes(bv.GasUsed))
 }
 
 func (br LlrFullBlockRecord) Hash() hash.Hash {
 	return LlrBlockVote{
-		Atropos:      br.Atropos,
-		Root:         br.Root,
+		BlockHash:    br.BlockHash,
+		StateRoot:    br.StateRoot,
 		TxHash:       inter.CalcTxHash(br.Txs),
 		ReceiptsHash: inter.CalcReceiptsHash(br.Receipts),
 		Time:         br.Time,

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlockHeader_SatisfyInvariants(t *testing.T) {
+func TestBlockHeader_SatisfiesInvariants(t *testing.T) {
 	const numBlocks = 5
 	require := require.New(t)
 
@@ -74,11 +74,11 @@ func testHeaders_ParentHashCoversParentContent(t *testing.T, headers []*types.He
 	require := require.New(t)
 
 	// All other blocks have a parent hash that matches the previous block's hash.
-	// TODO: fix support for genesis blocks 0 and 1 as well;
-	for i := 2; i < len(headers); i++ {
+	for i := 1; i < len(headers); i++ {
 		require.Equal(
 			headers[i].ParentHash,
 			headers[i-1].Hash(),
+			"invalid hash stored in block %d for block %d", i, i-1,
 		)
 	}
 }
@@ -86,9 +86,6 @@ func testHeaders_ParentHashCoversParentContent(t *testing.T, headers []*types.He
 func testHeaders_GasUsedIsBelowGasLimit(t *testing.T, headers []*types.Header) {
 	require := require.New(t)
 	for i, header := range headers {
-		if i < 2 { // TODO: fix support for genesis blocks 0 and 1 as well;
-			continue
-		}
 		require.LessOrEqual(header.GasUsed, header.GasLimit, "block %d", i)
 	}
 }

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -21,9 +21,7 @@ func TestBlockHeader_SatisfiesInvariants(t *testing.T) {
 	// Produce a few blocks on the network.
 	for range numBlocks {
 		_, err := net.EndowAccount(common.Address{42}, 100)
-		if err != nil {
-			t.Fatalf("failed to endow account; %v", err)
-		}
+		require.NoError(err, "failed to endow account")
 	}
 
 	client, err := net.GetClient()

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -41,8 +41,8 @@ func TestBlockHeader_SatisfiesInvariants(t *testing.T) {
 		headers = append(headers, header)
 	}
 
-	t.Run("NumberMatchesPosition", func(t *testing.T) {
-		testHeaders_NumberMatchesPosition(t, headers)
+	t.Run("BlockNumberEqualsPositionInChain", func(t *testing.T) {
+		testHeaders_BlockNumberEqualsPositionInChain(t, headers)
 	})
 
 	t.Run("ParentHashCoversParentContent", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestBlockHeader_SatisfiesInvariants(t *testing.T) {
 	// - the random mixDigest field is different for each block
 }
 
-func testHeaders_NumberMatchesPosition(t *testing.T, headers []*types.Header) {
+func testHeaders_BlockNumberEqualsPositionInChain(t *testing.T, headers []*types.Header) {
 	require := require.New(t)
 	for i, header := range headers {
 		require.Equal(header.Number.Uint64(), uint64(i))
@@ -72,6 +72,12 @@ func testHeaders_NumberMatchesPosition(t *testing.T, headers []*types.Header) {
 
 func testHeaders_ParentHashCoversParentContent(t *testing.T, headers []*types.Header) {
 	require := require.New(t)
+
+	// The parent hash of block 0 is expected to be zero.
+	require.Equal(
+		headers[0].ParentHash, common.Hash{},
+		"invalid parent hash for block 0",
+	)
 
 	// All other blocks have a parent hash that matches the previous block's hash.
 	for i := 1; i < len(headers); i++ {

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -1,0 +1,94 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockHeader_SatisfyInvariants(t *testing.T) {
+	const numBlocks = 5
+	require := require.New(t)
+
+	net, err := StartIntegrationTestNet(t.TempDir())
+	require.NoError(err)
+	defer net.Stop()
+
+	// Produce a few blocks on the network.
+	for range numBlocks {
+		_, err := net.EndowAccount(common.Address{42}, 100)
+		if err != nil {
+			t.Fatalf("failed to endow account; %v", err)
+		}
+	}
+
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	lastBlock, err := client.BlockByNumber(context.Background(), nil)
+	require.NoError(err)
+	require.GreaterOrEqual(lastBlock.NumberU64(), uint64(numBlocks))
+
+	headers := []*types.Header{}
+	for i := int64(0); i < int64(lastBlock.NumberU64()); i++ {
+		header, err := client.HeaderByNumber(context.Background(), big.NewInt(i))
+		require.NoError(err)
+		headers = append(headers, header)
+	}
+
+	t.Run("NumberMatchesPosition", func(t *testing.T) {
+		testHeaders_NumberMatchesPosition(t, headers)
+	})
+
+	t.Run("ParentHashCoversParentContent", func(t *testing.T) {
+		testHeaders_ParentHashCoversParentContent(t, headers)
+	})
+
+	t.Run("GasUsedIsBelowGasLimit", func(t *testing.T) {
+		testHeaders_GasUsedIsBelowGasLimit(t, headers)
+	})
+
+	// TODO: Add more tests.
+	// - check that the transaction root matches the transactions in the block
+	// - check that the receipt root matches the receipts in the block
+	// - check that the logs bloom matches the logs in the receipts
+	// - coinbase is zero for all blocks
+	// - difficulty and nonce is set to 0
+	// - time is progressing strictly monotonically and approximately matches the current time
+	// - the random mixDigest field is different for each block
+}
+
+func testHeaders_NumberMatchesPosition(t *testing.T, headers []*types.Header) {
+	require := require.New(t)
+	for i, header := range headers {
+		require.Equal(header.Number.Uint64(), uint64(i))
+	}
+}
+
+func testHeaders_ParentHashCoversParentContent(t *testing.T, headers []*types.Header) {
+	require := require.New(t)
+
+	// All other blocks have a parent hash that matches the previous block's hash.
+	// TODO: fix support for genesis blocks 0 and 1 as well;
+	for i := 2; i < len(headers); i++ {
+		require.Equal(
+			headers[i].ParentHash,
+			headers[i-1].Hash(),
+		)
+	}
+}
+
+func testHeaders_GasUsedIsBelowGasLimit(t *testing.T, headers []*types.Header) {
+	require := require.New(t)
+	for i, header := range headers {
+		if i < 2 { // TODO: fix support for genesis blocks 0 and 1 as well;
+			continue
+		}
+		require.LessOrEqual(header.GasUsed, header.GasLimit, "block %d", i)
+	}
+}

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -210,7 +210,7 @@ func (n *IntegrationTestNet) GetReceipt(txHash common.Hash) (*types.Receipt, err
 	const maxDelay = 100 * time.Millisecond
 	now := time.Now()
 	delay := time.Millisecond
-	for time.Since(now) < 10*time.Second {
+	for time.Since(now) < 100*time.Second {
 		receipt, err := client.TransactionReceipt(context.Background(), txHash)
 		if errors.Is(err, ethereum.NotFound) {
 			time.Sleep(delay)


### PR DESCRIPTION
This PR aligns the block format used by Sonic with the format defined by Ethereum. In particular, hashes to identify blocks are now equivalent to the hashes of the respective block headers.

**Note:** this PR breaks backward compatibility with the Fantom mainnet. After this change, genesis data of former Fantom networks can no longer be used and resulting block hashes are incompatible.

### Changes

The main change required for this is the re-design of the storage format of blocks as they are retained on the disk. The previous format was a summary of the consensus events that formed to block, in particular including the list of `Events` the block was created from, as well as the Atropos and various lists of transactions and flags composing the block. When block information was required, it was derived from the available set on demand. This information was incomplete.

The new format stores block information explicitly on the disk. Everything required to reproduce the block (header) in its full detail is captured, to facilitate a complete reproduction. In particular, the following fields got added:
- ParentHash ... the hash of the parent block
- Difficulty ... the difficulty value for this block
- GasLimit ... the maximum amount of gas allowed for this block
- BaseFee ... the minimum gas price for this block
- PrevRandao ... the random value generated by the consensus for this block
- ReceiptsHashRoot ... cryptographic summary of all receipts in the block
- LogBloom ... summary of all log messages in the block

To simplify code creating blocks, a `BlockBuilder` was added. This allows to build blocks gradually -- by adding pairs of transactions and receipts -- and compute derived values in a final `Build` step.

Finally, the creation of *genesis* blocks was adjusted to satisfy the requirements of well defined blocks (in particular to use correct parent pointers). A major change there is that Block 0, which was previously retained implicit through hard-coded values in the code is now explicitly restored in the block store.

### Testing

As this targets a core element of the system, most preexisting tests cover are affected by this change. In particular integration tests in the `./tests` directory running fake nets are covering the creation, storage, and retrieval of block information. All of those tests pass without any changes.

Additionally, a new integration test suite, `./tests/block_header_test.go`, is added by this PR, checking the following invariants:
- block headers retrieved for block height x are indeed for block x
- the parent hash of a block corresponds to the hash of the header of the block's predecessor
- the gas usage of every block is at most the the gas limit of the block

The test suite provides a general framework for defining such block invariant properties and tests. A list of future tests to be added is left as a TODO for a follow-up PR.

Finally, this change was tested using Norma to verify through a smoke test that the resulting client can handle multi-node settups.

### For Reviewers

The suggested way to review this PR is in the following order:
- start with reviewing the changes in the `inter` package. This is the core of the change, defining the new storage format and hashing schema
- continue with `tests/block_header_test.go`, which defines the main objective of this change; in particular, it contains a test making sure that parent-references of blocks correspond to the hash of the parent's header
- review `gossip/c_block_callbacks.go` which contains the changes required for the block creation; related to this is the change `gossip/blockproc/evmmodule/evm.go` altering the list of produced receipts to include `nil` values for skipped transactions
- review changes in `gossip/c_llr_callbacks.go` which cover adaptations for the processing of blocks during genesis imports such that also those blocks satisfy block-invariants 
- the rest of the changes are adaptations to those changes above
