### PR TITLE
Introduce getAccount rpc method 

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -712,6 +712,35 @@ func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address common.Add
 	return (*hexutil.U256)(state.GetBalance(address)), state.Error()
 }
 
+// GetAccountResult is result struct for GetAccount
+type GetAccountResult struct {
+	CodeHash    common.Hash    `json:"codeHash"`
+	StorageRoot common.Hash    `json:"storageRoot"`
+	Balance     *hexutil.U256  `json:"balance"`
+	Nonce       hexutil.Uint64 `json:"nonce"`
+}
+
+// GetAccount returns the information about account with given address in the state of the given block number.
+// The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block numbers are also allowed.
+// The result contains:
+// 1) CodeHash - hash of the code for the given address
+// 2) StorageRoot - storage root for the given address
+// 3) Balance - the amount of wei for the given address
+// 4) Nonce - the number of transactions the given address
+func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*GetAccountResult, error) {
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
+	}
+	defer state.Release()
+	return &GetAccountResult{
+		CodeHash:    state.GetCodeHash(address),
+		StorageRoot: state.GetStorageRoot(address),
+		Balance:     (*hexutil.U256)(state.GetBalance(address)),
+		Nonce:       hexutil.Uint64(state.GetNonce(address)),
+	}, state.Error()
+}
+
 // AccountResult is result struct for GetProof
 type AccountResult struct {
 	Address      common.Address  `json:"address"`

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -726,10 +726,10 @@ type GetAccountResult struct {
 // 1) CodeHash - hash of the code for the given address
 // 2) StorageRoot - storage root for the given address
 // 3) Balance - the amount of wei for the given address
-// 4) Nonce - the number of transactions the given address
+// 4) Nonce - the number of transactions for given address
 func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*GetAccountResult, error) {
 	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
+	if err != nil {
 		return nil, err
 	}
 	defer state.Release()

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -1,0 +1,67 @@
+package tests
+
+import (
+	"github.com/Fantom-foundation/go-opera/ethapi"
+	"github.com/Fantom-foundation/go-opera/tests/contracts/transientstorage"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
+	"testing"
+)
+
+func TestGetAccount(t *testing.T) {
+	net, err := StartIntegrationTestNet(t.TempDir())
+	if err != nil {
+		t.Fatalf("Failed to start the fake network: %v", err)
+	}
+	defer net.Stop()
+
+	// Deploy the transient storage contract
+	contract, deployReceipt, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	if err != nil {
+		t.Fatalf("failed to deploy contract; %v", err)
+	}
+
+	// Fund the account furthermore with some tokens
+	addr := deployReceipt.ContractAddress
+
+	// Store the value in transient storage value
+	receipt, err := net.Apply(contract.StoreValue)
+	if err != nil {
+		t.Fatalf("failed to store value; %v", err)
+	}
+
+	// Check that the value was stored during transaction and emitted to logs
+	if len(receipt.Logs) != 1 {
+		t.Fatalf("unexpected number of logs; expected 1, got %d", len(receipt.Logs))
+	}
+
+	c, err := net.GetClient()
+	if err != nil {
+		t.Fatalf("failed to get client; %v", err)
+	}
+
+	rpcClient := c.Client()
+
+	var res ethapi.GetAccountResult
+	err = rpcClient.Call(&res, "eth_getAccount", addr, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Fatalf("failed to get account; %v", err)
+	}
+
+	if res.CodeHash == (common.Hash{}) {
+		t.Error("code hash should not be empty")
+	}
+
+	if res.StorageRoot == (common.Hash{}) {
+		t.Error("storage root should not be empty")
+	}
+
+	if got, want := (*uint256.Int)(res.Balance).Uint64(), uint64(0); got != want {
+		t.Errorf("balance too low, got: %d want: %d", got, want)
+	}
+
+	if res.Nonce < 1 {
+		t.Errorf("accounts nonce is expected to by at least 1")
+	}
+}

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -17,24 +17,12 @@ func TestGetAccount(t *testing.T) {
 	defer net.Stop()
 
 	// Deploy the transient storage contract
-	contract, deployReceipt, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	_, deployReceipt, err := DeployContract(net, transientstorage.DeployTransientstorage)
 	if err != nil {
 		t.Fatalf("failed to deploy contract; %v", err)
 	}
 
-	// Fund the account furthermore with some tokens
 	addr := deployReceipt.ContractAddress
-
-	// Store the value in transient storage value
-	receipt, err := net.Apply(contract.StoreValue)
-	if err != nil {
-		t.Fatalf("failed to store value; %v", err)
-	}
-
-	// Check that the value was stored during transaction and emitted to logs
-	if len(receipt.Logs) != 1 {
-		t.Fatalf("unexpected number of logs; expected 1, got %d", len(receipt.Logs))
-	}
 
 	c, err := net.GetClient()
 	if err != nil {
@@ -58,10 +46,10 @@ func TestGetAccount(t *testing.T) {
 	}
 
 	if got, want := (*uint256.Int)(res.Balance).Uint64(), uint64(0); got != want {
-		t.Errorf("balance too low, got: %d want: %d", got, want)
+		t.Errorf("balance not as expected, got: %d want: %d", got, want)
 	}
 
 	if res.Nonce < 1 {
-		t.Errorf("accounts nonce is expected to by at least 1")
+		t.Errorf("account nonce is expected to by at least 1")
 	}
 }


### PR DESCRIPTION
This PR adds `getAccount` method to the RPC according to [this](https://www.quicknode.com/docs/ethereum/eth_getAccount) documentation.

**Note:** As written in the code [here](https://github.com/Fantom-foundation/Sonic/blob/2001b3718c9182b159897adc0ceb66ba608dcb47/gossip/evmstore/carmen.go#L162) - Carmen currently actually does support `GetStorageRoot(addr)` - it returns a const non-empty hash for accounts which do not have empty storage and an empty hash for account which do have empty storage.