### PR TITLE
Add integration test for rejected transactions because of insufficient balance

### DIFF
--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -119,7 +119,7 @@ func (f *txFactory) makeLegacyTransactionWithPrice(
 		GasPrice: big.NewInt(price),
 		To:       &common.Address{},
 		Nonce:    nonce,
-	}), types.NewLondonSigner(f.chainId), f.senderKey)
+	}), types.NewEIP155Signer(f.chainId), f.senderKey)
 	require.NoError(t, err, "failed to sign transaction")
 	return transaction
 }
@@ -135,7 +135,7 @@ func (f *txFactory) makeAccessListTransactionWithPrice(
 		GasPrice: big.NewInt(price),
 		To:       &common.Address{},
 		Nonce:    nonce,
-	}), types.NewLondonSigner(f.chainId), f.senderKey)
+	}), types.NewEIP2930Signer(f.chainId), f.senderKey)
 	require.NoError(t, err, "failed to sign transaction:")
 	return transaction
 }

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -71,25 +71,25 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 	for _, extra := range []int{-10, 0, baseFee / 100, 4 * baseFee / 100} {
 		feeCap := int64(baseFee + extra)
 
-		err = send(factory.makeLegacyTransactionWithPrice(t, nonce, feeCap))
+		err = send(factory.makeLegacyTransactionWithPrice(t, nonce, feeCap, 0))
 		require.ErrorContains(err, "transaction underpriced")
 
-		err = send(factory.makeAccessListTransactionWithPrice(t, nonce, feeCap))
+		err = send(factory.makeAccessListTransactionWithPrice(t, nonce, feeCap, 0))
 		require.ErrorContains(err, "transaction underpriced")
 
-		err = send(factory.makeDynamicFeeTransactionWithPrice(t, nonce, feeCap))
+		err = send(factory.makeDynamicFeeTransactionWithPrice(t, nonce, feeCap, 0))
 		require.ErrorContains(err, "transaction underpriced")
 
-		err = send(factory.makeBlobTransactionWithPrice(t, nonce, feeCap))
+		err = send(factory.makeBlobTransactionWithPrice(t, nonce, feeCap, 0))
 		require.ErrorContains(err, "transaction underpriced")
 	}
 
 	// Everything over ~5% above the base fee should be accepted.
 	feeCap := int64(baseFee + 7*baseFee/100)
-	require.NoError(send(factory.makeLegacyTransactionWithPrice(t, nonce, feeCap)))
-	require.NoError(send(factory.makeAccessListTransactionWithPrice(t, nonce+1, feeCap)))
-	require.NoError(send(factory.makeDynamicFeeTransactionWithPrice(t, nonce+2, feeCap)))
-	require.NoError(send(factory.makeBlobTransactionWithPrice(t, nonce+3, feeCap)))
+	require.NoError(send(factory.makeLegacyTransactionWithPrice(t, nonce, feeCap, 0)))
+	require.NoError(send(factory.makeAccessListTransactionWithPrice(t, nonce+1, feeCap, 0)))
+	require.NoError(send(factory.makeDynamicFeeTransactionWithPrice(t, nonce+2, feeCap, 0)))
+	require.NoError(send(factory.makeBlobTransactionWithPrice(t, nonce+3, feeCap, 0)))
 }
 
 func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *ethclient.Client) {
@@ -113,12 +113,14 @@ func (f *txFactory) makeLegacyTransactionWithPrice(
 	t *testing.T,
 	nonce uint64,
 	price int64,
+	value int64,
 ) *types.Transaction {
 	transaction, err := types.SignTx(types.NewTx(&types.LegacyTx{
 		Gas:      21_000,
 		GasPrice: big.NewInt(price),
 		To:       &common.Address{},
 		Nonce:    nonce,
+		Value:    big.NewInt(value),
 	}), types.NewEIP155Signer(f.chainId), f.senderKey)
 	require.NoError(t, err, "failed to sign transaction")
 	return transaction
@@ -128,6 +130,7 @@ func (f *txFactory) makeAccessListTransactionWithPrice(
 	t *testing.T,
 	nonce uint64,
 	price int64,
+	value int64,
 ) *types.Transaction {
 	transaction, err := types.SignTx(types.NewTx(&types.AccessListTx{
 		ChainID:  f.chainId,
@@ -135,6 +138,7 @@ func (f *txFactory) makeAccessListTransactionWithPrice(
 		GasPrice: big.NewInt(price),
 		To:       &common.Address{},
 		Nonce:    nonce,
+		Value:    big.NewInt(value),
 	}), types.NewEIP2930Signer(f.chainId), f.senderKey)
 	require.NoError(t, err, "failed to sign transaction:")
 	return transaction
@@ -144,6 +148,7 @@ func (f *txFactory) makeDynamicFeeTransactionWithPrice(
 	t *testing.T,
 	nonce uint64,
 	price int64,
+	value int64,
 ) *types.Transaction {
 	transaction, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
 		ChainID:   f.chainId,
@@ -152,6 +157,7 @@ func (f *txFactory) makeDynamicFeeTransactionWithPrice(
 		GasTipCap: big.NewInt(0),
 		To:        &common.Address{},
 		Nonce:     nonce,
+		Value:     big.NewInt(value),
 	}), types.NewLondonSigner(f.chainId), f.senderKey)
 	require.NoError(t, err, "failed to sign transaction:")
 	return transaction
@@ -161,6 +167,7 @@ func (f *txFactory) makeBlobTransactionWithPrice(
 	t *testing.T,
 	nonce uint64,
 	price int64,
+	value int64,
 ) *types.Transaction {
 	transaction, err := types.SignTx(types.NewTx(&types.BlobTx{
 		ChainID:    uint256.MustFromBig(f.chainId),
@@ -168,6 +175,7 @@ func (f *txFactory) makeBlobTransactionWithPrice(
 		GasFeeCap:  uint256.MustFromBig(big.NewInt(price)),
 		GasTipCap:  uint256.MustFromBig(big.NewInt(0)),
 		Nonce:      nonce,
+		Value:      uint256.MustFromBig(big.NewInt(value)),
 		BlobFeeCap: uint256.NewInt(3e10), // fee cap for the blob data
 		BlobHashes: nil,                  // blob hashes in the transaction
 		Sidecar:    nil,                  // sidecar data in the transaction

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -1,0 +1,88 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRejectedTx(t *testing.T) {
+	require := require.New(t)
+
+	// start network
+	net, err := StartIntegrationTestNet(t.TempDir())
+	require.NoError(err)
+	defer net.Stop()
+
+	newAccount := NewAccount()
+
+	// create a client
+	client, err := net.GetClient()
+	require.NoError(err, "failed to get client")
+
+	// make a dynamic tx that cannot be afford
+	value := big.NewInt(42)
+	gas := int64(21000)
+	maxFeeCap := getMaxFee(t, client)
+
+	tx := makeDynamicTxWithValue(t, net, newAccount, value, big.NewInt(maxFeeCap), uint64(gas))
+	balance := int64(tx.Gas()*tx.GasFeeCap().Uint64()) + tx.Value().Int64()
+	theoreticalCost := value.Int64() + gas*maxFeeCap
+	require.Equal(balance, theoreticalCost, "balance and theoretical cost should be equal")
+
+	_, err = net.EndowAccount(newAccount.Address(), balance-1-42)
+	require.NoError(err, "failed to endow account")
+
+	err = client.SendTransaction(context.Background(), tx)
+	require.ErrorContains(err, "insufficient funds")
+
+	_, err = net.EndowAccount(newAccount.Address(), balance)
+	require.NoError(err, "failed to endow account")
+
+	err = client.SendTransaction(context.Background(), tx)
+	require.NoError(err)
+
+}
+
+func makeDynamicTxWithValue(t *testing.T, net *IntegrationTestNet, account *Account, value, maxFeeCap *big.Int, gas uint64) *types.Transaction {
+	chainId, nonce := getChainAndNonce(t, net, account.Address())
+
+	transaction, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainId,
+		Gas:       gas,
+		GasFeeCap: maxFeeCap,
+		To:        &common.Address{},
+		Nonce:     nonce,
+		Value:     value,
+	}), types.NewLondonSigner(chainId), account.PrivateKey)
+	require.NoError(t, err, "failed to sign transaction:")
+
+	return transaction
+}
+
+func getChainAndNonce(t *testing.T, net *IntegrationTestNet, address common.Address) (chainId *big.Int, nonce uint64) {
+	// create a client
+	client, err := net.GetClient()
+	require.NoError(t, err, "failed to get client")
+
+	chainId, err = client.ChainID(context.Background())
+	require.NoError(t, err, "failed to get chain ID::")
+
+	nonce, err = client.NonceAt(context.Background(), address, nil)
+	require.NoError(t, err, "failed to get nonce:")
+	return
+}
+
+func getMaxFee(t *testing.T, client *ethclient.Client) (maxFeeCap int64) {
+	// get the gas limit and max fee cap from the client
+	block, err := client.BlockByNumber(context.Background(), nil)
+	require.NoError(t, err, "failed to get block by number")
+	baseFee := int64(block.BaseFee().Uint64())
+	maxFeeCap = baseFee + int64(float64(baseFee)*0.06)
+	return
+}

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +20,6 @@ func TestRejectedTx(t *testing.T) {
 	require.NoError(err)
 	defer net.Stop()
 
-	newAccount := NewAccount()
-
 	// create a client
 	client, err := net.GetClient()
 	require.NoError(err, "failed to get client")
@@ -28,61 +27,154 @@ func TestRejectedTx(t *testing.T) {
 	// make a dynamic tx that cannot be afford
 	value := big.NewInt(42)
 	gas := int64(21000)
-	maxFeeCap := getMaxFee(t, client)
 
-	tx := makeDynamicTxWithValue(t, net, newAccount, value, big.NewInt(maxFeeCap), uint64(gas))
-	balance := int64(tx.Gas()*tx.GasFeeCap().Uint64()) + tx.Value().Int64()
-	theoreticalCost := value.Int64() + gas*maxFeeCap
-	require.Equal(balance, theoreticalCost, "balance and theoretical cost should be equal")
+	testCases := map[string]struct {
+		nonce   uint64
+		txMaker func(t *testing.T, net *IntegrationTestNet, tc testConfig) *types.Transaction
+	}{
+		"LegacyTx": {
+			nonce:   0,
+			txMaker: makeLegacyTxWithValue,
+		},
+		"AccessListTx": {
+			nonce:   1,
+			txMaker: makeAccessListTxWithValue,
+		},
+		"DynamicTx": {
+			nonce:   2,
+			txMaker: makeDynamicTxWithValue,
+		},
+		"BlobTx": {
+			nonce:   3,
+			txMaker: makeBlobTxWithValue,
+		},
+	}
 
-	_, err = net.EndowAccount(newAccount.Address(), balance-1-42)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			maxFeeCap := getMaxFee(t, client)
+			newAccount := NewAccount()
+			testConfig := testConfig{
+				account:   newAccount,
+				value:     value,
+				gas:       uint64(gas),
+				maxFeeCap: big.NewInt(maxFeeCap),
+				nonce:     tc.nonce,
+			}
+			testRejectedTx(t, net, testConfig, tc.txMaker(t, net, testConfig))
+		})
+	}
+}
+
+func testRejectedTx(t *testing.T, net *IntegrationTestNet, testConfig testConfig, tx *types.Transaction) {
+	require := require.New(t)
+
+	// create a client
+	client, err := net.GetClient()
+	require.NoError(err, "failed to get client")
+
+	balance := tx.Gas()*tx.GasFeeCap().Uint64() + tx.Value().Uint64()
+
+	_, err = net.EndowAccount(testConfig.account.Address(), int64(balance-1))
 	require.NoError(err, "failed to endow account")
 
 	err = client.SendTransaction(context.Background(), tx)
 	require.ErrorContains(err, "insufficient funds")
 
-	_, err = net.EndowAccount(newAccount.Address(), balance)
+	_, err = net.EndowAccount(testConfig.account.Address(), int64(1))
 	require.NoError(err, "failed to endow account")
 
 	err = client.SendTransaction(context.Background(), tx)
 	require.NoError(err)
-
 }
 
-func makeDynamicTxWithValue(t *testing.T, net *IntegrationTestNet, account *Account, value, maxFeeCap *big.Int, gas uint64) *types.Transaction {
-	chainId, nonce := getChainAndNonce(t, net, account.Address())
-
-	transaction, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
-		ChainID:   chainId,
-		Gas:       gas,
-		GasFeeCap: maxFeeCap,
-		To:        &common.Address{},
-		Nonce:     nonce,
-		Value:     value,
-	}), types.NewLondonSigner(chainId), account.PrivateKey)
+func makeLegacyTxWithValue(
+	t *testing.T,
+	net *IntegrationTestNet,
+	tc testConfig,
+) *types.Transaction {
+	chainId := getChainId(t, net)
+	transaction, err := types.SignTx(types.NewTx(&types.LegacyTx{
+		Gas:      tc.gas,
+		GasPrice: tc.maxFeeCap,
+		To:       &common.Address{},
+		Nonce:    tc.nonce,
+		Value:    tc.value,
+	}), types.NewLondonSigner(chainId), tc.account.PrivateKey)
 	require.NoError(t, err, "failed to sign transaction:")
-
 	return transaction
 }
 
-func getChainAndNonce(t *testing.T, net *IntegrationTestNet, address common.Address) (chainId *big.Int, nonce uint64) {
-	// create a client
+func makeAccessListTxWithValue(
+	t *testing.T,
+	net *IntegrationTestNet,
+	tc testConfig,
+) *types.Transaction {
+	chainId := getChainId(t, net)
+	transaction, err := types.SignTx(types.NewTx(&types.AccessListTx{
+		ChainID:  chainId,
+		Gas:      tc.gas,
+		GasPrice: tc.maxFeeCap,
+		To:       &common.Address{},
+		Nonce:    tc.nonce,
+		Value:    tc.value,
+	}), types.NewLondonSigner(chainId), tc.account.PrivateKey)
+	require.NoError(t, err, "failed to sign transaction:")
+	return transaction
+}
+
+func makeDynamicTxWithValue(t *testing.T, net *IntegrationTestNet, tc testConfig) *types.Transaction {
+	chainId := getChainId(t, net)
+	transaction, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainId,
+		Gas:       tc.gas,
+		GasFeeCap: tc.maxFeeCap,
+		To:        &common.Address{},
+		Nonce:     tc.nonce,
+		Value:     tc.value,
+	}), types.NewLondonSigner(chainId), tc.account.PrivateKey)
+	require.NoError(t, err, "failed to sign transaction:")
+	return transaction
+}
+
+func makeBlobTxWithValue(t *testing.T, net *IntegrationTestNet, tc testConfig) *types.Transaction {
+	chainId := getChainId(t, net)
+	transaction, err := types.SignTx(types.NewTx(&types.BlobTx{
+		ChainID:    uint256.MustFromBig(chainId),
+		Gas:        tc.gas,
+		GasFeeCap:  uint256.MustFromBig(tc.maxFeeCap),
+		GasTipCap:  uint256.MustFromBig(big.NewInt(0)),
+		Nonce:      tc.nonce,
+		Value:      uint256.MustFromBig(tc.value),
+		BlobFeeCap: uint256.NewInt(3e10), // fee cap for the blob data
+		BlobHashes: nil,                  // blob hashes in the transaction
+		Sidecar:    nil,                  // sidecar data in the transaction
+	}), types.NewCancunSigner(chainId), tc.account.PrivateKey)
+	require.NoError(t, err, "failed to sign transaction:")
+	return transaction
+}
+
+func getChainId(t *testing.T, net *IntegrationTestNet) *big.Int {
 	client, err := net.GetClient()
 	require.NoError(t, err, "failed to get client")
 
-	chainId, err = client.ChainID(context.Background())
+	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err, "failed to get chain ID::")
-
-	nonce, err = client.NonceAt(context.Background(), address, nil)
-	require.NoError(t, err, "failed to get nonce:")
-	return
+	return chainId
 }
 
 func getMaxFee(t *testing.T, client *ethclient.Client) (maxFeeCap int64) {
-	// get the gas limit and max fee cap from the client
 	block, err := client.BlockByNumber(context.Background(), nil)
 	require.NoError(t, err, "failed to get block by number")
 	baseFee := int64(block.BaseFee().Uint64())
 	maxFeeCap = baseFee + int64(float64(baseFee)*0.06)
 	return
+}
+
+type testConfig struct {
+	account   *Account
+	value     *big.Int
+	gas       uint64
+	maxFeeCap *big.Int
+	nonce     uint64
 }

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -86,7 +86,7 @@ func testRejectedTx(t *testing.T, net *IntegrationTestNet, account common.Addres
 	if tx.Type() == types.BlobTxType {
 		estimatedCost += tx.BlobGasFeeCap().Uint64() * tx.BlobGas()
 	}
-	require.Equal(tx.Cost().Int64(), int64(estimatedCost), "transaction estimation is not equal to balance")
+	require.Equal(tx.Cost().Uint64(), estimatedCost, "transaction estimation is not equal to test estimation")
 
 	// provide just enough balance to NOT cover the cost
 	_, err := net.EndowAccount(account, int64(estimatedCost-1))


### PR DESCRIPTION
This PR solves https://github.com/Fantom-foundation/sonic-admin/issues/84
A test it added that specifically verifies that transactions are rejected if the signing account does not have enough balance to pay for `transferred value + gas_limit * max_fee_cap`. This is tested for all 4 types of transactions. 

The test uses a slice of Tx instead of a map because of the issue fixed in #346 