### PR TITLE
Fix the block hash listed by log messages stored in the index table

### DIFF
--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/go-opera/inter/state"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
@@ -38,7 +37,7 @@ func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {
 				SkipAccountChecks: internal,
 				GasPrice:          big.NewInt(0),
 				Value:             big.NewInt(0),
-			}, nil, gp, state, nil, common.Hash{}, nil, nil, evm, nil)
+			}, gp, state, nil, nil, nil, evm, nil)
 			if err == nil {
 				t.Errorf("expected transaction to fail")
 			}

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -100,7 +100,6 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 
 	h := &evmcore.EvmHeader{
 		Number:          p.blockIdx,
-		Hash:            common.Hash(p.block.Atropos),
 		ParentHash:      p.prevBlockHash,
 		Root:            common.Hash{},
 		Time:            p.block.Time,

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -287,6 +287,18 @@ func consensusCallbackBeginBlockFn(
 						WithGasUsed(evmBlock.GasUsed).
 						WithBaseFee(evmBlock.BaseFee)
 
+					// Complete the block.
+					block := blockBuilder.Build()
+					evmBlock.Hash = block.Hash()
+					evmBlock.Duration = blockDuration
+
+					// Update block-hash references in logs.
+					for i := range allReceipts {
+						for j := range allReceipts[i].Logs {
+							allReceipts[i].Logs[j].BlockHash = block.Hash()
+						}
+					}
+
 					// memorize event position of each tx
 					txPositions := make(map[common.Hash]ExtendedTxPosition)
 					for _, e := range blockEvents {
@@ -348,10 +360,6 @@ func consensusCallbackBeginBlockFn(
 						store.SetHistoryBlockEpochState(es.Epoch, bs, es)
 						store.SetEpochBlock(blockCtx.Idx+1, es.Epoch)
 					}
-
-					block := blockBuilder.Build()
-					evmBlock.Hash = block.Hash()
-					evmBlock.Duration = blockDuration
 
 					for _, tx := range blockBuilder.GetTransactions() {
 						store.evm.SetTx(tx.Hash(), tx)

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -583,6 +583,24 @@ func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, cli
 	slices.SortFunc(logs, logCompare)
 	slices.SortFunc(allLogs, logCompare)
 	require.Equal(allLogs, logs, "log mismatch")
+
+	// Fetch by topic index -- this uses a different table in the database.
+	topicZeroOptions := []common.Hash{}
+	for _, log := range allLogs {
+		topicZeroOptions = append(topicZeroOptions, log.Topics[0])
+	}
+	logs, err = client.FilterLogs(
+		context.Background(),
+		ethereum.FilterQuery{
+			ToBlock: big.NewInt(int64(len(headers) - 1)),
+			Topics:  [][]common.Hash{topicZeroOptions},
+		},
+	)
+	require.NoError(err, "failed to get logs")
+
+	slices.SortFunc(logs, logCompare)
+	slices.SortFunc(allLogs, logCompare)
+	require.Equal(allLogs, logs, "log mismatch")
 }
 
 func testHeaders_CounterStateIsVerifiable(


### PR DESCRIPTION
This PR fixes an issue discovered by @jenikd: when querying for log events by index-topic, the wrong block hash is reported.