### PR TITLE
Cleanup of network rule parameters

### DIFF
--- a/gossip/gasprice/base_fee.go
+++ b/gossip/gasprice/base_fee.go
@@ -10,12 +10,12 @@ import (
 
 // GetInitialBaseFee returns the initial base fee to be used in the genesis block.
 func GetInitialBaseFee(rules opera.EconomyRules) *big.Int {
-	// The default initial base fee is set to 1 Gwei. While a value of 0 would
+	// The default initial base fee is set to 10 Gwei. While a value of 0 would
 	// also be valid, this value was chosen to have non-zero prices in low-load
 	// test networks at least for the first several minutes. In case of no load
 	// on the network, the base fee will decrease to 0 within ~35 minutes if
 	// no minimum gas price is set in the rules.
-	const defaultInitialBaseFee = 1e9
+	const defaultInitialBaseFee = 1e10
 	fee := big.NewInt(defaultInitialBaseFee)
 	if rules.MinBaseFee != nil && rules.MinBaseFee.Cmp(fee) > 0 {
 		fee = new(big.Int).Set(rules.MinBaseFee)

--- a/gossip/gasprice/base_fee_test.go
+++ b/gossip/gasprice/base_fee_test.go
@@ -238,7 +238,7 @@ func TestBaseFee_ShrinksAtMostTwelveAndAHalfPercentPer15Seconds(t *testing.T) {
 	}
 }
 
-func TestBaseFee_DecayTimeFromInitialToZeroIsApproximately35Minutes(t *testing.T) {
+func TestBaseFee_DecayTimeFromInitialToZeroIsApproximately40Minutes(t *testing.T) {
 	rules := opera.EconomyRules{
 		ShortGasPower: opera.GasPowerRules{
 			AllocPerSec: 1e6,
@@ -266,7 +266,7 @@ func TestBaseFee_DecayTimeFromInitialToZeroIsApproximately35Minutes(t *testing.T
 				decayDuration += blockTime
 			}
 
-			if decayDuration < 30*time.Minute || decayDuration > 40*time.Minute {
+			if decayDuration < 35*time.Minute || decayDuration > 45*time.Minute {
 				t.Errorf(
 					"time to decay from initial to zero is incorrect; got %v",
 					decayDuration,


### PR DESCRIPTION
This PR updates various default network parameters to be consistent with a network capacity of ~30 MGas/s with a target rate of ~15 MGas/s. These targets values are used as the defaults for main and fake-net rule sets.

Further changes:
- the initial base-fee price is increased to 10 Gwei
- the minimum base-fee price is increased to 1 Gwei