### PR TITLE
genesis timestamp

### DIFF
--- a/cmd/sonicd/app/fake_test.go
+++ b/cmd/sonicd/app/fake_test.go
@@ -95,5 +95,5 @@ func readFakeValidator(fakenet string) *validatorpk.PubKey {
 }
 
 func genesisStart() string {
-	return time.Unix(genesis.TimeStampZero, 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
+	return time.Unix(genesis.TimeStampZero.Unix(), 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
 }

--- a/cmd/sonicd/app/fake_test.go
+++ b/cmd/sonicd/app/fake_test.go
@@ -1,20 +1,22 @@
 package app
 
 import (
-	"github.com/Fantom-foundation/go-opera/config"
-	"github.com/Fantom-foundation/go-opera/version"
-	"github.com/ethereum/go-ethereum/crypto"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Fantom-foundation/go-opera/config"
+	"github.com/Fantom-foundation/go-opera/opera/genesis"
+	"github.com/Fantom-foundation/go-opera/version"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/Fantom-foundation/go-opera/integration/makefakegenesis"
 	"github.com/Fantom-foundation/go-opera/inter/validatorpk"
 )
 
 const (
-	ipcAPIs  = "abft:1.0 admin:1.0 dag:1.0 debug:1.0 ftm:1.0 net:1.0 personal:1.0 rpc:1.0 trace:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs = "abft:1.0 admin:1.0 dag:1.0 debug:1.0 ftm:1.0 net:1.0 personal:1.0 rpc:1.0 trace:1.0 txpool:1.0 web3:1.0"
 )
 
 func TestFakeNetFlag_NonValidator(t *testing.T) {
@@ -93,5 +95,5 @@ func readFakeValidator(fakenet string) *validatorpk.PubKey {
 }
 
 func genesisStart() string {
-	return time.Unix(int64(makefakegenesis.FakeGenesisTime.Unix()), 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
+	return time.Unix(genesis.TimeStampZero, 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
 }

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -62,7 +62,7 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 
 	blockZero := inter.NewBlockBuilder().
 		WithNumber(0).
-		WithTime(genesis.TimeStampZero - 1). // TODO: extend genesis generator to provide time
+		WithTime(genesis.TimeStampZero - 1).
 		WithGasLimit(gasLimit).
 		WithStateRoot(common.Hash{}). // TODO: get proper state root from genesis data
 		WithBaseFee(gasprice.GetInitialBaseFee(rules.Economy)).

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -62,7 +62,7 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 
 	blockZero := inter.NewBlockBuilder().
 		WithNumber(0).
-		WithTime(evmcore.FakeGenesisTime - 1). // TODO: extend genesis generator to provide time
+		WithTime(genesis.TimeStampZero - 1). // TODO: extend genesis generator to provide time
 		WithGasLimit(gasLimit).
 		WithStateRoot(common.Hash{}). // TODO: get proper state root from genesis data
 		WithBaseFee(gasprice.GetInitialBaseFee(rules.Economy)).

--- a/integration/makefakegenesis/genesis.go
+++ b/integration/makefakegenesis/genesis.go
@@ -3,7 +3,6 @@ package makefakegenesis
 import (
 	"crypto/ecdsa"
 	"math/big"
-	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/integration/makegenesis"
-	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/inter/drivertype"
 	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/inter/ier"
@@ -31,10 +29,6 @@ import (
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
 	"github.com/Fantom-foundation/go-opera/opera/genesis/gpos"
 	"github.com/Fantom-foundation/go-opera/opera/genesisstore"
-)
-
-var (
-	FakeGenesisTime = inter.Timestamp(1608600000 * time.Second)
 )
 
 // FakeKey gets n-th fake private key.
@@ -89,7 +83,7 @@ func FakeGenesisStoreWithRulesAndStart(num idx.Validator, balance, stake *big.In
 			BlockState: iblockproc.BlockState{
 				LastBlock: iblockproc.BlockCtx{
 					Idx:     block - 1,
-					Time:    FakeGenesisTime,
+					Time:    genesis.TimeStampZero,
 					Atropos: hash.Event{},
 				},
 				FinalizedStateRoot:    hash.Hash{},
@@ -103,8 +97,8 @@ func FakeGenesisStoreWithRulesAndStart(num idx.Validator, balance, stake *big.In
 			},
 			EpochState: iblockproc.EpochState{
 				Epoch:             epoch - 1,
-				EpochStart:        FakeGenesisTime,
-				PrevEpochStart:    FakeGenesisTime - 1,
+				EpochStart:        genesis.TimeStampZero,
+				PrevEpochStart:    genesis.TimeStampZero - 1,
 				EpochStateRoot:    hash.Zero,
 				Validators:        pos.NewBuilder().Build(),
 				ValidatorStates:   make([]iblockproc.ValidatorEpochState, 0),
@@ -176,7 +170,7 @@ func GetFakeValidators(num idx.Validator) gpos.Validators {
 				Raw:  pubkeyraw,
 				Type: validatorpk.Types.Secp256k1,
 			},
-			CreationTime:     FakeGenesisTime,
+			CreationTime:     genesis.TimeStampZero,
 			CreationEpoch:    0,
 			DeactivatedTime:  0,
 			DeactivatedEpoch: 0,

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -5,6 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/big"
+	"os"
+
 	"github.com/Fantom-foundation/go-opera/integration/makegenesis"
 	"github.com/Fantom-foundation/go-opera/inter/drivertype"
 	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
@@ -18,8 +21,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"math/big"
-	"os"
 )
 
 type GenesisJson struct {
@@ -80,7 +81,7 @@ func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
 			BlockState: iblockproc.BlockState{
 				LastBlock: iblockproc.BlockCtx{
 					Idx:     0,
-					Time:    FakeGenesisTime,
+					Time:    genesis.TimeStampZero,
 					Atropos: hash.Event{},
 				},
 				FinalizedStateRoot:    hash.Hash{},
@@ -94,8 +95,8 @@ func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
 			},
 			EpochState: iblockproc.EpochState{
 				Epoch:             1,
-				EpochStart:        FakeGenesisTime,
-				PrevEpochStart:    FakeGenesisTime - 1,
+				EpochStart:        genesis.TimeStampZero,
+				PrevEpochStart:    genesis.TimeStampZero - 1,
 				EpochStateRoot:    hash.Zero,
 				Validators:        pos.NewBuilder().Build(),
 				ValidatorStates:   make([]iblockproc.ValidatorEpochState, 0),

--- a/opera/genesis/types.go
+++ b/opera/genesis/types.go
@@ -1,9 +1,11 @@
 package genesis
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
 	"io"
 
+	"github.com/Fantom-foundation/lachesis-base/hash"
+
+	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/inter/ibr"
 	"github.com/Fantom-foundation/go-opera/inter/ier"
 )
@@ -35,7 +37,7 @@ type (
 	}
 	SignedMetadata struct {
 		Signature []byte
-		Hashes []byte
+		Hashes    []byte
 	}
 	Genesis struct {
 		Header
@@ -48,6 +50,8 @@ type (
 		SignatureSection
 	}
 )
+
+const TimeStampZero inter.Timestamp = 1608600000
 
 func (hh Hashes) Includes(hh2 Hashes) bool {
 	for n, h := range hh {

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -257,7 +257,7 @@ func testHeaders_TimeProgressesMonotonically(t *testing.T, headers []*types.Head
 	for i := 1; i < len(headers); i++ {
 		currentTime := getTimeFrom(headers[i])
 		previousTime := getTimeFrom(headers[i-1])
-		require.Greater(currentTime, previousTime, "time is not monotonically increasing")
+		require.Greater(currentTime, previousTime, "time is not monotonically increasing. block %d", i)
 	}
 }
 


### PR DESCRIPTION
This PR attempts to fix https://github.com/Fantom-foundation/sonic-admin/issues/80
by gathering the multiple declarations of `fakeGenesisTime` into the genesis package, and referring to it when needed.
