### PR TITLE
Caution package

### DIFF
--- a/utils/caution/caution.go
+++ b/utils/caution/caution.go
@@ -1,0 +1,26 @@
+// package caution provides utility functions for handling errors and closing
+// resources.
+// This package should be only be used for sitations where errors are unexpected
+// and should be ignored or panic
+
+package caution
+
+import (
+	"fmt"
+	"io"
+)
+
+func ExecuteAndReportError(err *error, f func() error, message string) {
+	if *err == nil {
+		*err = f()
+		if *err != nil {
+			*err = fmt.Errorf("%s: %w", message, *err)
+		}
+	}
+}
+
+func CloseAndReportError(err *error, closer io.Closer, message string) {
+	ExecuteAndReportError(err, func() error {
+		return closer.Close()
+	}, message)
+}

--- a/utils/caution/caution.go
+++ b/utils/caution/caution.go
@@ -1,24 +1,67 @@
-// package caution provides utility functions for handling errors and closing
-// resources.
-// This package should be only be used for sitations where errors are unexpected
-// and should be ignored or panic
-
+// package caution provides utility functions for handling errors in defer
+// cleanup and closing resources.
 package caution
 
 import (
+	"errors"
 	"fmt"
 	"io"
 )
 
+// ExecuteAndReportError is intended for use in production code to handle errors
+// ignored in defer clean ups.
+//
+// - The first argument is the error variable where the error, if any, will be
+// accumulated. If it already contains an error, the new error will be combined.
+// - The second argument is a cleanup function that may return an error. This
+// function will always be executed.
+// - The third argument is a mandatory context message that will be used in the
+// error if the cleanup function fails.
+//
+// Usage example:
+//
+// Original code:
+//
+//	func F(....) error {
+//	    [...]
+//	    defer f.CleanUpThatMayFail(someArg)
+//	    [...]
+//	}
+//
+// Refactored with the new functions:
+//
+//	func F(....) (err error) {
+//	    [...]
+//	    defer ExecuteAndReportError(&err, f() error {f.CleanUpThatMayFail(someArg) }, "failed to cleanup f")
+//	    [...]
+//	}
 func ExecuteAndReportError(err *error, f func() error, message string) {
-	if *err == nil {
-		*err = f()
-		if *err != nil {
-			*err = fmt.Errorf("%s: %w", message, *err)
-		}
+	fErr := f()
+	if fErr != nil {
+		*err = errors.Join(*err, fmt.Errorf("%s: %w", message, fErr))
 	}
 }
 
+// CloseAndReportError is specialization of ExecuteAndReportError for types that
+// implement the Closer interface, to add error management in the
+// `defer f.Close()` pattern.
+// Usage example:
+//
+// Original code:
+//
+//	func F(....) error {
+//	    [...]
+//	    defer f.Close()
+//	    [...]
+//	}
+//
+// Refactored with the new functions:
+//
+//	func F(....) (err error) {
+//	    [...]
+//	    defer CloseAndReportError(&err, f, "failed to close f")
+//	    [...]
+//	}
 func CloseAndReportError(err *error, closer io.Closer, message string) {
 	ExecuteAndReportError(err, func() error {
 		return closer.Close()

--- a/utils/caution/caution_test.go
+++ b/utils/caution/caution_test.go
@@ -1,52 +1,68 @@
 package caution
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestExecuteAndReportError_DoesNothingWhenInputErrorIsNotNil(t *testing.T) {
-	err := fmt.Errorf("someError")
-	ExecuteAndReportError(&err, func() error {
-		panic("mypanic")
-	}, "mymessage")
-	if err.Error() != "someError" {
-		t.Errorf("error not reported, got %v", err)
-	}
-}
-
-func TestExecuteAndReportError_ExecutesFunAndReportsError(t *testing.T) {
-	var err error
-	ExecuteAndReportError(&err, func() error {
-		return fmt.Errorf("someError")
-	}, "message")
-	if errors.Is(err, fmt.Errorf("message: someError")) {
-		t.Errorf("unexpected error, got %v", err)
-	}
-}
-
-func TestExecuteAndReportError_ExecutesFunNothingToReport(t *testing.T) {
+func TestExecuteAndReportError_ExecutesAndReturnsError(t *testing.T) {
 	var err error
 	ExecuteAndReportError(&err, func() error {
 		return nil
 	}, "message")
-	if err != nil {
-		t.Errorf("unexpected error, got %v", err)
-	}
+	require.NoError(t, err)
+	someError := fmt.Errorf("someError")
+	ExecuteAndReportError(&err, func() error {
+		return someError
+	}, "message")
+	require.ErrorIs(t, err, someError)
+}
+
+func TestExecuteAndReportError_ExecutesAndCombinesErrors(t *testing.T) {
+	firstError := fmt.Errorf("firstError")
+	err := firstError
+	ExecuteAndReportError(&err, func() error {
+		return nil
+	}, "message")
+	require.ErrorIs(t, err, firstError)
+
+	ExecuteAndReportError(&err, func() error {
+		return fmt.Errorf("secondError")
+	}, "message")
+	require.ErrorContains(t, err, "firstError")
+	require.ErrorContains(t, err, "secondError")
+}
+
+type closeMe struct {
+	err error
+}
+
+func (c *closeMe) Close() error {
+	return c.err
 }
 
 func TestCloseAndReportError_(t *testing.T) {
-	tmpfile := filepath.Join(t.TempDir(), "file")
-	file, err := os.Create(tmpfile)
-	if err != nil {
-		t.Fatal(err)
+	file := &closeMe{}
+	var err error
+	CloseAndReportError(&err, file, "message")
+	require.NoError(t, err)
+
+	file.err = fmt.Errorf("someError")
+	CloseAndReportError(&err, file, "message")
+	require.ErrorContains(t, err, "message: someError")
+}
+
+func TestCloseAndReportError_UsagePatternPropagatesError(t *testing.T) {
+	expectedError := fmt.Errorf("someError")
+
+	testFun := func() (outErr error) {
+		file := &closeMe{err: expectedError}
+		defer CloseAndReportError(&outErr, file, "message")
+		return
 	}
 
-	CloseAndReportError(&err, file, "message")
-	if _, err := file.Read([]byte{0}); err == nil {
-		t.Errorf("file not closed, %v", err)
-	}
+	gotError := testFun()
+	require.ErrorIs(t, gotError, expectedError)
 }

--- a/utils/caution/caution_test.go
+++ b/utils/caution/caution_test.go
@@ -1,0 +1,52 @@
+package caution
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExecuteAndReportError_DoesNothingWhenInputErrorIsNotNil(t *testing.T) {
+	err := fmt.Errorf("someError")
+	ExecuteAndReportError(&err, func() error {
+		panic("mypanic")
+	}, "mymessage")
+	if err.Error() != "someError" {
+		t.Errorf("error not reported, got %v", err)
+	}
+}
+
+func TestExecuteAndReportError_ExecutesFunAndReportsError(t *testing.T) {
+	var err error
+	ExecuteAndReportError(&err, func() error {
+		return fmt.Errorf("someError")
+	}, "message")
+	if errors.Is(err, fmt.Errorf("message: someError")) {
+		t.Errorf("unexpected error, got %v", err)
+	}
+}
+
+func TestExecuteAndReportError_ExecutesFunNothingToReport(t *testing.T) {
+	var err error
+	ExecuteAndReportError(&err, func() error {
+		return nil
+	}, "message")
+	if err != nil {
+		t.Errorf("unexpected error, got %v", err)
+	}
+}
+
+func TestCloseAndReportError_(t *testing.T) {
+	tmpfile := filepath.Join(t.TempDir(), "file")
+	file, err := os.Create(tmpfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	CloseAndReportError(&err, file, "message")
+	if _, err := file.Read([]byte{0}); err == nil {
+		t.Errorf("file not closed, %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds a utility lib that calls a function and reports whether it returned an error or not.

The function `CloseAndReportError` is meant to facilitate the check and handle of closing resources, which is one of the main unhandled errors across the code base. As we work on fixing unhandled errors (which are mostly unlikely to fail or coming from non-logical issues). 

part of https://github.com/Fantom-foundation/sonic-admin/issues/90