### PR TITLE
Skip fetching event payloads when streaming events

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -3,6 +3,8 @@ package gossip
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"math"
 	"math/rand/v2"
 	"strings"
@@ -553,7 +555,11 @@ func (h *handler) handle(p *peer) error {
 	// Handle incoming messages until the connection is torn down
 	for {
 		if err := h.handleMsg(p); err != nil {
-			p.Log().Debug("Message handling failed", "err", err, "peer", p.ID(), "name", p.Name())
+			level := slog.LevelWarn
+			if errors.Is(err, io.EOF) {
+				level = slog.LevelDebug
+			}
+			p.Log().Log(level, "Message handling failed", "err", err, "peer", p.ID(), "name", p.Name())
 			return err
 		}
 	}

--- a/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
+++ b/gossip/protocols/dag/dagstream/dagstreamleecher/leecher.go
@@ -148,10 +148,11 @@ func (d *Leecher) startSession(candidates []string) {
 		}
 	}
 
+	// We only fetch IDs since fetching IDs and events leads to message decoding
+	// issues causing the peer connection the request was send to to be closed.
+	// By requesting IDs only, this issue is avoided. The payloads of events are
+	// then requested independently using the non-streaming P2P protocol.
 	typ := dagstream.RequestIDs
-	if d.callback.PeerEpoch(peer) > d.epoch && d.emptyState && d.session.try == 0 {
-		typ = dagstream.RequestEvents
-	}
 
 	session := dagstream.Session{
 		ID:    getSessionID(d.epoch, d.session.try),


### PR DESCRIPTION
This PR disables the requesting of event payload data when streaming events from other nodes.

Receiving messaged from a stream of events with payload currently leads to a message parsing error, causing the peer connection used for streaming those events to be disconnected. After a time-out of a few seconds, another attempt for streaming events is started -- however in the second attempt only event IDs are fetched, which then succeeds.

During syncing, this effect can be observed by the process seemingly freezing between epochs for a few seconds. With this fix, this effect disappears.

Besides disabling requests of event streams with payload, this PR also upgrades the reporting of communication issues to the log-level of a warning to allow issues like this to be detected more easily in the future.