### PR TITLE
Add check of state-root hash consistency

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run unit tests
         env:
           GOPRIVATE: github.com/Fantom-foundation
-        run: go test -v ./...
+        run: go test -v ./... --timeout 30m
 
       - name: Build
         run: make

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -171,7 +171,6 @@ func (b *GenesisBuilder) FinalizeBlockZero(
 	// construct state root of initial state
 	b.tmpStateDB.EndBlock(0)
 	genesisStateRoot := b.tmpStateDB.GetStateHash()
-	fmt.Printf("Genesis state root: %x\n", genesisStateRoot)
 
 	// construct the block record for the genesis block
 	blockBuilder := inter.NewBlockBuilder().
@@ -306,25 +305,7 @@ func (f *memFile) Close() error {
 }
 
 func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
-
-	b.carmenStateDb.Flush()
-
-	fmt.Printf("Building genesis:\n")
-	height, empty, err := b.carmenStateDb.GetArchiveBlockHeight()
-	fmt.Printf("Archive Height: %d / %t / %v\n", height, empty, err)
-
-	if err == nil && !empty {
-		for i := uint64(0); i <= height; i++ {
-			db, err := b.carmenStateDb.GetArchiveStateDB(i)
-			if err != nil {
-				panic(err)
-			}
-			fmt.Printf("Block %d: %x\n", i, db.GetHash())
-			db.Release()
-		}
-	}
-
-	err = b.carmenStateDb.Close()
+	err := b.carmenStateDb.Close()
 	if err != nil {
 		panic(fmt.Errorf("failed to close genesis carmen state; %s", err))
 	}

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -39,7 +39,7 @@ func TestBlockHeader_JsonGenesis_SatisfiesInvariants(t *testing.T) {
 }
 
 func testBlockHeadersOnNetwork(t *testing.T, net *IntegrationTestNet) {
-	const numBlocks = 5
+	const numBlocks = 10
 	require := require.New(t)
 
 	// Produce a few blocks on the network.
@@ -130,12 +130,10 @@ func testBlockHeadersOnNetwork(t *testing.T, net *IntegrationTestNet) {
 	}
 
 	runTests()
-	/*
-		require.NoError(net.Restart())
-		runTests()
-		require.NoError(net.RestartWithExportImport())
-		runTests()
-	*/
+	require.NoError(net.Restart())
+	runTests()
+	require.NoError(net.RestartWithExportImport())
+	runTests()
 }
 
 func testHeaders_CompareHeadersHashes(t *testing.T, hashes []common.Hash, newHeaders []*types.Header) {
@@ -388,11 +386,6 @@ func getEpochOfBlock(client *ethclient.Client, blockNumber int) (int, error) {
 
 func testHeaders_StateRootsMatchActualStateRoots(t *testing.T, headers []*types.Header, client *ethclient.Client) {
 	require := require.New(t)
-
-	for i, header := range headers {
-		fmt.Printf("Block %d: %x\n", i, header.Root)
-	}
-
 	for i, header := range headers {
 		// The direct way to get the state root of a block would be to request the
 		// block header and extract the state root from it. However, we would like


### PR DESCRIPTION
This PR adds a check verifying that the state roots reported by blocks match the state roots stored in the database.

It does so by extracting witness proofs for account states on each block and verify that those proofs are rooted by a corresponding node.

While doing so, an issue regarding the initialization of archives during genesis imports has been discovered and fixed.