### PR TITLE
updates Carmen - fix to HasEmptyStorage for self-destruct acc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.3
 
 require (
-	github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8
+	github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4
 	github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.3
 
 require (
-	github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4
+	github.com/Fantom-foundation/Carmen/go v0.0.0-20241121102311-62fc85c89464
 	github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8 h1:uDl
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4 h1:8FF/xZh6fBMHF3B19cMvPg909eDQJqatsVuUbtBQeHk=
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241121102311-62fc85c89464 h1:xWayjc87Mk3ESu4xGtX6YYx7KrN+gJpCWZhqmZHDpxs=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241121102311-62fc85c89464/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10 h1:D7askaARHcrcXDVZHweaxxz2wKvo/ipvjA/qooyEkNM=
 github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10/go.mod h1:DtJlv3NCjaFxBKGXR7HQfLhLSu+BY5OILQ/4s7MR6lA=
 github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675 h1:Meqtt0eM9UAw1ceQ1tGiD497V0IVfqj8c6UrFJhkFNE=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Fantom-foundation/Carmen/go v0.0.0-20241021085109-e8dc12374917 h1:Nis
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241021085109-e8dc12374917/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8 h1:uDlLl/ZbGUM7FHxDjmzHxMnJkSvOt8mLV9+O41pROGA=
 github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4 h1:8FF/xZh6fBMHF3B19cMvPg909eDQJqatsVuUbtBQeHk=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10 h1:D7askaARHcrcXDVZHweaxxz2wKvo/ipvjA/qooyEkNM=
 github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10/go.mod h1:DtJlv3NCjaFxBKGXR7HQfLhLSu+BY5OILQ/4s7MR6lA=
 github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675 h1:Meqtt0eM9UAw1ceQ1tGiD497V0IVfqj8c6UrFJhkFNE=


### PR DESCRIPTION
This PR updates Carmen to include this fix: https://github.com/Fantom-foundation/Carmen/pull/1049

It fixes `HasEmptyStorage` method on `stateDB` to return a correct value if an account is self destructed and re-created within the same block.  Originally,   `HasEmptyStorage`  has seen only the state from previous block. If the self-destruct was called, the storage must be considered empty, but the method would reflect it and prevented re-creation of the account. 

With this change, the method  `HasEmptyStorage` checks changes happening in current block and reflects that a desctructed account has an empty storge.

TODO 

- [x] Update this PR to a merged version of Carmen, not the PR