### PR TITLE
Update Carmen to get proof steps in correct order

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -745,7 +745,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 
 	storageProof := make([]StorageResult, len(keys))
 	for i, key := range keys {
-		elements, _, _ := proof.GetStorageElements(cc.Hash(header.Root), cc.Address(address), cc.Key(keys[i]))
+		elements, _ := proof.GetStorageElements(cc.Hash(header.Root), cc.Address(address), cc.Key(keys[i]))
 		storageProof[i] = StorageResult{
 			Key:   key.Hex(),
 			Value: (*hexutil.Big)(state.GetState(address, key).Big()),
@@ -753,14 +753,12 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		}
 	}
 
-	_, storageHash, _ := proof.GetStorageElements(cc.Hash(header.Root), cc.Address(address))
+	accountProof, storageHash, _ := proof.GetAccountElements(cc.Hash(header.Root), cc.Address(address))
 	codeHash := state.GetCodeHash(address)
-
-	accountProof, _ := proof.Extract(cc.Hash(header.Root), cc.Address(address))
 
 	return &AccountResult{
 		Address:      address,
-		AccountProof: toHexSlice(accountProof.GetElements()),
+		AccountProof: toHexSlice(accountProof),
 		Balance:      (*hexutil.U256)(state.GetBalance(address)),
 		CodeHash:     codeHash,
 		Nonce:        hexutil.Uint64(state.GetNonce(address)),

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.3
 
 require (
-	github.com/Fantom-foundation/Carmen/go v0.0.0-20241128114701-34dad37b5648
+	github.com/Fantom-foundation/Carmen/go v0.0.0-20241129202153-690bc10fa624
 	github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241128114701-34dad37b5648 h1:gVmZHEjmw9/JAyaU28MOWkbDzLPZ+Qfu1WTHOuE26UU=
-github.com/Fantom-foundation/Carmen/go v0.0.0-20241128114701-34dad37b5648/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241129202153-690bc10fa624 h1:9bFojtY5KoLFUtLYZGc1GNf0oIdBIOarlLr4+a/DA7U=
+github.com/Fantom-foundation/Carmen/go v0.0.0-20241129202153-690bc10fa624/go.mod h1:vNRGm/b21hDlF8kYyKHkXq1s+jLMKpV4jGwXHylXIIg=
 github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675 h1:Meqtt0eM9UAw1ceQ1tGiD497V0IVfqj8c6UrFJhkFNE=
 github.com/Fantom-foundation/Tosca v0.0.0-20241028082205-7b33705a4675/go.mod h1:8i7r+dUOkXjEC61SaFoRet6JYjRaSoiM/PhviP6K4Y8=
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20241022121122-7063a6b506bd h1:WoAkgzLLlyh3Zpnd/3gW8Ym5sHtugLCA4rQdT5udVF8=


### PR DESCRIPTION
Updates Carmen version to deliver witness proof steps in trie-navigation order.

TODO:
- [x] complete full witness proof test for updated Carmen