### PR TITLE
Restrict access to errlock file

### DIFF
--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -69,5 +69,5 @@ func read(dir string) (bool, string, string, error) {
 func write(dir string, eLockStr string) (string, error) {
 	eLockPath := path.Join(dir, "errlock")
 
-	return eLockPath, os.WriteFile(eLockPath, []byte(eLockStr), 0666) // assume no custom encoding needed
+	return eLockPath, os.WriteFile(eLockPath, []byte(eLockStr), 0600) // assume no custom encoding needed
 }


### PR DESCRIPTION
This PR restricts the file-permission of error log file.

This issue was identified by an external audit and was classified at a medium risk level. In its old state it would allow malicious local users on the system to inject messages that would get displaced to the user of the `sonicd` application.