### PR TITLE
Implement getAccount RPC method

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -708,7 +708,12 @@ func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address common.Add
 	return (*hexutil.U256)(state.GetBalance(address)), state.Error()
 }
 
-// GetAccountResult is result struct for GetAccount
+// GetAccountResult is result struct for GetAccount.
+// The result contains:
+// 1) CodeHash - hash of the code for the given address
+// 2) StorageRoot - storage root for the given address
+// 3) Balance - the amount of wei for the given address
+// 4) Nonce - the number of transactions for given address
 type GetAccountResult struct {
 	CodeHash    common.Hash    `json:"codeHash"`
 	StorageRoot common.Hash    `json:"storageRoot"`
@@ -718,11 +723,6 @@ type GetAccountResult struct {
 
 // GetAccount returns the information about account with given address in the state of the given block number.
 // The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block numbers are also allowed.
-// The result contains:
-// 1) CodeHash - hash of the code for the given address
-// 2) StorageRoot - storage root for the given address
-// 3) Balance - the amount of wei for the given address
-// 4) Nonce - the number of transactions for given address
 func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*GetAccountResult, error) {
 	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -148,29 +148,12 @@ func TestAPI_GetAccount(t *testing.T) {
 	api := NewPublicBlockChainAPI(mockBackend)
 
 	account, err := api.GetAccount(context.Background(), addr, blkNr)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
+	require.NoError(t, err, "failed to get account")
 
-	if codeHash.Cmp(account.CodeHash) != 0 {
-		t.Errorf("unexpected code hash, got: %s want %s", account.CodeHash, codeHash)
-	}
-
-	if common.Hash(storageRoot).Cmp(account.StorageRoot) != 0 {
-		t.Errorf("unexpected storage root, got: %s want %s", account.StorageRoot, storageRoot)
-	}
-
-	if balance.Cmp((*uint256.Int)(account.Balance)) != 0 {
-		t.Errorf("unexpected balance, got: %s want %s", account.Balance, balance)
-	}
-
-	if balance.Cmp((*uint256.Int)(account.Balance)) != 0 {
-		t.Errorf("unexpected balance, got: %s want %s", account.Balance, balance)
-	}
-
-	if nonce != uint64(account.Nonce) {
-		t.Errorf("unexpected nonce, got: %d want %d", account.Nonce, nonce)
-	}
+	require.Equal(t, codeHash, account.CodeHash)
+	require.Equal(t, common.Hash(storageRoot), account.StorageRoot)
+	require.Equal(t, (*hexutil.U256)(balance), account.Balance)
+	require.Equal(t, hexutil.Uint64(nonce), account.Nonce)
 }
 
 func testGetBlockReceipts(t *testing.T, blockParam rpc.BlockNumberOrHash) ([]map[string]interface{}, error) {

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -4,52 +4,52 @@ import (
 	"github.com/Fantom-foundation/go-opera/ethapi"
 	"github.com/Fantom-foundation/go-opera/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestGetAccount(t *testing.T) {
 	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
+	require.NoError(t, err, "failed to start the fake network")
 	defer net.Stop()
 
 	// Deploy the transient storage contract
 	_, deployReceipt, err := DeployContract(net, transientstorage.DeployTransientstorage)
-	if err != nil {
-		t.Fatalf("failed to deploy contract; %v", err)
-	}
+	require.NoError(t, err, "failed to deploy contract")
 
 	addr := deployReceipt.ContractAddress
 
 	c, err := net.GetClient()
-	if err != nil {
-		t.Fatalf("failed to get client; %v", err)
-	}
+	require.NoError(t, err, "failed to get client")
+	defer c.Close()
 
 	rpcClient := c.Client()
+	defer rpcClient.Close()
 
 	var res ethapi.GetAccountResult
 	err = rpcClient.Call(&res, "eth_getAccount", addr, rpc.LatestBlockNumber)
-	if err != nil {
-		t.Fatalf("failed to get account; %v", err)
-	}
+	require.NoError(t, err, "failed to call get account")
 
-	if res.CodeHash == (common.Hash{}) {
-		t.Error("code hash should not be empty")
+	// Extract proof to find actual StorageHash(Root), Nonce, Balance and CodeHash
+	var proofRes struct {
+		StorageHash common.Hash
+		Nonce       hexutil.Uint64
+		Balance     *hexutil.U256
+		CodeHash    common.Hash
 	}
+	err = rpcClient.Call(
+		&proofRes,
+		"eth_getProof",
+		addr,
+		nil,
+		rpc.LatestBlockNumber,
+	)
+	require.NoError(t, err, "failed call to get proof")
 
-	if res.StorageRoot == (common.Hash{}) {
-		t.Error("storage root should not be empty")
-	}
-
-	if got, want := (*uint256.Int)(res.Balance).Uint64(), uint64(0); got != want {
-		t.Errorf("balance not as expected, got: %d want: %d", got, want)
-	}
-
-	if res.Nonce < 1 {
-		t.Errorf("account nonce is expected to by at least 1")
-	}
+	require.Equal(t, proofRes.CodeHash, res.CodeHash)
+	require.Equal(t, proofRes.StorageHash, res.StorageRoot)
+	require.Equal(t, proofRes.Balance, res.Balance)
+	require.Equal(t, proofRes.Nonce, res.Nonce)
 }

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"github.com/Fantom-foundation/go-opera/ethapi"
-	"github.com/Fantom-foundation/go-opera/tests/contracts/transientstorage"
+	"github.com/Fantom-foundation/go-opera/tests/contracts/counter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -16,7 +16,7 @@ func TestGetAccount(t *testing.T) {
 	defer net.Stop()
 
 	// Deploy the transient storage contract
-	_, deployReceipt, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	_, deployReceipt, err := DeployContract(net, counter.DeployCounter)
 	require.NoError(t, err, "failed to deploy contract")
 
 	addr := deployReceipt.ContractAddress

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"github.com/Fantom-foundation/go-opera/ethapi"
+	"github.com/Fantom-foundation/go-opera/tests/contracts/transientstorage"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
+	"testing"
+)
+
+func TestGetAccount(t *testing.T) {
+	net, err := StartIntegrationTestNet(t.TempDir())
+	if err != nil {
+		t.Fatalf("Failed to start the fake network: %v", err)
+	}
+	defer net.Stop()
+
+	// Deploy the transient storage contract
+	_, deployReceipt, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	if err != nil {
+		t.Fatalf("failed to deploy contract; %v", err)
+	}
+
+	addr := deployReceipt.ContractAddress
+
+	c, err := net.GetClient()
+	if err != nil {
+		t.Fatalf("failed to get client; %v", err)
+	}
+
+	rpcClient := c.Client()
+
+	var res ethapi.GetAccountResult
+	err = rpcClient.Call(&res, "eth_getAccount", addr, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Fatalf("failed to get account; %v", err)
+	}
+
+	if res.CodeHash == (common.Hash{}) {
+		t.Error("code hash should not be empty")
+	}
+
+	if res.StorageRoot == (common.Hash{}) {
+		t.Error("storage root should not be empty")
+	}
+
+	if got, want := (*uint256.Int)(res.Balance).Uint64(), uint64(0); got != want {
+		t.Errorf("balance not as expected, got: %d want: %d", got, want)
+	}
+
+	if res.Nonce < 1 {
+		t.Errorf("account nonce is expected to by at least 1")
+	}
+}


### PR DESCRIPTION
This PR adds getAccount method to the RPC according to [this](https://www.quicknode.com/docs/ethereum/eth_getAccount) documentation.

Copy of #317 - `StorageRoot` can now be extracted from `WitnessProof`