### PR TITLE
Lower integration tests memory usage

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -65,6 +65,8 @@ func initFlags() {
 	}
 	performanceFlags = []cli.Flag{
 		flags.CacheFlag,
+		flags.LiveDbCacheFlag,
+		flags.ArchiveCacheFlag,
 	}
 	networkingFlags = []cli.Flag{
 		flags.BootnodesFlag,
@@ -222,9 +224,12 @@ func lachesisMain(ctx *cli.Context) error {
 	}
 
 	metrics.SetDataDir(cfg.Node.DataDir) // report disk space usage into metrics
-	if ctx.GlobalIsSet(config.FakeNetFlag.Name) {
-		cfg.OperaStore.EVM.StateDb.LiveCache = 1
-		cfg.OperaStore.EVM.StateDb.ArchiveCache = 1
+	if ctx.IsSet(flags.LiveDbCacheFlag.Name) {
+		cfg.OperaStore.EVM.StateDb.LiveCache = ctx.Int64(flags.LiveDbCacheFlag.Name)
+	}
+
+	if ctx.IsSet(flags.ArchiveCacheFlag.Name) {
+		cfg.OperaStore.EVM.StateDb.ArchiveCache = ctx.Int64(flags.ArchiveCacheFlag.Name)
 	}
 
 	node, _, nodeClose, err := config.MakeNode(ctx, cfg)

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -222,6 +222,10 @@ func lachesisMain(ctx *cli.Context) error {
 	}
 
 	metrics.SetDataDir(cfg.Node.DataDir) // report disk space usage into metrics
+	if ctx.GlobalIsSet(config.FakeNetFlag.Name) {
+		cfg.OperaStore.EVM.StateDb.LiveCache = 1
+		cfg.OperaStore.EVM.StateDb.ArchiveCache = 1
+	}
 
 	node, _, nodeClose, err := config.MakeNode(ctx, cfg)
 	if err != nil {

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -224,12 +224,14 @@ func lachesisMain(ctx *cli.Context) error {
 	}
 
 	metrics.SetDataDir(cfg.Node.DataDir) // report disk space usage into metrics
-	if ctx.IsSet(flags.LiveDbCacheFlag.Name) {
-		cfg.OperaStore.EVM.StateDb.LiveCache = ctx.Int64(flags.LiveDbCacheFlag.Name)
+	liveCache := ctx.Int64(flags.LiveDbCacheFlag.Name)
+	if liveCache > 0 {
+		cfg.OperaStore.EVM.StateDb.LiveCache = liveCache
 	}
 
-	if ctx.IsSet(flags.ArchiveCacheFlag.Name) {
-		cfg.OperaStore.EVM.StateDb.ArchiveCache = ctx.Int64(flags.ArchiveCacheFlag.Name)
+	archiveCache := ctx.Int64(flags.ArchiveCacheFlag.Name)
+	if archiveCache > 0 {
+		cfg.OperaStore.EVM.StateDb.ArchiveCache = archiveCache
 	}
 
 	node, _, nodeClose, err := config.MakeNode(ctx, cfg)

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -224,12 +224,12 @@ func lachesisMain(ctx *cli.Context) error {
 	}
 
 	metrics.SetDataDir(cfg.Node.DataDir) // report disk space usage into metrics
-	liveCache := ctx.Int64(flags.LiveDbCacheFlag.Name)
+	liveCache := ctx.GlobalInt64(flags.LiveDbCacheFlag.Name)
 	if liveCache > 0 {
 		cfg.OperaStore.EVM.StateDb.LiveCache = liveCache
 	}
 
-	archiveCache := ctx.Int64(flags.ArchiveCacheFlag.Name)
+	archiveCache := ctx.GlobalInt64(flags.ArchiveCacheFlag.Name)
 	if archiveCache > 0 {
 		cfg.OperaStore.EVM.StateDb.ArchiveCache = archiveCache
 	}

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -26,7 +26,7 @@ func tmpdir(t *testing.T) string {
 func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 	genesisStore := makefakegenesis.FakeGenesisStore(validatorsNum, futils.ToFtm(1000000000), futils.ToFtm(5000000))
 	defer genesisStore.Close()
-	if err := genesis.ImportGenesisStore(genesisStore, dataDir, false, cachescale.Identity); err != nil {
+	if err := genesis.ImportGenesisStore(genesisStore, dataDir, false, cachescale.Identity, true); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"gopkg.in/urfave/cli.v1"
 	"os"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func tmpdir(t *testing.T) string {
 func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 	genesisStore := makefakegenesis.FakeGenesisStore(validatorsNum, futils.ToFtm(1000000000), futils.ToFtm(5000000))
 	defer genesisStore.Close()
-	if err := genesis.ImportGenesisStore(genesisStore, dataDir, false, cachescale.Identity, true); err != nil {
+	if err := genesis.ImportGenesisStore(&cli.Context{}, genesisStore, dataDir, false, cachescale.Identity); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"flag"
 	"fmt"
 	"gopkg.in/urfave/cli.v1"
 	"os"
@@ -27,7 +28,13 @@ func tmpdir(t *testing.T) string {
 func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 	genesisStore := makefakegenesis.FakeGenesisStore(validatorsNum, futils.ToFtm(1000000000), futils.ToFtm(5000000))
 	defer genesisStore.Close()
-	if err := genesis.ImportGenesisStore(&cli.Context{}, genesisStore, dataDir, false, cachescale.Identity); err != nil {
+	if err := genesis.ImportGenesisStore(
+		cli.NewContext(cli.NewApp(), new(flag.FlagSet), nil),
+		genesisStore,
+		dataDir,
+		false,
+		cachescale.Identity,
+	); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -1,9 +1,8 @@
 package app
 
 import (
-	"flag"
 	"fmt"
-	"gopkg.in/urfave/cli.v1"
+	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"os"
 	"strings"
 	"testing"
@@ -13,8 +12,6 @@ import (
 	"github.com/Fantom-foundation/go-opera/integration/makefakegenesis"
 	futils "github.com/Fantom-foundation/go-opera/utils"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
-
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/ethereum/go-ethereum/common"
 
@@ -28,13 +25,14 @@ func tmpdir(t *testing.T) string {
 func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 	genesisStore := makefakegenesis.FakeGenesisStore(validatorsNum, futils.ToFtm(1000000000), futils.ToFtm(5000000))
 	defer genesisStore.Close()
-	if err := genesis.ImportGenesisStore(
-		cli.NewContext(cli.NewApp(), new(flag.FlagSet), nil),
-		genesisStore,
-		dataDir,
-		false,
-		cachescale.Identity,
-	); err != nil {
+
+	if err := genesis.ImportGenesisStore(genesis.ImportParams{
+		GenesisStore: genesisStore,
+		DataDir:      dataDir,
+		CacheRatio:   cachescale.Identity,
+		LiveDbCache:  1, // Set lowest cache
+		ArchiveCache: 1, // Set lowest cache
+	}); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/sonictool/app/chain.go
+++ b/cmd/sonictool/app/chain.go
@@ -3,6 +3,7 @@ package app
 import (
 	"compress/gzip"
 	"fmt"
+	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
 	"io"
 	"os"
 	"strconv"
@@ -57,8 +58,14 @@ func exportEvents(ctx *cli.Context) error {
 		to = idx.Epoch(n)
 	}
 
+	gdbParams := db.GossipDbParameters{
+		DataDir:      dataDir,
+		LiveDbCache:  ctx.Int64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache: ctx.Int64(flags.ArchiveCacheFlag.Name),
+	}
+
 	log.Info("Exporting events to file", "file", fn)
-	err = chain.ExportEvents(ctx, writer, dataDir, from, to)
+	err = chain.ExportEvents(gdbParams, writer, dataDir, from, to)
 	if err != nil {
 		return fmt.Errorf("export error: %w", err)
 	}

--- a/cmd/sonictool/app/chain.go
+++ b/cmd/sonictool/app/chain.go
@@ -58,7 +58,7 @@ func exportEvents(ctx *cli.Context) error {
 	}
 
 	log.Info("Exporting events to file", "file", fn)
-	err = chain.ExportEvents(writer, dataDir, from, to)
+	err = chain.ExportEvents(ctx, writer, dataDir, from, to)
 	if err != nil {
 		return fmt.Errorf("export error: %w", err)
 	}

--- a/cmd/sonictool/app/chain.go
+++ b/cmd/sonictool/app/chain.go
@@ -60,8 +60,8 @@ func exportEvents(ctx *cli.Context) error {
 
 	gdbParams := db.GossipDbParameters{
 		DataDir:      dataDir,
-		LiveDbCache:  ctx.Int64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache: ctx.Int64(flags.ArchiveCacheFlag.Name),
+		LiveDbCache:  ctx.GlobalInt64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache: ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
 	}
 
 	log.Info("Exporting events to file", "file", fn)

--- a/cmd/sonictool/app/chain.go
+++ b/cmd/sonictool/app/chain.go
@@ -65,7 +65,7 @@ func exportEvents(ctx *cli.Context) error {
 	}
 
 	log.Info("Exporting events to file", "file", fn)
-	err = chain.ExportEvents(gdbParams, writer, dataDir, from, to)
+	err = chain.ExportEvents(gdbParams, writer, from, to)
 	if err != nil {
 		return fmt.Errorf("export error: %w", err)
 	}

--- a/cmd/sonictool/app/export_genesis.go
+++ b/cmd/sonictool/app/export_genesis.go
@@ -48,7 +48,7 @@ func exportGenesis(ctx *cli.Context) error {
 	}
 	defer dbs.Close()
 
-	gdb, err := db.MakeGossipDb(dbs, dataDir, false, cachescale.Identity, false)
+	gdb, err := db.MakeGossipDb(ctx, dbs, dataDir, false, cachescale.Identity)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/app/export_genesis.go
+++ b/cmd/sonictool/app/export_genesis.go
@@ -48,7 +48,7 @@ func exportGenesis(ctx *cli.Context) error {
 	}
 	defer dbs.Close()
 
-	gdb, err := db.MakeGossipDb(dbs, dataDir, false, cachescale.Identity)
+	gdb, err := db.MakeGossipDb(dbs, dataDir, false, cachescale.Identity, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/app/export_genesis.go
+++ b/cmd/sonictool/app/export_genesis.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/genesis"
 	"github.com/Fantom-foundation/go-opera/config/flags"
 	"github.com/Fantom-foundation/go-opera/integration"
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"gopkg.in/urfave/cli.v1"
 	"os"
@@ -48,7 +47,14 @@ func exportGenesis(ctx *cli.Context) error {
 	}
 	defer dbs.Close()
 
-	gdb, err := db.MakeGossipDb(ctx, dbs, dataDir, false, cachescale.Identity)
+	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
+		Dbs:           dbs,
+		DataDir:       dataDir,
+		ValidatorMode: false,
+		CacheRatio:    cacheRatio,
+		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/app/export_genesis.go
+++ b/cmd/sonictool/app/export_genesis.go
@@ -52,8 +52,8 @@ func exportGenesis(ctx *cli.Context) error {
 		DataDir:       dataDir,
 		ValidatorMode: false,
 		CacheRatio:    cacheRatio,
-		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+		LiveDbCache:   ctx.GlobalInt64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
 	})
 	if err != nil {
 		return err

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -71,8 +71,8 @@ func gfileGenesisImport(ctx *cli.Context) error {
 		DataDir:       dataDir,
 		ValidatorMode: validatorMode,
 		CacheRatio:    cacheRatio,
-		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+		LiveDbCache:   ctx.GlobalInt64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
 	})
 }
 
@@ -110,8 +110,8 @@ func jsonGenesisImport(ctx *cli.Context) error {
 		DataDir:       dataDir,
 		ValidatorMode: validatorMode,
 		CacheRatio:    cacheRatio,
-		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+		LiveDbCache:   ctx.GlobalInt64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
 	})
 }
 
@@ -146,8 +146,8 @@ func fakeGenesisImport(ctx *cli.Context) error {
 		DataDir:       dataDir,
 		ValidatorMode: validatorMode,
 		CacheRatio:    cacheRatio,
-		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+		LiveDbCache:   ctx.GlobalInt64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
 	})
 }
 

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -66,7 +66,14 @@ func gfileGenesisImport(ctx *cli.Context) error {
 			return fmt.Errorf("genesis file check failed: %w", err)
 		}
 	}
-	return genesis.ImportGenesisStore(ctx, genesisStore, dataDir, validatorMode, cacheRatio)
+	return genesis.ImportGenesisStore(genesis.ImportParams{
+		GenesisStore:  genesisStore,
+		DataDir:       dataDir,
+		ValidatorMode: validatorMode,
+		CacheRatio:    cacheRatio,
+		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+	})
 }
 
 func jsonGenesisImport(ctx *cli.Context) error {
@@ -98,7 +105,14 @@ func jsonGenesisImport(ctx *cli.Context) error {
 		return fmt.Errorf("failed to prepare JSON genesis: %w", err)
 	}
 	defer genesisStore.Close()
-	return genesis.ImportGenesisStore(ctx, genesisStore, dataDir, validatorMode, cacheRatio)
+	return genesis.ImportGenesisStore(genesis.ImportParams{
+		GenesisStore:  genesisStore,
+		DataDir:       dataDir,
+		ValidatorMode: validatorMode,
+		CacheRatio:    cacheRatio,
+		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+	})
 }
 
 func fakeGenesisImport(ctx *cli.Context) error {
@@ -127,7 +141,14 @@ func fakeGenesisImport(ctx *cli.Context) error {
 
 	genesisStore := makefakegenesis.FakeGenesisStore(idx.Validator(validatorsNumber), futils.ToFtm(1000000000), futils.ToFtm(5000000))
 	defer genesisStore.Close()
-	return genesis.ImportGenesisStore(ctx, genesisStore, dataDir, validatorMode, cacheRatio)
+	return genesis.ImportGenesisStore(genesis.ImportParams{
+		GenesisStore:  genesisStore,
+		DataDir:       dataDir,
+		ValidatorMode: validatorMode,
+		CacheRatio:    cacheRatio,
+		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+	})
 }
 
 func isValidatorModeSet(ctx *cli.Context) (bool, error) {

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -66,7 +66,7 @@ func gfileGenesisImport(ctx *cli.Context) error {
 			return fmt.Errorf("genesis file check failed: %w", err)
 		}
 	}
-	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio)
+	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio, false)
 }
 
 func jsonGenesisImport(ctx *cli.Context) error {
@@ -98,7 +98,7 @@ func jsonGenesisImport(ctx *cli.Context) error {
 		return fmt.Errorf("failed to prepare JSON genesis: %w", err)
 	}
 	defer genesisStore.Close()
-	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio)
+	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio, false)
 }
 
 func fakeGenesisImport(ctx *cli.Context) error {
@@ -127,7 +127,7 @@ func fakeGenesisImport(ctx *cli.Context) error {
 
 	genesisStore := makefakegenesis.FakeGenesisStore(idx.Validator(validatorsNumber), futils.ToFtm(1000000000), futils.ToFtm(5000000))
 	defer genesisStore.Close()
-	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio)
+	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio, true)
 }
 
 func isValidatorModeSet(ctx *cli.Context) (bool, error) {

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -66,7 +66,7 @@ func gfileGenesisImport(ctx *cli.Context) error {
 			return fmt.Errorf("genesis file check failed: %w", err)
 		}
 	}
-	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio, false)
+	return genesis.ImportGenesisStore(ctx, genesisStore, dataDir, validatorMode, cacheRatio)
 }
 
 func jsonGenesisImport(ctx *cli.Context) error {
@@ -98,7 +98,7 @@ func jsonGenesisImport(ctx *cli.Context) error {
 		return fmt.Errorf("failed to prepare JSON genesis: %w", err)
 	}
 	defer genesisStore.Close()
-	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio, false)
+	return genesis.ImportGenesisStore(ctx, genesisStore, dataDir, validatorMode, cacheRatio)
 }
 
 func fakeGenesisImport(ctx *cli.Context) error {
@@ -127,7 +127,7 @@ func fakeGenesisImport(ctx *cli.Context) error {
 
 	genesisStore := makefakegenesis.FakeGenesisStore(idx.Validator(validatorsNumber), futils.ToFtm(1000000000), futils.ToFtm(5000000))
 	defer genesisStore.Close()
-	return genesis.ImportGenesisStore(genesisStore, dataDir, validatorMode, cacheRatio, true)
+	return genesis.ImportGenesisStore(ctx, genesisStore, dataDir, validatorMode, cacheRatio)
 }
 
 func isValidatorModeSet(ctx *cli.Context) (bool, error) {

--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -18,6 +18,8 @@ func Run() error {
 	app.Flags = []cli.Flag{
 		flags.DataDirFlag,
 		flags.CacheFlag,
+		flags.LiveDbCacheFlag,
+		flags.ArchiveCacheFlag,
 	}
 	app.Commands = []cli.Command{
 		{
@@ -60,8 +62,6 @@ Initialize the database using data from the experimental genesis file.
 					ArgsUsage: "<validators>",
 					Action:    fakeGenesisImport,
 					Flags: []cli.Flag{
-						flags.LiveDbCacheFlag,
-						flags.ArchiveCacheFlag,
 						ModeFlag,
 					},
 					Description: `

--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -60,6 +60,8 @@ Initialize the database using data from the experimental genesis file.
 					ArgsUsage: "<validators>",
 					Action:    fakeGenesisImport,
 					Flags: []cli.Flag{
+						flags.LiveDbCacheFlag,
+						flags.ArchiveCacheFlag,
 						ModeFlag,
 					},
 					Description: `

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -2,9 +2,7 @@ package chain
 
 import (
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
-	"github.com/Fantom-foundation/go-opera/config/flags"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
-	"gopkg.in/urfave/cli.v1"
 	"io"
 	"path/filepath"
 	"time"
@@ -26,7 +24,7 @@ var (
 // always print out progress. This avoids the user wondering what's going on.
 const statsReportLimit = 8 * time.Second
 
-func ExportEvents(ctx *cli.Context, w io.Writer, dataDir string, from, to idx.Epoch) (err error) {
+func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, dataDir string, from, to idx.Epoch) (err error) {
 	chaindataDir := filepath.Join(dataDir, "chaindata")
 	dbs, err := db.MakeDbProducer(chaindataDir, cachescale.Identity)
 	if err != nil {
@@ -34,14 +32,11 @@ func ExportEvents(ctx *cli.Context, w io.Writer, dataDir string, from, to idx.Ep
 	}
 	defer dbs.Close()
 
-	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
-		Dbs:           dbs,
-		DataDir:       dataDir,
-		ValidatorMode: false,
-		CacheRatio:    cachescale.Identity,
-		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
-	})
+	// Fill the rest of the params
+	gdbParams.Dbs = dbs
+	gdbParams.CacheRatio = cachescale.Identity
+
+	gdb, err := db.MakeGossipDb(gdbParams)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+	"gopkg.in/urfave/cli.v1"
 	"io"
 	"path/filepath"
 	"time"
@@ -24,7 +25,7 @@ var (
 // always print out progress. This avoids the user wondering what's going on.
 const statsReportLimit = 8 * time.Second
 
-func ExportEvents(w io.Writer, dataDir string, from, to idx.Epoch) (err error) {
+func ExportEvents(ctx *cli.Context, w io.Writer, dataDir string, from, to idx.Epoch) (err error) {
 	chaindataDir := filepath.Join(dataDir, "chaindata")
 	dbs, err := db.MakeDbProducer(chaindataDir, cachescale.Identity)
 	if err != nil {
@@ -32,7 +33,7 @@ func ExportEvents(w io.Writer, dataDir string, from, to idx.Epoch) (err error) {
 	}
 	defer dbs.Close()
 
-	gdb, err := db.MakeGossipDb(dbs, dataDir, false, cachescale.Identity, false)
+	gdb, err := db.MakeGossipDb(ctx, dbs, dataDir, false, cachescale.Identity)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
+	"github.com/Fantom-foundation/go-opera/config/flags"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"gopkg.in/urfave/cli.v1"
 	"io"
@@ -33,7 +34,14 @@ func ExportEvents(ctx *cli.Context, w io.Writer, dataDir string, from, to idx.Ep
 	}
 	defer dbs.Close()
 
-	gdb, err := db.MakeGossipDb(ctx, dbs, dataDir, false, cachescale.Identity)
+	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
+		Dbs:           dbs,
+		DataDir:       dataDir,
+		ValidatorMode: false,
+		CacheRatio:    cachescale.Identity,
+		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -24,8 +24,8 @@ var (
 // always print out progress. This avoids the user wondering what's going on.
 const statsReportLimit = 8 * time.Second
 
-func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, dataDir string, from, to idx.Epoch) (err error) {
-	chaindataDir := filepath.Join(dataDir, "chaindata")
+func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, from, to idx.Epoch) (err error) {
+	chaindataDir := filepath.Join(gdbParams.DataDir, "chaindata")
 	dbs, err := db.MakeDbProducer(chaindataDir, cachescale.Identity)
 	if err != nil {
 		return err

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -32,7 +32,7 @@ func ExportEvents(w io.Writer, dataDir string, from, to idx.Epoch) (err error) {
 	}
 	defer dbs.Close()
 
-	gdb, err := db.MakeGossipDb(dbs, dataDir, false, cachescale.Identity)
+	gdb, err := db.MakeGossipDb(dbs, dataDir, false, cachescale.Identity, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/db/dbutils.go
+++ b/cmd/sonictool/db/dbutils.go
@@ -31,7 +31,7 @@ func makeDatabaseHandles() uint64 {
 	if err != nil {
 		panic(fmt.Errorf("failed to raise file descriptor allowance: %v", err))
 	}
-	return raised / 6 + 1
+	return raised/6 + 1
 }
 
 func AssertDatabaseNotInitialized(dataDir string) error {
@@ -61,13 +61,18 @@ func MakeDbProducer(chaindataDir string, cacheRatio cachescale.Func) (kvdb.FullD
 	})
 }
 
-func MakeGossipDb(dbs kvdb.FullDBProducer, dataDir string, validatorMode bool, cacheRatio cachescale.Func) (*gossip.Store, error) {
+func MakeGossipDb(dbs kvdb.FullDBProducer, dataDir string, validatorMode bool, cacheRatio cachescale.Func, isFakeNet bool) (*gossip.Store, error) {
 	gdbConfig := gossip.DefaultStoreConfig(cacheRatio)
 	gdbConfig.EVM.StateDb.Directory = filepath.Join(dataDir, "carmen")
 	if validatorMode {
 		gdbConfig.EVM.StateDb.Archive = carmen.NoArchive
 		gdbConfig.EVM.DisableLogsIndexing = true
 		gdbConfig.EVM.DisableTxHashesIndexing = true
+	}
+
+	if isFakeNet {
+		gdbConfig.EVM.StateDb.ArchiveCache = 1
+		gdbConfig.EVM.StateDb.LiveCache = 1
 	}
 
 	gdb, err := gossip.NewStore(dbs, gdbConfig)

--- a/cmd/sonictool/db/dbutils.go
+++ b/cmd/sonictool/db/dbutils.go
@@ -67,7 +67,7 @@ type GossipDbParameters struct {
 	DataDir                   string
 	ValidatorMode             bool
 	CacheRatio                cachescale.Func
-	LiveDbCache, ArchiveCache int64
+	LiveDbCache, ArchiveCache int64 // in bytes
 }
 
 func MakeGossipDb(params GossipDbParameters) (*gossip.Store, error) {

--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 )
 
-func ImportGenesisStore(genesisStore *genesisstore.Store, dataDir string, validatorMode bool, cacheRatio cachescale.Func) error {
+func ImportGenesisStore(genesisStore *genesisstore.Store, dataDir string, validatorMode bool, cacheRatio cachescale.Func, isFakeNet bool) error {
 	if err := db.AssertDatabaseNotInitialized(dataDir); err != nil {
 		return fmt.Errorf("database in datadir is already initialized: %w", err)
 	}
@@ -29,7 +29,7 @@ func ImportGenesisStore(genesisStore *genesisstore.Store, dataDir string, valida
 	defer dbs.Close()
 	setGenesisProcessing(chaindataDir)
 
-	gdb, err := db.MakeGossipDb(dbs, dataDir, validatorMode, cacheRatio)
+	gdb, err := db.MakeGossipDb(dbs, dataDir, validatorMode, cacheRatio, isFakeNet)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -10,10 +10,11 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/ethereum/go-ethereum/log"
+	"gopkg.in/urfave/cli.v1"
 	"path/filepath"
 )
 
-func ImportGenesisStore(genesisStore *genesisstore.Store, dataDir string, validatorMode bool, cacheRatio cachescale.Func, isFakeNet bool) error {
+func ImportGenesisStore(ctx *cli.Context, genesisStore *genesisstore.Store, dataDir string, validatorMode bool, cacheRatio cachescale.Func) error {
 	if err := db.AssertDatabaseNotInitialized(dataDir); err != nil {
 		return fmt.Errorf("database in datadir is already initialized: %w", err)
 	}
@@ -29,7 +30,7 @@ func ImportGenesisStore(genesisStore *genesisstore.Store, dataDir string, valida
 	defer dbs.Close()
 	setGenesisProcessing(chaindataDir)
 
-	gdb, err := db.MakeGossipDb(dbs, dataDir, validatorMode, cacheRatio, isFakeNet)
+	gdb, err := db.MakeGossipDb(ctx, dbs, dataDir, false, cacheRatio)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -3,7 +3,6 @@ package genesis
 import (
 	"fmt"
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
-	"github.com/Fantom-foundation/go-opera/config/flags"
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
 	"github.com/Fantom-foundation/go-opera/opera/genesisstore"
 	"github.com/Fantom-foundation/lachesis-base/abft"
@@ -11,20 +10,28 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/ethereum/go-ethereum/log"
-	"gopkg.in/urfave/cli.v1"
 	"path/filepath"
 )
 
-func ImportGenesisStore(ctx *cli.Context, genesisStore *genesisstore.Store, dataDir string, validatorMode bool, cacheRatio cachescale.Func) error {
-	if err := db.AssertDatabaseNotInitialized(dataDir); err != nil {
+// ImportParams are parameters for ImportGenesisStore func.
+type ImportParams struct {
+	GenesisStore              *genesisstore.Store
+	DataDir                   string
+	ValidatorMode             bool
+	CacheRatio                cachescale.Func
+	LiveDbCache, ArchiveCache int64 // in bytes
+}
+
+func ImportGenesisStore(params ImportParams) error {
+	if err := db.AssertDatabaseNotInitialized(params.DataDir); err != nil {
 		return fmt.Errorf("database in datadir is already initialized: %w", err)
 	}
-	if err := db.RemoveDatabase(dataDir); err != nil {
+	if err := db.RemoveDatabase(params.DataDir); err != nil {
 		return fmt.Errorf("failed to remove existing data from the datadir: %w", err)
 	}
 
-	chaindataDir := filepath.Join(dataDir, "chaindata")
-	dbs, err := db.MakeDbProducer(chaindataDir, cacheRatio)
+	chaindataDir := filepath.Join(params.DataDir, "chaindata")
+	dbs, err := db.MakeDbProducer(chaindataDir, params.CacheRatio)
 	if err != nil {
 		return err
 	}
@@ -33,18 +40,18 @@ func ImportGenesisStore(ctx *cli.Context, genesisStore *genesisstore.Store, data
 
 	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
 		Dbs:           dbs,
-		DataDir:       dataDir,
-		ValidatorMode: validatorMode,
-		CacheRatio:    cacheRatio,
-		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+		DataDir:       params.DataDir,
+		ValidatorMode: params.ValidatorMode,
+		CacheRatio:    params.CacheRatio,
+		LiveDbCache:   params.LiveDbCache,
+		ArchiveCache:  params.ArchiveCache,
 	})
 	if err != nil {
 		return err
 	}
 	defer gdb.Close()
 
-	err = gdb.ApplyGenesis(genesisStore.Genesis())
+	err = gdb.ApplyGenesis(params.GenesisStore.Genesis())
 	if err != nil {
 		return fmt.Errorf("failed to write Gossip genesis state: %v", err)
 	}
@@ -63,7 +70,7 @@ func ImportGenesisStore(ctx *cli.Context, genesisStore *genesisstore.Store, data
 	abftCrit := func(err error) {
 		panic(fmt.Errorf("lachesis store error: %w", err))
 	}
-	cdb := abft.NewStore(cMainDb, cGetEpochDB, abftCrit, abft.DefaultStoreConfig(cacheRatio))
+	cdb := abft.NewStore(cMainDb, cGetEpochDB, abftCrit, abft.DefaultStoreConfig(params.CacheRatio))
 	defer cdb.Close()
 
 	err = cdb.ApplyGenesis(&abft.Genesis{

--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -3,6 +3,7 @@ package genesis
 import (
 	"fmt"
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
+	"github.com/Fantom-foundation/go-opera/config/flags"
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
 	"github.com/Fantom-foundation/go-opera/opera/genesisstore"
 	"github.com/Fantom-foundation/lachesis-base/abft"
@@ -30,7 +31,14 @@ func ImportGenesisStore(ctx *cli.Context, genesisStore *genesisstore.Store, data
 	defer dbs.Close()
 	setGenesisProcessing(chaindataDir)
 
-	gdb, err := db.MakeGossipDb(ctx, dbs, dataDir, false, cacheRatio)
+	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
+		Dbs:           dbs,
+		DataDir:       dataDir,
+		ValidatorMode: validatorMode,
+		CacheRatio:    cacheRatio,
+		LiveDbCache:   ctx.Int64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:  ctx.Int64(flags.ArchiveCacheFlag.Name),
+	})
 	if err != nil {
 		return err
 	}

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -17,6 +17,7 @@
 package flags
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
@@ -351,11 +352,19 @@ var (
 
 	// StateDb
 	LiveDbCacheFlag = cli.Int64Flag{
-		Name:  "statedb.livecache",
-		Usage: "Size of live db cache in bytes.",
+		Name: "statedb.livecache",
+		Usage: fmt.Sprintf("Size of live db cache in bytes. Leaving this blank (which is generally recommended),"+
+			"or setting this to <1 will automatically allocate cache size depending on how much cache you use with %s."+
+			"Setting this value to <=2000 will result in cache capacity of 2KB (which is the lowest value that Carmen allows)",
+			CacheFlag.Name),
+		Value: 0,
 	}
 	ArchiveCacheFlag = cli.IntFlag{
-		Name:  "statedb.archivecache",
-		Usage: "Size of archive cache in bytes.",
+		Name: "statedb.archivecache",
+		Usage: fmt.Sprintf("Size of archive cache in bytes. Leaving this blank (which is generally recommended),"+
+			"or setting this to <1 will automatically allocate cache size depending on how much cache you use with %s."+
+			"Setting this value to <=2000 will result in cache capacity of 2KB (which is the lowest value that Carmen allows)",
+			CacheFlag.Name),
+		Value: 0,
 	}
 )

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -348,4 +348,14 @@ var (
 		Name:  "lachesis.suppress-frame-panic",
 		Usage: "Suppress frame missmatch error (when testing on historical imported/synced events)",
 	}
+
+	// StateDb
+	LiveDbCacheFlag = cli.Int64Flag{
+		Name:  "statedb.livecache",
+		Usage: "Size of live db cache in bytes.",
+	}
+	ArchiveCacheFlag = cli.IntFlag{
+		Name:  "statedb.archivecache",
+		Usage: "Size of archive cache in bytes.",
+	}
 )

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -355,16 +355,14 @@ var (
 		Name: "statedb.livecache",
 		Usage: fmt.Sprintf("Size of live db cache in bytes. Leaving this blank (which is generally recommended),"+
 			"or setting this to <1 will automatically allocate cache size depending on how much cache you use with %s."+
-			"Setting this value to <=2000 will result in cache capacity of 2KB (which is the lowest value that Carmen allows)",
-			CacheFlag.Name),
+			"Setting this value to <=2000 will result in pre-confugired cache capacity of 2KB", CacheFlag.Name),
 		Value: 0,
 	}
 	ArchiveCacheFlag = cli.IntFlag{
 		Name: "statedb.archivecache",
 		Usage: fmt.Sprintf("Size of archive cache in bytes. Leaving this blank (which is generally recommended),"+
 			"or setting this to <1 will automatically allocate cache size depending on how much cache you use with %s."+
-			"Setting this value to <=2000 will result in cache capacity of 2KB (which is the lowest value that Carmen allows)",
-			CacheFlag.Name),
+			"Setting this value to <=2000 will result in pre-confugired cache capacity of 2KB", CacheFlag.Name),
 		Value: 0,
 	}
 )

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -169,11 +169,21 @@ func startIntegrationTestNet(directory string, args []string) (*IntegrationTestN
 	// initialize the data directory for the single node on the test network
 	// equivalent to running `sonictool --datadir <dataDir> genesis fake 1`
 	originalArgs := os.Args
-	os.Args = append([]string{"sonictool", "--datadir", result.stateDir()}, args...)
+	os.Args =  append([]string{
+		"sonictool",
+		"--datadir", result.stateDir(),
+		"genesis",
+		"fake",
+		"--statedb.livecache", "1",
+		"--statedb.archivecache", "1",
+		"1",
+	}, args...)
 	if err := sonictool.Run(); err != nil {
 		os.Args = originalArgs
 		return nil, fmt.Errorf("failed to initialize the test network: %w", err)
 	}
+	os.Args = originalArgs
+
 	os.Args = originalArgs
 
 	if err := result.start(); err != nil {
@@ -200,10 +210,17 @@ func (n *IntegrationTestNet) start() error {
 			"sonicd",
 			"--datadir", n.stateDir(),
 			"--fakenet", "1/1",
-			"--http", "--http.addr", "0.0.0.0", "--http.port", "18545",
+			"--http",
+			"--http.addr", "0.0.0.0",
+			"--http.port", "18545",
 			"--http.api", "admin,eth,web3,net,txpool,ftm,trace,debug",
-			"--ws", "--ws.addr", "0.0.0.0", "--ws.port", "18546", "--ws.api", "admin,eth,ftm",
+			"--ws",
+			"--ws.addr", "0.0.0.0",
+			"--ws.port", "18546",
+			"--ws.api", "admin,eth,ftm",
 			"--datadir.minfreedisk", "0",
+			"--statedb.livecache", "1",
+			"--statedb.archivecache", "1",
 		}
 		sonicd.Run()
 	}()

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -169,14 +169,11 @@ func startIntegrationTestNet(directory string, args []string) (*IntegrationTestN
 	// initialize the data directory for the single node on the test network
 	// equivalent to running `sonictool --datadir <dataDir> genesis fake 1`
 	originalArgs := os.Args
-	os.Args =  append([]string{
+	os.Args = append([]string{
 		"sonictool",
 		"--datadir", result.stateDir(),
-		"genesis",
-		"fake",
 		"--statedb.livecache", "1",
 		"--statedb.archivecache", "1",
-		"1",
 	}, args...)
 	if err := sonictool.Run(); err != nil {
 		os.Args = originalArgs


### PR DESCRIPTION
This PR lowers memory usage for fake net and integration tests by ~500 MB per test.
Before:
<img width="300" alt="Screenshot 2024-11-28 at 12 36 47" src="https://github.com/user-attachments/assets/6db9254a-9140-4972-b759-e13512c58e37">

After:
<img width="300" alt="Screenshot 2024-11-28 at 12 37 05" src="https://github.com/user-attachments/assets/85c2bec9-a289-487e-a2b3-9b00013f6404">

part of https://github.com/Fantom-foundation/sonic-admin/issues/50