### PR TITLE
genesis export import test

### DIFF
--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -39,19 +39,22 @@ func TestBlockHeader_SatisfiesInvariants(t *testing.T) {
 	require.NoError(err)
 	defer client.Close()
 
-	lastBlock, err := client.BlockByNumber(context.Background(), nil)
+	originalHeaders, err := net.GetHeaders()
 	require.NoError(err)
-	require.GreaterOrEqual(lastBlock.NumberU64(), uint64(numBlocks))
-
-	headers := []*types.Header{}
-	for i := int64(0); i < int64(lastBlock.NumberU64()); i++ {
-		header, err := client.HeaderByNumber(context.Background(), big.NewInt(i))
-		require.NoError(err)
-		headers = append(headers, header)
+	originalHashes := []common.Hash{}
+	for _, header := range originalHeaders {
+		originalHashes = append(originalHashes, header.Hash())
 	}
 
 	// Run twice - once before and once after a node restart.
-	for range 2 {
+	runTests := func() {
+		headers, err := net.GetHeaders()
+		require.NoError(err)
+
+		t.Run("CompareHeadersHashes", func(t *testing.T) {
+			testHeaders_CompareHeadersHashes(t, originalHashes, headers)
+		})
+
 		t.Run("BlockNumberEqualsPositionInChain", func(t *testing.T) {
 			testHeaders_BlockNumberEqualsPositionInChain(t, headers)
 		})
@@ -107,8 +110,23 @@ func TestBlockHeader_SatisfiesInvariants(t *testing.T) {
 		t.Run("LastBlockOfEpochContainsSealingTransaction", func(t *testing.T) {
 			testHeaders_LastBlockOfEpochContainsSealingTransaction(t, headers, client)
 		})
+	}
 
-		require.NoError(net.Restart())
+	runTests()
+	require.NoError(net.Restart())
+	runTests()
+
+	// TODO: enable when genesis is fixed
+	// require.NoError(net.restartWithExportImport())
+	// runTests()
+}
+
+func testHeaders_CompareHeadersHashes(t *testing.T, hashes []common.Hash, newHeaders []*types.Header) {
+	require := require.New(t)
+
+	require.Len(newHeaders, len(hashes), "length mismatch")
+	for i, header := range newHeaders {
+		require.Equal(hashes[i], header.Hash(), "hash mismatch")
 	}
 }
 
@@ -269,7 +287,9 @@ func testHeaders_TimeProgressesMonotonically(t *testing.T, headers []*types.Head
 	for i := 1; i < len(headers); i++ {
 		currentTime := getTimeFrom(headers[i])
 		previousTime := getTimeFrom(headers[i-1])
-		require.Greater(currentTime, previousTime, "time is not monotonically increasing")
+		// TODO: enable to print timestamps of blocks
+		// t.Logf("block %d: %s parent time: %v", i, currentTime, previousTime)
+		require.Greater(currentTime, previousTime, "time is not monotonically increasing. block %d", i)
 	}
 }
 

--- a/tests/genesis_import_test.go
+++ b/tests/genesis_import_test.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: enable test once genesis is fixed
+func testGenesis_NetworkCanCreateNewBlocksAfterExportImport(t *testing.T) {
+	const numBlocks = 3
+	require := require.New(t)
+
+	tempDir := t.TempDir()
+	net, err := StartIntegrationTestNet(tempDir)
+	require.NoError(err)
+
+	// Produce a few blocks on the network.
+	for range numBlocks {
+		_, err := net.EndowAccount(common.Address{42}, 100)
+		require.NoError(err, "failed to endow account")
+	}
+
+	// get client
+	client, err := net.GetClient()
+	require.NoError(err)
+	originalHeaders, err := net.GetHeaders()
+	require.NoError(err)
+	client.Close()
+
+	originalHashes := []common.Hash{}
+	for _, header := range originalHeaders {
+		originalHashes = append(originalHashes, header.Hash())
+	}
+
+	net.RestartWithExportImport()
+
+	// get a fresh client
+	newClient, err := net.GetClient()
+	require.NoError(err)
+	defer newClient.Close()
+
+	// check address 42 has balance
+	balance42, err := newClient.BalanceAt(context.Background(), common.Address{42}, nil)
+	require.NoError(err)
+	require.Equal(0, balance42.Cmp(big.NewInt(100)), "unexpected balance")
+
+	// check headers are consistent with original hashes
+	newHeaders, err := net.GetHeaders()
+	require.NoError(err)
+	require.Equal(len(originalHashes), len(newHeaders), "unexpected number of headers")
+	for i := 0; i < len(originalHashes); i++ {
+		require.Equal(originalHashes[i], newHeaders[i].Hash(), "unexpected header")
+	}
+
+	// Produce a few blocks on the network
+	for range numBlocks {
+		_, err := net.EndowAccount(common.Address{42}, 100)
+		require.NoError(err, "failed to endow account")
+	}
+
+	// get headers for all blocks
+	allHeaders, err := net.GetHeaders()
+	require.NoError(err)
+
+	// check headers from before the export are still reachable
+	require.Equal(numBlocks*2+2, len(allHeaders), "unexpected number of headers")
+
+	// TODO: check blocks timestamps
+}


### PR DESCRIPTION
This PR:
- extends the test-net to provide two new methods `GetHeaders` which returns a list of the headers of all the blocks, from 0 to latest, and `RestartWithExportImport` which stops the net, exports the genesis file, cleans the net's directory, imports the genesis, and starts the network again.
- extends `block_header_tests` to also compare hashes of original headers to the headers fetched after the restart, and prepares the test to run another iteration with the `RestartWithExportImport` once genesis file format is fixed.
- adds a test `testGenesis_NetworkCanCreateNewBlocksAfterExportImport` which also depends on genesis format being fixed. This test checks that after a `RestartWithExportImport`, the network can add more blocks and all invariants should hold between old and new blocks. 