### PR TITLE
Introduce dedicated min-base-fee parameter into rules

### DIFF
--- a/gossip/gasprice/base_fee.go
+++ b/gossip/gasprice/base_fee.go
@@ -17,8 +17,8 @@ func GetInitialBaseFee(rules opera.EconomyRules) *big.Int {
 	// no minimum gas price is set in the rules.
 	const defaultInitialBaseFee = 1e9
 	fee := big.NewInt(defaultInitialBaseFee)
-	if rules.MinGasPrice != nil && rules.MinGasPrice.Cmp(fee) > 0 {
-		fee = new(big.Int).Set(rules.MinGasPrice)
+	if rules.MinBaseFee != nil && rules.MinBaseFee.Cmp(fee) > 0 {
+		fee = new(big.Int).Set(rules.MinBaseFee)
 	}
 	return fee
 }
@@ -26,8 +26,8 @@ func GetInitialBaseFee(rules opera.EconomyRules) *big.Int {
 // GetBaseFeeForNextBlock computes the base fee for the next block based on the parent block.
 func GetBaseFeeForNextBlock(parent *evmcore.EvmHeader, rules opera.EconomyRules) *big.Int {
 	newPrice := getBaseFeeForNextBlock(parent, rules)
-	if rules.MinGasPrice != nil && newPrice.Cmp(rules.MinGasPrice) < 0 {
-		newPrice.Set(rules.MinGasPrice)
+	if rules.MinBaseFee != nil && newPrice.Cmp(rules.MinBaseFee) < 0 {
+		newPrice.Set(rules.MinBaseFee)
 	}
 	return newPrice
 }

--- a/gossip/gasprice/base_fee_test.go
+++ b/gossip/gasprice/base_fee_test.go
@@ -276,9 +276,9 @@ func TestBaseFee_DecayTimeFromInitialToZeroIsApproximately35Minutes(t *testing.T
 	}
 }
 
-func TestBaseFee_InitialPriceIsAtLeastMinGasPrice(t *testing.T) {
+func TestBaseFee_InitialPriceIsAtLeastMinBaseFee(t *testing.T) {
 	for _, minPrice := range []int64{-1, 0, 1, 1e8, 1e9, 1e10, 1e12} {
-		rules := opera.EconomyRules{MinGasPrice: big.NewInt(int64(minPrice))}
+		rules := opera.EconomyRules{MinBaseFee: big.NewInt(int64(minPrice))}
 		got := GetInitialBaseFee(rules).Int64()
 		if got < minPrice {
 			t.Errorf("initial price is below min gas price; got %d, min %d", got, minPrice)
@@ -286,12 +286,12 @@ func TestBaseFee_InitialPriceIsAtLeastMinGasPrice(t *testing.T) {
 	}
 }
 
-func TestBaseFee_DoesNotSinkBelowMinGasPrice(t *testing.T) {
+func TestBaseFee_DoesNotSinkBelowMinBaseFee(t *testing.T) {
 	for _, minPrice := range []int64{-1, 0, 1, 1e8, 1e9, 1e10} {
 		t.Run(fmt.Sprintf("minPrice=%d", minPrice), func(t *testing.T) {
 			minPrice := big.NewInt(minPrice)
 			rules := opera.EconomyRules{
-				MinGasPrice: minPrice,
+				MinBaseFee: minPrice,
 				ShortGasPower: opera.GasPowerRules{
 					AllocPerSec: 1e6,
 				},

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -125,7 +125,32 @@ type EconomyRules struct {
 
 	Gas GasRules
 
+	// MinGasPrice defines a lower boundary for the gas price
+	// on the network. However, its interpretation is different
+	// in the context of the Fantom and Sonic networks.
+	//
+	// On the Fantom network: MinGasPrice is the minimum gas price
+	// defining the base fee of a block. The MinGasPrice is set by
+	// the node driver and SFC on the Fantom network and adjusted
+	// based on load observed during an epoch. Base fees charged
+	// on the network correspond exactly to the MinGasPrice.
+	//
+	// On the Sonic network: this parameter is ignored. Base fees
+	// are controlled by the MinBaseFee parameter.
 	MinGasPrice *big.Int
+
+	// MinBaseFee is a lower bound for the base fee on the network.
+	// This option is only supported by the Sonic network. On the
+	// Fantom network it is ignored.
+	//
+	// On the Sonic network, base fees are automatically adjusted
+	// after each block based on the observed gas consumption rate.
+	// The value set by this parameter is a lower bound for these
+	// adjustments. Base fees may never fall below this value.
+	// Adjustments are made dynamically analogous to EIP-1559.
+	// See https://eips.ethereum.org/EIPS/eip-1559 and https://t.ly/BKrcr
+	// for additional information.
+	MinBaseFee *big.Int
 
 	ShortGasPower GasPowerRules
 	LongGasPower  GasPowerRules
@@ -163,10 +188,10 @@ var BaseChainConfig = ethparams.ChainConfig{
 	PetersburgBlock:               big.NewInt(0),
 	IstanbulBlock:                 big.NewInt(0),
 	MuirGlacierBlock:              big.NewInt(0), // EIP-2384: Muir Glacier Difficulty Bomb Delay - relevant for ethereum only
-	BerlinBlock:                   nil, // to be overwritten in EvmChainConfig
-	LondonBlock:                   nil, // to be overwritten in EvmChainConfig
-	ArrowGlacierBlock:             nil, // EIP-4345: Difficulty Bomb Delay - relevant for ethereum only
-	GrayGlacierBlock:              nil, // EIP-5133: Delaying Difficulty Bomb - relevant for ethereum only
+	BerlinBlock:                   nil,           // to be overwritten in EvmChainConfig
+	LondonBlock:                   nil,           // to be overwritten in EvmChainConfig
+	ArrowGlacierBlock:             nil,           // EIP-4345: Difficulty Bomb Delay - relevant for ethereum only
+	GrayGlacierBlock:              nil,           // EIP-5133: Delaying Difficulty Bomb - relevant for ethereum only
 	MergeNetsplitBlock:            nil,
 	ShanghaiTime:                  nil, // to be overwritten in EvmChainConfig
 	CancunTime:                    nil, // to be overwritten in EvmChainConfig
@@ -258,6 +283,7 @@ func DefaultEconomyRules() EconomyRules {
 		BlockMissedSlack: 50,
 		Gas:              DefaultGasRules(),
 		MinGasPrice:      big.NewInt(1e9),
+		MinBaseFee:       big.NewInt(1e3),
 		ShortGasPower:    DefaultShortGasPowerRules(),
 		LongGasPower:     DefaulLongGasPowerRules(),
 	}


### PR DESCRIPTION
This PR introduces a dedicated `MinBaseFee` parameter into the `EconomyRules` to control the minimum base fee in a network.

This eliminates the overloaded semantic of the preexisting `MinBaseFee`. 

It also eliminates interference of (outdated) SFC gas-price updates emitted at the end of each epoch with the new per-block base-fee pricing. This as been encountered as an obstacle when trying to test the new base-fee pricing model in fake-nets and experimental nets in Norma.