### PR TITLE
Include epoch 1 in generated Genesis data

### DIFF
--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -283,8 +283,9 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 		Idx:                blockCtx.Idx,
 	})
 
-	// add epoch
-	b.currentEpoch = ier.LlrIdxFullEpochRecord{
+	// add epochs
+	b.epochs = append(b.epochs, b.currentEpoch) // safe epoch 1
+	b.currentEpoch = ier.LlrIdxFullEpochRecord{ // create epoch 2
 		LlrFullEpochRecord: ier.LlrFullEpochRecord{
 			BlockState: bs,
 			EpochState: es,


### PR DESCRIPTION
This PR updates the genesis data generation to include epoch 1 in the produced data set.