### PR TITLE
Add an integration test covering the restart of a node

### DIFF
--- a/gossip/gasprice/gasprice.go
+++ b/gossip/gasprice/gasprice.go
@@ -119,6 +119,10 @@ func NewOracle(params Config, backend Reader) *Oracle {
 	}
 }
 
+func (gpo *Oracle) SetReader(backend Reader) {
+	gpo.backend = backend
+}
+
 func (gpo *Oracle) Start() {
 	gpo.wg.Add(1)
 	go func() {

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func TestIntegrationTestNet_CanStartAndStopIntegrationTestNet(t *testing.T) {
+func TestIntegrationTestNet_CanStartRestartAndStopIntegrationTestNet(t *testing.T) {
 	dataDir := t.TempDir()
 	net, err := StartIntegrationTestNet(dataDir)
 	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
+		t.Fatalf("Failed to start the test network: %v", err)
+	}
+	if err := net.Restart(); err != nil {
+		t.Fatalf("Failed to restart the test network: %v", err)
 	}
 	net.Stop()
 }

--- a/tests/node_restart_test.go
+++ b/tests/node_restart_test.go
@@ -1,0 +1,58 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeRestart_CanRestartAndRestoreItsState(t *testing.T) {
+	const numBlocks = 3
+	const numRestarts = 2
+	require := require.New(t)
+
+	net, err := StartIntegrationTestNet(t.TempDir())
+	require.NoError(err)
+	defer net.Stop()
+
+	// All transaction hashes indexed by their blocks.
+	receipts := map[int]types.Receipts{}
+
+	// Run through multiple restarts.
+	for i := 0; i < numRestarts; i++ {
+		for range numBlocks {
+			receipt, err := net.EndowAccount(common.Address{42}, 100)
+			if err != nil {
+				t.Fatalf("failed to endow account; %v", err)
+			}
+			block := int(receipt.BlockNumber.Int64())
+			receipts[block] = append(receipts[block], receipt)
+		}
+		require.NoError(net.Restart())
+	}
+
+	// Check that access to all blocks is possible.
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	lastBlock, err := client.BlockByNumber(context.Background(), nil)
+	require.NoError(err)
+	require.GreaterOrEqual(lastBlock.NumberU64(), uint64(numBlocks*numRestarts))
+
+	for i := range lastBlock.NumberU64() {
+		block, err := client.BlockByNumber(context.Background(), big.NewInt(int64(i)))
+		require.NoError(err)
+
+		for _, receipt := range receipts[int(i)] {
+			position := receipt.TransactionIndex
+			require.Less(int(position), len(block.Transactions()), "block %d", i)
+			got := block.Transactions()[position].Hash()
+			require.Equal(got, receipt.TxHash, "block %d, tx %d", i, position)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the ability to add tests including the restart of a network node.

Recently, issues have been reported that the restart of a node with local state fails during it startup phase. To address such issues, a new integration test including the restarting of nodes got added. One of the reported issue -- for the node failing to be able to re-load its local transaction pool data -- could be reproduced and fixed as part of this PR.