### PR TITLE
Increase gas limit for internal transactions

### DIFF
--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -66,7 +66,7 @@ func InternalTxBuilder(statedb state.StateDB) func(calldata []byte, addr common.
 		if nonce == math.MaxUint64 {
 			nonce = statedb.GetNonce(common.Address{})
 		}
-		tx := types.NewTransaction(nonce, addr, common.Big0, 1e6, common.Big0, calldata)
+		tx := types.NewTransaction(nonce, addr, common.Big0, 500_000_000, common.Big0, calldata)
 		nonce++
 		return tx
 	}

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -25,6 +25,8 @@ const (
 	londonBit              = 1 << 1
 	llrBit                 = 1 << 2
 	sonicBit               = 1 << 3
+
+	defaultMaxBlockGas uint64 = 1_000_000_000
 )
 
 var DefaultVMConfig = func() vm.Config {
@@ -251,7 +253,7 @@ func MainNetRules() Rules {
 		Epochs:    DefaultEpochsRules(),
 		Economy:   DefaultEconomyRules(),
 		Blocks: BlocksRules{
-			MaxBlockGas:             20500000,
+			MaxBlockGas:             defaultMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(1 * time.Minute),
 		},
 	}
@@ -265,7 +267,7 @@ func FakeNetRules() Rules {
 		Epochs:    FakeNetEpochsRules(),
 		Economy:   FakeEconomyRules(),
 		Blocks: BlocksRules{
-			MaxBlockGas:             20500000,
+			MaxBlockGas:             defaultMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(3 * time.Second),
 		},
 		Upgrades: Upgrades{


### PR DESCRIPTION
This PR increases the gas limit used for internal transactions to 500M units of gas and the maximum gas limit per block to 1000M gas units.