### PR TITLE
Bring back epoch logging

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -393,6 +393,7 @@ func consensusCallbackBeginBlockFn(
 						"txs", fmt.Sprintf("%d/%d", len(evmBlock.Transactions), len(skippedTxs)),
 						"age", utils.PrettyDuration(blockAge),
 						"t", utils.PrettyDuration(now.Sub(start)),
+						"epoch", evmBlock.Epoch,
 					)
 					blockAgeGauge.Update(int64(blockAge.Nanoseconds()))
 


### PR DESCRIPTION
This PR brings back the epoch number to the `NewBlock` logging.