### PR TITLE
block/header properties tests

### DIFF
--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -257,7 +257,7 @@ func testHeaders_TimeProgressesMonotonically(t *testing.T, headers []*types.Head
 		return time.Unix(int64(header.Time), int64(currentNano))
 	}
 
-	for i := 2; i < len(headers); i++ {
+	for i := 1; i < len(headers); i++ {
 
 		currentTime := makeTimeFrom(headers[i])
 		previousTime := makeTimeFrom(headers[i-1])


### PR DESCRIPTION
This PR adds test checking the following properties for `block` and `header`.
- check that the transaction root matches the transactions in the block
- check that the receipt root matches the receipts in the block
- check that the logs bloom matches the logs in the receipts
- coinbase is zero for all blocks
- difficulty and nonce is set to 0
- time is progressing strictly monotonically and approximately matches the current time
- the random `mixDigest` field is different for each block

NOTE: issues https://github.com/Fantom-foundation/sonic-admin/issues/81 and https://github.com/Fantom-foundation/sonic-admin/issues/80 were originally found during development of these tests. 
