### PR TITLE
Set correct block-hash in receipts after finishing the block

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -292,8 +292,9 @@ func consensusCallbackBeginBlockFn(
 					evmBlock.Hash = block.Hash()
 					evmBlock.Duration = blockDuration
 
-					// Update block-hash references in logs.
+					// Update block-hash references in receipts and logs.
 					for i := range allReceipts {
+						allReceipts[i].BlockHash = block.Hash()
 						for j := range allReceipts[i].Logs {
 							allReceipts[i].Logs[j].BlockHash = block.Hash()
 						}


### PR DESCRIPTION
This PR also adds an update of the block hash inside the receipt as soon as the block completes.

It does not seem like the missing block-hash set in `c_block_callbacks.go` was actually used by anybody, since all tests passed already before. However, in the spirit of defensive coding this value should be set to avoid potential future mistakes.