### PR TITLE
Change gasTipCap suggestion to a more meanigful estimation.

### DIFF
--- a/gossip/gasprice/gasprice.go
+++ b/gossip/gasprice/gasprice.go
@@ -130,15 +130,21 @@ func (gpo *Oracle) Stop() {
 }
 
 func (gpo *Oracle) suggestTip() *big.Int {
-	maxTip := big.NewInt(0)
+	totalTip := big.NewInt(0)
+	txCount := 0
+
 	for _, txs := range gpo.backend.PendingTxs() {
 		for _, tx := range txs {
-			if tx.GasTipCap().Cmp(maxTip) > 0 {
-				maxTip = tx.GasTipCap()
-			}
+			totalTip.Add(totalTip, tx.GasTipCap())
+			txCount++
 		}
 	}
-	return maxTip
+
+	if txCount == 0 {
+		return totalTip
+	}
+
+	return totalTip.Div(totalTip, big.NewInt(int64(txCount)))
 }
 
 // SuggestTip returns a tip cap so that newly created transaction has priority

--- a/gossip/gasprice/reactive.go
+++ b/gossip/gasprice/reactive.go
@@ -194,16 +194,6 @@ func addBigI(a, b *big.Int) *big.Int {
 	return a.Add(a, b)
 }
 
-func (c *circularTxpoolStats) totalGas() uint64 {
-	atomic.StoreUint32(&c.activated, 1)
-	avgC := c.avg.Load()
-	if avgC == nil {
-		return 0
-	}
-	avg := avgC.(txpoolStat)
-	return avg.totalGas
-}
-
 // calcTxpoolStat retrieves txpool transactions and calculates statistics
 func (gpo *Oracle) calcTxpoolStat() txpoolStat {
 	txsMap := gpo.backend.PendingTxs()


### PR DESCRIPTION
According to [Eip-1559](https://eips.ethereum.org/EIPS/eip-1559), GasTipCap (maximum priority fee) allows for transactions to be prioritized over the ones that provide a lower value for the field. 
The current estimation does not reflect the current state of the transaction pool. 

The new algorithm proposes a GasTipCap equal to the current maximum value found in the queued transactions for the pool (not yet submitted for execution). Transactions using this value will be added to the next event.

