### PR TITLE
Remove unit tests from github actions

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run unit tests
         env:
           GOPRIVATE: github.com/Fantom-foundation
-        run: go test -v ./... --timeout 30m
+        run: go test ./... --count 0 
 
       - name: Build
         run: make


### PR DESCRIPTION
Tests are currently too large for GH, tests are checked by Jenkins. 
GH would test compilation of unit tests, but it will not run them. 