### PR TITLE
Remove unnecessary effective base-fee method

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -155,10 +155,6 @@ func (s *PublicEthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexO
 	return res, nil
 }
 
-func (s *PublicEthereumAPI) EffectiveBaseFee(ctx context.Context) *hexutil.Big {
-	return (*hexutil.Big)(s.b.EffectiveMinGasPrice(ctx))
-}
-
 func (s *PublicEthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
 	// As blobs are not supported yet, blob base fee is equal to min blob gas price
 	// because calculation of blob base fee is based on the blob gas price and

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -57,7 +57,6 @@ type Backend interface {
 	// General Ethereum API
 	Progress() PeerProgress
 	SuggestGasTipCap(ctx context.Context, certainty uint64) *big.Int
-	EffectiveMinGasPrice(ctx context.Context) *big.Int
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool
 	RPCGasCap() uint64            // global gas cap for eth_call over rpc: DoS protection

--- a/ethapi/mock_backend.go
+++ b/ethapi/mock_backend.go
@@ -155,20 +155,6 @@ func (mr *MockBackendMockRecorder) CurrentEpoch(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentEpoch", reflect.TypeOf((*MockBackend)(nil).CurrentEpoch), ctx)
 }
 
-// EffectiveMinGasPrice mocks base method.
-func (m *MockBackend) EffectiveMinGasPrice(ctx context.Context) *big.Int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EffectiveMinGasPrice", ctx)
-	ret0, _ := ret[0].(*big.Int)
-	return ret0
-}
-
-// EffectiveMinGasPrice indicates an expected call of EffectiveMinGasPrice.
-func (mr *MockBackendMockRecorder) EffectiveMinGasPrice(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EffectiveMinGasPrice", reflect.TypeOf((*MockBackend)(nil).EffectiveMinGasPrice), ctx)
-}
-
 // ExtRPCEnabled mocks base method.
 func (m *MockBackend) ExtRPCEnabled() bool {
 	m.ctrl.T.Helper()

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -444,10 +444,6 @@ func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context, certainty uint64) 
 	return b.svc.gpo.SuggestTip(certainty)
 }
 
-func (b *EthAPIBackend) EffectiveMinGasPrice(ctx context.Context) *big.Int {
-	return b.svc.gpo.EffectiveMinGasPrice()
-}
-
 func (b *EthAPIBackend) AccountManager() *accounts.Manager {
 	return b.svc.AccountManager()
 }

--- a/gossip/gasprice/constructive.go
+++ b/gossip/gasprice/constructive.go
@@ -16,10 +16,6 @@ func (gpo *Oracle) maxTotalGasPower() *big.Int {
 	return maxTotalGasPowerBn
 }
 
-func (gpo *Oracle) effectiveMinGasPrice() *big.Int {
-	return gpo.constructiveGasPrice(0, 0, gpo.backend.GetRules().Economy.MinGasPrice)
-}
-
 func (gpo *Oracle) constructiveGasPrice(gasOffestAbs uint64, gasOffestRatio uint64, adjustedMinPrice *big.Int) *big.Int {
 	max := gpo.maxTotalGasPower()
 


### PR DESCRIPTION
Removes the method `ftm_effectiveBaseFee` from the list of supported RPC methods. 

This method is nowhere documented and introduces complexity that restricts refactoring and other improvements. For instance, it blocks #326 due to the difficult interaction of network rules with those base-fee predictions.

Furthermore, this function's implementation seems to be wrong. For anybody to obtain the effective base fee, a simple query of the current block head would be sufficient. This head includes the current base fee.