### PR TITLE
Update Carmen version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.3
 
 require (
-	github.com/Fantom-foundation/Carmen/go v0.0.0-20241121102311-62fc85c89464
+	github.com/Fantom-foundation/Carmen/go v0.0.0-20241128114701-34dad37b5648
 	github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,7 @@
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241021085109-e8dc12374917 h1:NisjazAL9OL1n51CRXpUtkrfz/zzkcEEnA39wO0pcXM=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241021085109-e8dc12374917/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8 h1:uDlLl/ZbGUM7FHxDjmzHxMnJkSvOt8mLV9+O41pROGA=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241023071438-8b3c25fd1ff8/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4 h1:8FF/xZh6fBMHF3B19cMvPg909eDQJqatsVuUbtBQeHk=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241119172232-50adaaafeea4/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241121102311-62fc85c89464 h1:xWayjc87Mk3ESu4xGtX6YYx7KrN+gJpCWZhqmZHDpxs=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241121102311-62fc85c89464/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
-github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10 h1:D7askaARHcrcXDVZHweaxxz2wKvo/ipvjA/qooyEkNM=
-github.com/Fantom-foundation/Tosca v0.0.0-20241009135726-aa99babe0a10/go.mod h1:DtJlv3NCjaFxBKGXR7HQfLhLSu+BY5OILQ/4s7MR6lA=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241128114701-34dad37b5648 h1:gVmZHEjmw9/JAyaU28MOWkbDzLPZ+Qfu1WTHOuE26UU=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241128114701-34dad37b5648/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675 h1:Meqtt0eM9UAw1ceQ1tGiD497V0IVfqj8c6UrFJhkFNE=
 github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675/go.mod h1:8i7r+dUOkXjEC61SaFoRet6JYjRaSoiM/PhviP6K4Y8=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241022121122-7063a6b506bd h1:WoAkgzLLlyh3Zpnd/3gW8Ym5sHtugLCA4rQdT5udVF8=


### PR DESCRIPTION
This PR updates Carmen version to `34dad37b56481fcd1863d93cd501278420a1e265` which contains Cache capacity changes for `Export/ImportLiveDb` which lowers memory consumption in `integration_tests` by ~1.1GB
Before:
<img width="300" alt="Screenshot 2024-11-28 at 12 53 29" src="https://github.com/user-attachments/assets/f5e2cea4-23ca-4923-92ab-4479d2310bd3">

After:
<img width="300" alt="Screenshot 2024-11-28 at 12 53 43" src="https://github.com/user-attachments/assets/63b68f62-f38b-48ee-810b-5c449c90f886">

Part of https://github.com/Fantom-foundation/sonic-admin/issues/50