### PR TITLE
Correct epoch number in block data

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -230,7 +230,7 @@ func consensusCallbackBeginBlockFn(
 					maxBlockGas := es.Rules.Blocks.MaxBlockGas
 					blockDuration := time.Duration(blockCtx.Time - bs.LastBlock.Time)
 					blockBuilder := inter.NewBlockBuilder().
-						WithEpoch(es.Epoch).
+						WithEpoch(blockCtx.Atropos.Epoch()).
 						WithNumber(number).
 						WithParentHash(lastBlockHeader.Hash).
 						WithTime(blockCtx.Time).


### PR DESCRIPTION
This PR fixes association of blocks to epochs.

Before this PR, blocks concluding an epoch got incorrectly associated to the newly started epoch. After this change, blocks sealing an epoch are the last block within the sealed epoch.

For the issue to be revealed, block information must be read from the store -- not from an in-memory cache of block information that is internally used to speed up RPC requests of recent blocks. Thus, to discover such caching issues also in potential other contexts, the header-invariant test was extended to include a node-restart step.