### PR TITLE
Switch to fixed emitter rate

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -158,6 +158,11 @@ func consensusCallbackBeginBlockFn(
 				// We have to skip block in case (1) to ensure that every block ID is unique.
 				// If Atropos ID wasn't used as a block ID, it wouldn't be required.
 				skipBlock := atroposDegenerate
+				// Check if empty block should be pruned
+				if es.Rules.Emitter.Interval == 0 {
+					emptyBlock := false // confirmedEvents.Len() == 0 && cBlock.Cheaters.Len() == 0
+					skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+es.Rules.Blocks.MaxEmptyBlockSkipPeriod)
+				}
 				// Finalize the progress of eventProcessor
 				bs = eventProcessor.Finalize(blockCtx, skipBlock) // TODO: refactor to not mutate the bs, it is unclear
 				if skipBlock {

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -158,9 +158,6 @@ func consensusCallbackBeginBlockFn(
 				// We have to skip block in case (1) to ensure that every block ID is unique.
 				// If Atropos ID wasn't used as a block ID, it wouldn't be required.
 				skipBlock := atroposDegenerate
-				// Check if empty block should be pruned
-				emptyBlock := confirmedEvents.Len() == 0 && cBlock.Cheaters.Len() == 0
-				skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+es.Rules.Blocks.MaxEmptyBlockSkipPeriod)
 				// Finalize the progress of eventProcessor
 				bs = eventProcessor.Finalize(blockCtx, skipBlock) // TODO: refactor to not mutate the bs, it is unclear
 				if skipBlock {

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -159,10 +159,8 @@ func consensusCallbackBeginBlockFn(
 				// If Atropos ID wasn't used as a block ID, it wouldn't be required.
 				skipBlock := atroposDegenerate
 				// Check if empty block should be pruned
-				if es.Rules.Emitter.Interval == 0 {
-					emptyBlock := confirmedEvents.Len() == 0 && cBlock.Cheaters.Len() == 0
-					skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+es.Rules.Blocks.MaxEmptyBlockSkipPeriod)
-				}
+				emptyBlock := confirmedEvents.Len() == 0 && cBlock.Cheaters.Len() == 0
+				skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+es.Rules.Blocks.MaxEmptyBlockSkipPeriod)
 				// Finalize the progress of eventProcessor
 				bs = eventProcessor.Finalize(blockCtx, skipBlock) // TODO: refactor to not mutate the bs, it is unclear
 				if skipBlock {

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -160,7 +160,7 @@ func consensusCallbackBeginBlockFn(
 				skipBlock := atroposDegenerate
 				// Check if empty block should be pruned
 				if es.Rules.Emitter.Interval == 0 {
-					emptyBlock := false // confirmedEvents.Len() == 0 && cBlock.Cheaters.Len() == 0
+					emptyBlock := confirmedEvents.Len() == 0 && cBlock.Cheaters.Len() == 0
 					skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+es.Rules.Blocks.MaxEmptyBlockSkipPeriod)
 				}
 				// Finalize the progress of eventProcessor

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -140,6 +140,7 @@ func newTestEnv(firstEpoch idx.Epoch, validatorsNum idx.Validator, tb testing.TB
 	rules := opera.FakeNetRules()
 	rules.Epochs.MaxEpochDuration = inter.Timestamp(maxEpochDuration)
 	rules.Blocks.MaxEmptyBlockSkipPeriod = 0
+	rules.Emitter.Interval = 0
 
 	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(validatorsNum, utils.ToFtm(genesisBalance), utils.ToFtm(genesisStake), rules, firstEpoch, 2)
 	genesis := genStore.Genesis()

--- a/gossip/emitter/control.go
+++ b/gossip/emitter/control.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/utils/piecefunc"
 
 	"github.com/Fantom-foundation/go-opera/inter"
+	"github.com/Fantom-foundation/go-opera/opera"
 )
 
 func scalarUpdMetric(diff idx.Event, weight pos.Weight, totalWeight pos.Weight) ancestor.Metric {
@@ -47,7 +48,10 @@ func (em *Emitter) isAllowedToEmit(e inter.EventI, eTxs bool, metric ancestor.Me
 		passedTime = 0
 	}
 
-	return passedTime >= 600*time.Millisecond // TODO: make it configurable
+	// If a emitter interval is defined, all other heuristics are ignored.
+	if interval, enabled := em.getEmitterIntervalLimit(); enabled {
+		return passedTime >= interval
+	}
 
 	passedTimeIdle := e.CreationTime().Time().Sub(em.prevIdleTime)
 	if passedTimeIdle < 0 {
@@ -145,4 +149,42 @@ func (em *Emitter) recheckIdleTime() {
 	if em.idle() {
 		em.prevIdleTime = time.Now()
 	}
+}
+
+func (em *Emitter) getEmitterIntervalLimit() (interval time.Duration, enabled bool) {
+	rules := em.world.GetRules().Emitter
+
+	var lastConfirmationTime time.Time
+	if last := em.lastTimeAnEventWasConfirmed.Load(); last != nil {
+		lastConfirmationTime = *last
+	} else {
+		// If we have not seen any event confirmed so far, we take the current time
+		// as the last confirmation time. Thus, during start-up we would not unnecessarily
+		// slow down the event emission for the very first event. The switch into the stall
+		// mode is delayed by the stall-threshold.
+		now := time.Now()
+		em.lastTimeAnEventWasConfirmed.Store(&now)
+		lastConfirmationTime = now
+	}
+
+	return getEmitterIntervalLimit(rules, time.Since(lastConfirmationTime))
+}
+
+func getEmitterIntervalLimit(
+	rules opera.EmitterRules,
+	delayOfLastConfirmedEvent time.Duration,
+) (interval time.Duration, enabled bool) {
+	// Check whether the fixed-interval emitter should be enabled.
+	if rules.Interval == 0 {
+		return 0, false
+	}
+
+	// Check for a network-stall situation in which events emitting should be slowed down.
+	stallThreshold := time.Duration(rules.StallThreshold) * time.Millisecond
+	if delayOfLastConfirmedEvent > stallThreshold {
+		return time.Duration(rules.StalledInterval) * time.Millisecond, true
+	}
+
+	// Use the regular emitter interval.
+	return time.Duration(rules.Interval) * time.Millisecond, true
 }

--- a/gossip/emitter/control.go
+++ b/gossip/emitter/control.go
@@ -46,6 +46,9 @@ func (em *Emitter) isAllowedToEmit(e inter.EventI, eTxs bool, metric ancestor.Me
 	if passedTime < 0 {
 		passedTime = 0
 	}
+
+	return passedTime >= 600*time.Millisecond // TODO: make it configurable
+
 	passedTimeIdle := e.CreationTime().Time().Sub(em.prevIdleTime)
 	if passedTimeIdle < 0 {
 		passedTimeIdle = 0

--- a/gossip/emitter/control.go
+++ b/gossip/emitter/control.go
@@ -180,11 +180,11 @@ func getEmitterIntervalLimit(
 	}
 
 	// Check for a network-stall situation in which events emitting should be slowed down.
-	stallThreshold := time.Duration(rules.StallThreshold) * time.Millisecond
+	stallThreshold := time.Duration(rules.StallThreshold)
 	if delayOfLastConfirmedEvent > stallThreshold {
-		return time.Duration(rules.StalledInterval) * time.Millisecond, true
+		return time.Duration(rules.StalledInterval), true
 	}
 
 	// Use the regular emitter interval.
-	return time.Duration(rules.Interval) * time.Millisecond, true
+	return time.Duration(rules.Interval), true
 }

--- a/gossip/emitter/control_test.go
+++ b/gossip/emitter/control_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/opera"
 )
 
 func TestGetEmitterIntervalLimit_IsOffWhenIntervalIsZero(t *testing.T) {
+	ms := time.Microsecond
 	rules := opera.EmitterRules{
 		Interval:       0,
-		StallThreshold: 200,
+		StallThreshold: inter.Timestamp(200 * ms),
 	}
-	ms := time.Microsecond
 	for _, delay := range []time.Duration{0, 100 * ms, 199 * ms, 200 * ms, 201 * ms} {
 		_, enabled := getEmitterIntervalLimit(rules, delay)
 		if enabled {
@@ -28,9 +29,9 @@ func TestGetEmitterIntervalLimit_SwitchesToStallIfDelayed(t *testing.T) {
 	stalled := 300 * ms
 
 	rules := opera.EmitterRules{
-		Interval:        uint64(regular.Milliseconds()),
-		StallThreshold:  uint64(stallThreshold.Milliseconds()),
-		StalledInterval: uint64(stalled.Milliseconds()),
+		Interval:        inter.Timestamp(regular),
+		StallThreshold:  inter.Timestamp(stallThreshold),
+		StalledInterval: inter.Timestamp(stalled),
 	}
 
 	for _, delay := range []time.Duration{0, 100 * ms, 199 * ms, 200 * ms, 201 * ms, 60 * time.Minute} {
@@ -43,7 +44,7 @@ func TestGetEmitterIntervalLimit_SwitchesToStallIfDelayed(t *testing.T) {
 			want = stalled
 		}
 		if want != got {
-			t.Fatalf("for delay %v, want %v, got %v", delay, want, got)
+			t.Errorf("for delay %v, want %v, got %v", delay, want, got)
 		}
 	}
 }

--- a/gossip/emitter/control_test.go
+++ b/gossip/emitter/control_test.go
@@ -1,0 +1,49 @@
+package emitter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/go-opera/opera"
+)
+
+func TestGetEmitterIntervalLimit_IsOffWhenIntervalIsZero(t *testing.T) {
+	rules := opera.EmitterRules{
+		Interval:       0,
+		StallThreshold: 200,
+	}
+	ms := time.Microsecond
+	for _, delay := range []time.Duration{0, 100 * ms, 199 * ms, 200 * ms, 201 * ms} {
+		_, enabled := getEmitterIntervalLimit(rules, delay)
+		if enabled {
+			t.Fatal("should be disabled")
+		}
+	}
+}
+
+func TestGetEmitterIntervalLimit_SwitchesToStallIfDelayed(t *testing.T) {
+	ms := time.Millisecond
+	regular := 100 * ms
+	stallThreshold := 200 * ms
+	stalled := 300 * ms
+
+	rules := opera.EmitterRules{
+		Interval:        uint64(regular.Milliseconds()),
+		StallThreshold:  uint64(stallThreshold.Milliseconds()),
+		StalledInterval: uint64(stalled.Milliseconds()),
+	}
+
+	for _, delay := range []time.Duration{0, 100 * ms, 199 * ms, 200 * ms, 201 * ms, 60 * time.Minute} {
+		got, enabled := getEmitterIntervalLimit(rules, delay)
+		if !enabled {
+			t.Fatalf("should be enabled for delay %v", delay)
+		}
+		want := regular
+		if delay > stallThreshold {
+			want = stalled
+		}
+		if want != got {
+			t.Fatalf("for delay %v, want %v, got %v", delay, want, got)
+		}
+	}
+}

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Fantom-foundation/go-opera/utils"
@@ -107,6 +108,8 @@ type Emitter struct {
 	logger.Periodic
 
 	baseFeeSource BaseFeeSource
+
+	lastTimeAnEventWasConfirmed atomic.Pointer[time.Time]
 }
 
 type BaseFeeSource interface {

--- a/gossip/emitter/hooks.go
+++ b/gossip/emitter/hooks.go
@@ -1,8 +1,9 @@
 package emitter
 
 import (
-	"github.com/Fantom-foundation/go-opera/utils/txtime"
 	"time"
+
+	"github.com/Fantom-foundation/go-opera/utils/txtime"
 
 	"github.com/Fantom-foundation/lachesis-base/emitter/ancestor"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -117,6 +118,8 @@ func (em *Emitter) OnEventConfirmed(he inter.EventI) {
 	if !em.isValidator() {
 		return
 	}
+	now := time.Now()
+	em.lastTimeAnEventWasConfirmed.Store(&now)
 	if em.pendingGas > he.GasPowerUsed() {
 		em.pendingGas -= he.GasPowerUsed()
 	} else {

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -65,6 +65,9 @@ type RulesRLP struct {
 	// Graph options
 	Dag DagRules
 
+	// Emitter options
+	Emitter EmitterRules
+
 	// Epochs options
 	Epochs EpochsRules
 
@@ -113,6 +116,44 @@ type DagRules struct {
 	MaxParents     idx.Event
 	MaxFreeParents idx.Event // maximum number of parents with no gas cost
 	MaxExtraData   uint32
+}
+
+// EmitterRules contains options for the emitter of Lachesis events.
+type EmitterRules struct {
+	// Interval defines the length of the period
+	// between events produced by the emitter in milliseconds.
+	// If set to zero, a heuristic is used producing irregular
+	// intervals.
+	//
+	// The Interval is used to control the rate of event
+	// production by the emitter. It thus indirectly controls
+	// the rate of blocks production on the network, by providing
+	// a lower bound. The actual block production rate is also
+	// influenced by the number of validators, their weighting,
+	// and the inter-connection of events. However, the Interval
+	// should provide an effective mean to control the block
+	// production rate.
+	Interval uint64 // in milliseconds, 0 to disable
+
+	// StallThreshold defines a maximum time the confirmation of
+	// new events may be delayed before the emitter considers the
+	// network stalled.
+	//
+	// The emitter has two modes: normal and stalled. In normal
+	// mode, the emitter produces events at a regular interval, as
+	// defined by the Interval option. In stalled mode, the emitter
+	// produces events at a much lower rate, to avoid building up
+	// a backlog of events. The StallThreshold defines the upper
+	// limit of delay seen for new confirmed events before the emitter
+	// switches to stalled mode.
+	//
+	// This option is disabled if Interval is set to 0.
+	StallThreshold uint64 // in milliseconds
+
+	// StallInterval defines the length of the period between
+	// events produced by the emitter in milliseconds when the
+	// network is stalled.
+	StalledInterval uint64 // in milliseconds
 }
 
 // BlocksMissed is information about missed blocks from a staker
@@ -250,6 +291,7 @@ func MainNetRules() Rules {
 		Name:      "main",
 		NetworkID: MainNetworkID,
 		Dag:       DefaultDagRules(),
+		Emitter:   DefaultEmitterRules(),
 		Epochs:    DefaultEpochsRules(),
 		Economy:   DefaultEconomyRules(),
 		Blocks: BlocksRules{
@@ -264,6 +306,7 @@ func FakeNetRules() Rules {
 		Name:      "fake",
 		NetworkID: FakeNetworkID,
 		Dag:       DefaultDagRules(),
+		Emitter:   DefaultEmitterRules(),
 		Epochs:    FakeNetEpochsRules(),
 		Economy:   FakeEconomyRules(),
 		Blocks: BlocksRules{
@@ -305,6 +348,14 @@ func DefaultDagRules() DagRules {
 		MaxParents:     10,
 		MaxFreeParents: 3,
 		MaxExtraData:   128,
+	}
+}
+
+func DefaultEmitterRules() EmitterRules {
+	return EmitterRules{
+		Interval:        600,       // ms
+		StallThreshold:  30 * 1000, // 30 seconds in ms
+		StalledInterval: 60 * 1000, // 60 seconds in ms
 	}
 }
 

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -133,7 +133,7 @@ type EmitterRules struct {
 	// and the inter-connection of events. However, the Interval
 	// should provide an effective mean to control the block
 	// production rate.
-	Interval uint64 // in milliseconds, 0 to disable
+	Interval inter.Timestamp
 
 	// StallThreshold defines a maximum time the confirmation of
 	// new events may be delayed before the emitter considers the
@@ -148,12 +148,12 @@ type EmitterRules struct {
 	// switches to stalled mode.
 	//
 	// This option is disabled if Interval is set to 0.
-	StallThreshold uint64 // in milliseconds
+	StallThreshold inter.Timestamp
 
 	// StallInterval defines the length of the period between
 	// events produced by the emitter in milliseconds when the
 	// network is stalled.
-	StalledInterval uint64 // in milliseconds
+	StalledInterval inter.Timestamp
 }
 
 // BlocksMissed is information about missed blocks from a staker
@@ -353,9 +353,9 @@ func DefaultDagRules() DagRules {
 
 func DefaultEmitterRules() EmitterRules {
 	return EmitterRules{
-		Interval:        600,       // ms
-		StallThreshold:  30 * 1000, // 30 seconds in ms
-		StalledInterval: 60 * 1000, // 60 seconds in ms
+		Interval:        inter.Timestamp(600 * time.Millisecond),
+		StallThreshold:  inter.Timestamp(30 * time.Second),
+		StalledInterval: inter.Timestamp(60 * time.Second),
 	}
 }
 

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -279,10 +279,21 @@ func testHeaders_MixDigestDiffersForAllBlocks(t *testing.T, headers []*types.Hea
 	seen := map[common.Hash]struct{}{}
 
 	for i := 1; i < len(headers); i++ {
-		_, ok := seen[headers[i].MixDigest]
-		require.False(ok, "mix digest is not unique")
-		seen[headers[i].MixDigest] = struct{}{}
+		// We skip empty blocks, since in those cases the MixDigest value is not
+		// consumed by any transaction. For those cases, values may be reused.
+		// Since the prev-randao value filling this field is computed based on
+		// the hash of non-empty lachesis events, the value used for empty blocks
+		// is always the same.
+		header := headers[i]
+		if header.GasUsed == 0 {
+			continue
+		}
+		digest := header.MixDigest
+		_, found := seen[digest]
+		require.False(found, "mix digest is not unique, block %d, value %x", i, digest)
+		seen[digest] = struct{}{}
 	}
+	require.NotZero(len(seen), "no non-empty blocks in the chain")
 }
 
 func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, headers []*types.Header, client *ethclient.Client) {

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -37,10 +37,10 @@ func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 	}
 
 	// Suggestions should over-estimate the actual prices by ~10%
-	for i := range suggestions {
-		ratio := float64(suggestions[i]) / float64(fees[i])
-		require.Less(1.09, ratio)
-		require.Less(ratio, 1.11)
+	for i := 1; i < int(len(suggestions)); i++ {
+		ratio := float64(suggestions[i]) / float64(fees[i-1])
+		require.Less(1.09, ratio, "step %d, suggestion %d, fees %d", i, suggestions[i], fees[i-1])
+		require.Less(ratio, 1.11, "step %d, suggestion %d, fees %d", i, suggestions[i], fees[i-1])
 	}
 }
 


### PR DESCRIPTION
This PR introduces a simplification of the event emitter timing policy. The previous emitter policy which was deriving the decision whether to emit or not from various network-state parameters is (optionally) replaced by a simpler time-based emitter rate.

#### Fixed-Rate Emitter Policy
If enabled, the new emitter has the following properties:
- in normal mode, every validator produces a new event every `X` milliseconds
- if for threshold time `T` no new events are confirmed on the network, the emitter switches into a `stall` mode and reduces the emitter rate to `Y`

The parameters `X`, `T`, and `Y` can be configured using network rules. Those rules also allow to disable this rate-based emitter policy and revert to the previous policy.

#### Evaluation
In Norma based experiments, this new emitter timing policy helps reducing block-time variability. To demonstrate this, the following scenario was evaluated:
- a network is started comprising 2 validators
- for 40 seconds a minimal load of 1 transaction per second is send into the network, produced by a single user
- after a 10 second break, a load of 10 transactions per second is send into the network for another 40 seconds

The following chart shows the block-times **before** this change:
![image](https://github.com/user-attachments/assets/ff484131-f207-47f0-906a-f12af2c1b968)

For the low-load interval, few blocks are created, with a block time of approximately 4.6 seconds. Once the 10 Tx/s load case is reached, numerous blocks are created, with a block time of a few 100 milliseconds -- significantly lower than required.

Thus, the network load had a considerable impact on the block time -- and thus the lower boundary of the time to finality. With low load, blocks could take more than 4 seconds to be created, while with moderate load too many blocks are created.

The following chart shows the block-times **after** this change, with a target-block time of 600 ms (dashed red line):
![image](https://github.com/user-attachments/assets/74911eae-bf5d-4cfa-b915-222cb8155c0d)

With this change, the timing of new blocks becomes independent of the actual network traffic.

When repeating the experiment with 20 validator nodes, block times are also found to be stable, as shown in the following graph:
![image](https://github.com/user-attachments/assets/0f074392-99c6-4cf2-a88a-4eefa1359844)

However, due to the delay of the propagation of events and the limited degree of parent references in events, the block time becomes more variable. For the network deployment, this property should be monitored and the desired emitter rate adjusted accordingly.
