### PR TITLE
Refactor defer-close with error handling

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/cmd/sonicd/metrics"
 	"github.com/Fantom-foundation/go-opera/config"
 	"github.com/Fantom-foundation/go-opera/config/flags"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/Fantom-foundation/go-opera/version"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/console/prompt"
@@ -202,11 +203,10 @@ func initApp() {
 		return nil
 	}
 
-	app.After = func(ctx *cli.Context) error {
+	app.After = func(ctx *cli.Context) (err error) {
 		debug.Exit()
-		prompt.Stdin.Close() // Resets terminal mode.
-
-		return nil
+		caution.CloseAndReportError(&err, prompt.Stdin, "failed to reset terminal input") // Resets terminal mode.
+		return
 	}
 }
 

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -203,10 +203,10 @@ func initApp() {
 		return nil
 	}
 
-	app.After = func(ctx *cli.Context) (err error) {
+	app.After = func(ctx *cli.Context) error {
 		debug.Exit()
-		caution.CloseAndReportError(&err, prompt.Stdin, "failed to reset terminal input") // Resets terminal mode.
-		return
+		// Close will resets terminal mode.
+		return caution.IfErrorAddContext(prompt.Stdin.Close(), "failed to reset terminal input")
 	}
 }
 

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -203,10 +203,11 @@ func initApp() {
 		return nil
 	}
 
-	app.After = func(ctx *cli.Context) error {
+	app.After = func(ctx *cli.Context) (err error) {
 		debug.Exit()
 		// Close will resets terminal mode.
-		return caution.IfErrorAddContext(prompt.Stdin.Close(), "failed to reset terminal input")
+		caution.CloseAndReportError(&err, prompt.Stdin, "failed to reset terminal input")
+		return err
 	}
 }
 

--- a/cmd/sonictool/app/chain.go
+++ b/cmd/sonictool/app/chain.go
@@ -33,7 +33,7 @@ func exportEvents(ctx *cli.Context) (err error) {
 	// Open the file handle and potentially wrap with a gzip stream
 	fileHandler, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
-		return
+		return err
 	}
 	defer caution.CloseAndReportError(&err, fileHandler, fmt.Sprintf("failed to close file %v", filename))
 
@@ -74,7 +74,7 @@ func exportEvents(ctx *cli.Context) (err error) {
 		return fmt.Errorf("export error: %w", err)
 	}
 
-	return
+	return nil
 }
 
 func importEvents(ctx *cli.Context) error {

--- a/cmd/sonictool/app/cli.go
+++ b/cmd/sonictool/app/cli.go
@@ -2,11 +2,13 @@ package app
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/Fantom-foundation/go-opera/config/flags"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/rpc"
 	"gopkg.in/urfave/cli.v1"
-	"strings"
 )
 
 var (
@@ -27,7 +29,7 @@ var (
 
 // remoteConsole will connect to a remote opera instance, attaching a JavaScript
 // console to it.
-func remoteConsole(ctx *cli.Context) error {
+func remoteConsole(ctx *cli.Context) (err error) {
 	// Attach to a remotely running opera instance and start the JavaScript console
 	endpoint := ctx.Args().First()
 	if endpoint == "" {
@@ -57,18 +59,20 @@ func remoteConsole(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to start the JavaScript console: %v", err)
 	}
-	defer console.Stop(false)
+	defer caution.ExecuteAndReportError(&err,
+		func() error { return console.Stop(false) },
+		"failed to stop the JavaScript console")
 
 	if script := ctx.String(ExecFlag.Name); script != "" {
 		console.Evaluate(script)
-		return nil
+		return
 	}
 
 	// Otherwise print the welcome screen and enter interactive mode
 	console.Welcome()
 	console.Interactive()
 
-	return nil
+	return
 }
 
 // makeConsolePreloads retrieves the absolute paths for the console JavaScript

--- a/cmd/sonictool/app/compact.go
+++ b/cmd/sonictool/app/compact.go
@@ -53,13 +53,13 @@ func compactDB(name string, producer kvdb.DBProducer) (err error) {
 	err = compactdb.Compact(db, name, 64*opt.GiB)
 	if err != nil {
 		log.Error("Database compaction failed", "err", err)
-		return
+		return err
 	}
 
 	log.Info("Stats after compaction", "db", name)
 	showDbStats(db)
 
-	return
+	return nil
 }
 
 func showDbStats(db ethdb.Stater) {

--- a/cmd/sonictool/app/config.go
+++ b/cmd/sonictool/app/config.go
@@ -22,27 +22,27 @@ func checkConfig(ctx *cli.Context) error {
 func dumpConfig(ctx *cli.Context) (err error) {
 	cfg, err := config.MakeAllConfigs(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	comment := ""
 
 	out, err := config.TomlSettings.Marshal(&cfg)
 	if err != nil {
-		return
+		return err
 	}
 
 	dump := os.Stdout
 	if ctx.NArg() > 0 {
 		dump, err = os.OpenFile(ctx.Args().Get(0), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
-			return
+			return err
 		}
 		defer caution.CloseAndReportError(&err, dump, "failed to close config file")
 	}
 	_, err = dump.WriteString(comment)
 	if err != nil {
-		return
+		return err
 	}
 	_, err = dump.Write(out)
-	return
+	return err
 }

--- a/cmd/sonictool/app/export_genesis.go
+++ b/cmd/sonictool/app/export_genesis.go
@@ -3,20 +3,22 @@ package app
 import (
 	"context"
 	"fmt"
-	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
-	"github.com/Fantom-foundation/go-opera/cmd/sonictool/genesis"
-	"github.com/Fantom-foundation/go-opera/config/flags"
-	"github.com/Fantom-foundation/go-opera/integration"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"gopkg.in/urfave/cli.v1"
 	"os"
 	"os/signal"
 	"path"
 	"path/filepath"
 	"syscall"
+
+	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
+	"github.com/Fantom-foundation/go-opera/cmd/sonictool/genesis"
+	"github.com/Fantom-foundation/go-opera/config/flags"
+	"github.com/Fantom-foundation/go-opera/integration"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"gopkg.in/urfave/cli.v1"
 )
 
-func exportGenesis(ctx *cli.Context) error {
+func exportGenesis(ctx *cli.Context) (err error) {
 	dataDir := ctx.GlobalString(flags.DataDirFlag.Name)
 	if dataDir == "" {
 		return fmt.Errorf("--%s need to be set", flags.DataDirFlag.Name)
@@ -45,7 +47,7 @@ func exportGenesis(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to make DB producer: %v", err)
 	}
-	defer dbs.Close()
+	defer caution.CloseAndReportError(&err, dbs, "failed to close DB producer")
 
 	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
 		Dbs:           dbs,
@@ -58,17 +60,18 @@ func exportGenesis(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	defer gdb.Close()
+	defer caution.CloseAndReportError(&err, gdb, "failed to close Gossip DB")
 
-	fh, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	fileHandler, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err
 	}
-	defer fh.Close()
+	defer caution.CloseAndReportError(&err, fileHandler, fmt.Sprintf("failed to close file %v", fileName))
 
 	tmpPath := path.Join(dataDir, "tmp-genesis-export")
 	_ = os.RemoveAll(tmpPath)
-	defer os.RemoveAll(tmpPath)
+	defer caution.ExecuteAndReportError(&err, func() error { return os.RemoveAll(tmpPath) },
+		"failed to remove tmp genesis export dir")
 
-	return genesis.ExportGenesis(cancelCtx, gdb, !forValidatorMode, fh, tmpPath)
+	return genesis.ExportGenesis(cancelCtx, gdb, !forValidatorMode, fileHandler, tmpPath)
 }

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -57,7 +58,7 @@ func gfileGenesisImport(ctx *cli.Context) (err error) {
 
 	genesisStore, genesisHashes, err := genesisstore.OpenGenesisStore(genesisReader)
 	if err != nil {
-		return fmt.Errorf("failed to read genesis file: %w", err)
+		return errors.Join(fmt.Errorf("failed to read genesis file: %w", err), genesisReader.Close())
 	}
 	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")
 	if err := genesis.IsGenesisTrusted(genesisStore, genesisHashes); err != nil {

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -43,11 +43,11 @@ func gfileGenesisImport(ctx *cli.Context) (err error) {
 	}
 	validatorMode, err := isValidatorModeSet(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	cacheRatio, err := cacheScaler(ctx)
 	if err != nil {
-		return
+		return err
 	}
 
 	genesisReader, err := os.Open(ctx.Args().First())
@@ -91,11 +91,11 @@ func jsonGenesisImport(ctx *cli.Context) (err error) {
 	}
 	validatorMode, err := isValidatorModeSet(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	cacheRatio, err := cacheScaler(ctx)
 	if err != nil {
-		return
+		return err
 	}
 
 	genesisJson, err := makefakegenesis.LoadGenesisJson(ctx.Args().First())
@@ -135,11 +135,11 @@ func fakeGenesisImport(ctx *cli.Context) (err error) {
 	}
 	validatorMode, err := isValidatorModeSet(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	cacheRatio, err := cacheScaler(ctx)
 	if err != nil {
-		return
+		return err
 	}
 
 	genesisStore := makefakegenesis.FakeGenesisStore(

--- a/cmd/sonictool/app/heal.go
+++ b/cmd/sonictool/app/heal.go
@@ -112,7 +112,7 @@ func healLiveFromArchive(ctx context.Context, carmenLiveDir, carmenArchiveDir st
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		defer caution.CloseAndReportError(&err, writer, "failed to close writer")
+		defer caution.CloseAndReportError(&exportErr, writer, "failed to close writer")
 		exportErr = mptio.ExportBlockFromArchive(ctx, mptio.NewLog(), carmenArchiveDir, bufWriter, uint64(recoveredBlock))
 		if exportErr == nil {
 			exportErr = bufWriter.Flush()

--- a/cmd/sonictool/app/sign_genesis.go
+++ b/cmd/sonictool/app/sign_genesis.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/genesis"
 	ogenesis "github.com/Fantom-foundation/go-opera/opera/genesis"
 	"github.com/Fantom-foundation/go-opera/opera/genesisstore"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/Fantom-foundation/go-opera/utils/prompt"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
@@ -59,16 +60,16 @@ func signGenesis(ctx *cli.Context) error {
 
 func getGenesisHeaderHashes(genesisFile string) (ogenesis.Header, ogenesis.Hashes, error) {
 	genesisReader, err := os.Open(genesisFile)
+	// note, genesisStore closes the reader, no need to defer close it here
 	if err != nil {
 		return ogenesis.Header{}, nil, fmt.Errorf("failed to open the genesis file: %w", err)
 	}
-	defer genesisReader.Close()
 
 	genesisStore, genesisHashes, err := genesisstore.OpenGenesisStore(genesisReader)
 	if err != nil {
 		return ogenesis.Header{}, nil, fmt.Errorf("failed to read genesis file: %w", err)
 	}
-	defer genesisStore.Close()
+	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")
 
 	return genesisStore.Header(), genesisHashes, nil
 }

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -30,7 +30,7 @@ func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, from, to idx.Epo
 	chaindataDir := filepath.Join(gdbParams.DataDir, "chaindata")
 	dbs, err := db.MakeDbProducer(chaindataDir, cachescale.Identity)
 	if err != nil {
-		return
+		return err
 	}
 	defer caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 
@@ -40,14 +40,14 @@ func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, from, to idx.Epo
 
 	gdb, err := db.MakeGossipDb(gdbParams)
 	if err != nil {
-		return
+		return err
 	}
 	defer caution.CloseAndReportError(&err, gdb, "failed to close gossip db")
 
 	// Write header and version
 	_, err = w.Write(append(eventsFileHeader, eventsFileVersion...))
 	if err != nil {
-		return
+		return err
 	}
 
 	start, reported := time.Now(), time.Time{}

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -1,11 +1,13 @@
 package chain
 
 import (
-	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"io"
 	"path/filepath"
 	"time"
+
+	"github.com/Fantom-foundation/go-opera/cmd/sonictool/db"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
+	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -28,9 +30,9 @@ func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, from, to idx.Epo
 	chaindataDir := filepath.Join(gdbParams.DataDir, "chaindata")
 	dbs, err := db.MakeDbProducer(chaindataDir, cachescale.Identity)
 	if err != nil {
-		return err
+		return
 	}
-	defer dbs.Close()
+	defer caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 
 	// Fill the rest of the params
 	gdbParams.Dbs = dbs
@@ -38,14 +40,14 @@ func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, from, to idx.Epo
 
 	gdb, err := db.MakeGossipDb(gdbParams)
 	if err != nil {
-		return err
+		return
 	}
-	defer gdb.Close()
+	defer caution.CloseAndReportError(&err, gdb, "failed to close gossip db")
 
 	// Write header and version
 	_, err = w.Write(append(eventsFileHeader, eventsFileVersion...))
 	if err != nil {
-		return err
+		return
 	}
 
 	start, reported := time.Now(), time.Time{}

--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -154,7 +154,7 @@ func importEventsFile(srv *gossip.Service, filename string) (err error) {
 		if err == io.EOF {
 			err = processBatch()
 			if err != nil {
-				return
+				return err
 			}
 			break
 		}
@@ -164,7 +164,7 @@ func importEventsFile(srv *gossip.Service, filename string) (err error) {
 		if e.Epoch() != epoch || batchSize >= maxBatchSize {
 			err = processBatch()
 			if err != nil {
-				return
+				return err
 			}
 		}
 		epoch = e.Epoch()

--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -159,7 +159,7 @@ func importEventsFile(srv *gossip.Service, filename string) (err error) {
 			break
 		}
 		if err != nil {
-			return
+			return err
 		}
 		if e.Epoch() != epoch || batchSize >= maxBatchSize {
 			err = processBatch()

--- a/cmd/sonictool/check/archive.go
+++ b/cmd/sonictool/check/archive.go
@@ -62,5 +62,5 @@ func checkArchiveBlockRoots(dataDir string, cacheRatio cachescale.Func) (err err
 		return fmt.Errorf("block root verification failed for %d blocks (from %d total blocks)", invalidBlocks, lastBlockIdx)
 	}
 	log.Info("Block root verification OK for all blocks", "blocks", lastBlockIdx)
-	return
+	return err
 }

--- a/cmd/sonictool/check/archive.go
+++ b/cmd/sonictool/check/archive.go
@@ -62,5 +62,5 @@ func checkArchiveBlockRoots(dataDir string, cacheRatio cachescale.Func) (err err
 		return fmt.Errorf("block root verification failed for %d blocks (from %d total blocks)", invalidBlocks, lastBlockIdx)
 	}
 	log.Info("Block root verification OK for all blocks", "blocks", lastBlockIdx)
-	return err
+	return nil
 }

--- a/cmd/sonictool/check/live.go
+++ b/cmd/sonictool/check/live.go
@@ -51,5 +51,5 @@ func checkLiveBlockRoot(dataDir string, cacheRatio cachescale.Func) (err error) 
 		return fmt.Errorf("checking live state failed: %w", err)
 	}
 	log.Info("Live block root verification OK", "block", lastBlockIdx)
-	return
+	return nil
 }

--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -35,8 +35,7 @@ func ImportGenesisStore(params ImportParams) (err error) {
 	chaindataDir := filepath.Join(params.DataDir, "chaindata")
 	dbs, err := db.MakeDbProducer(chaindataDir, params.CacheRatio)
 	if err != nil {
-		err = fmt.Errorf("failed to create db producer: %w", err)
-		return
+		return fmt.Errorf("failed to create db producer: %w", err)
 	}
 	defer caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 	setGenesisProcessing(chaindataDir)
@@ -50,8 +49,7 @@ func ImportGenesisStore(params ImportParams) (err error) {
 		ArchiveCache:  params.ArchiveCache,
 	})
 	if err != nil {
-		err = fmt.Errorf("failed to create gossip db: %w", err)
-		return
+		return fmt.Errorf("failed to create gossip db: %w", err)
 	}
 	defer caution.CloseAndReportError(&err, gdb, "failed to close gossip db")
 
@@ -62,8 +60,7 @@ func ImportGenesisStore(params ImportParams) (err error) {
 
 	cMainDb, err := dbs.OpenDB("lachesis")
 	if err != nil {
-		err = fmt.Errorf("failed to open lachesis db: %w", err)
-		return
+		return fmt.Errorf("failed to open lachesis db: %w", err)
 	}
 	cGetEpochDB := func(epoch idx.Epoch) kvdb.Store {
 		db, err := dbs.OpenDB(fmt.Sprintf("lachesis-%d", epoch))
@@ -83,18 +80,16 @@ func ImportGenesisStore(params ImportParams) (err error) {
 		Validators: gdb.GetValidators(),
 	})
 	if err != nil {
-		err = fmt.Errorf("failed to write lachesis genesis state: %w", err)
-		return
+		return fmt.Errorf("failed to write lachesis genesis state: %w", err)
 	}
 
 	err = gdb.Commit()
 	if err != nil {
-		err = fmt.Errorf("failed to commit gossip db: %w", err)
-		return
+		return fmt.Errorf("failed to commit gossip db: %w", err)
 	}
 	setGenesisComplete(chaindataDir)
 	log.Info("Successfully imported genesis file")
-	return
+	return nil
 }
 
 func IsGenesisTrusted(genesisStore *genesisstore.Store, genesisHashes genesis.Hashes) error {

--- a/cmd/sonictool/genesis/signature.go
+++ b/cmd/sonictool/genesis/signature.go
@@ -110,8 +110,7 @@ func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file
 		return fmt.Errorf("failed to write signature to genesis file: %w", err)
 	}
 	_, err = writer.Flush()
-	utils.AnnotateIfError(err, "failed to flush genesis file:")
-	return err
+	return utils.AnnotateIfError(err, "failed to flush genesis file:")
 }
 
 // TypedDataAndHash is a helper function that calculates a hash for typed data conforming to EIP-712.

--- a/cmd/sonictool/genesis/signature.go
+++ b/cmd/sonictool/genesis/signature.go
@@ -86,19 +86,19 @@ func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file
 	out, err := os.OpenFile(file, os.O_RDWR, os.ModePerm) // avoid using O_APPEND for correct seek positions
 	if err != nil {
 		err = fmt.Errorf("failed to open genesis file: %w", err)
-		return
+		return err
 	}
 	_, err = out.Seek(0, io.SeekEnd)
 	if err != nil {
 		err = fmt.Errorf("failed to seek genesis file: %w", err)
-		return
+		return err
 	}
 	defer caution.CloseAndReportError(&err, out, "failed to close genesis file")
 
 	tmpDir, err := os.MkdirTemp("", "signing-genesis-tmp")
 	if err != nil {
 		err = fmt.Errorf("failed to create temporary directory: %w", err)
-		return
+		return err
 	}
 	defer caution.ExecuteAndReportError(&err, func() error { return os.RemoveAll(tmpDir) },
 		"failed to remove temporary directory")
@@ -106,18 +106,18 @@ func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file
 	writer := newUnitWriter(out)
 	if err = writer.Start(header, "signature", tmpDir); err != nil {
 		err = fmt.Errorf("failed to write start to genesis file: %w", err)
-		return
+		return err
 	}
 	_, err = writer.Write(signature)
 	if err != nil {
 		err = fmt.Errorf("failed to write signature to genesis file: %w", err)
-		return
+		return err
 	}
 	_, err = writer.Flush()
 	if err != nil {
 		err = fmt.Errorf("failed to flush genesis file: %w", err)
 	}
-	return
+	return nil
 }
 
 // TypedDataAndHash is a helper function that calculates a hash for typed data conforming to EIP-712.

--- a/cmd/sonictool/genesis/signature.go
+++ b/cmd/sonictool/genesis/signature.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
+	"github.com/Fantom-foundation/go-opera/utils"
 	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -85,39 +86,32 @@ func CheckGenesisSignature(hash []byte, signature []byte) error {
 func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file string) (err error) {
 	out, err := os.OpenFile(file, os.O_RDWR, os.ModePerm) // avoid using O_APPEND for correct seek positions
 	if err != nil {
-		err = fmt.Errorf("failed to open genesis file: %w", err)
-		return err
+		return fmt.Errorf("failed to open genesis file: %w", err)
 	}
 	_, err = out.Seek(0, io.SeekEnd)
 	if err != nil {
-		err = fmt.Errorf("failed to seek genesis file: %w", err)
-		return err
+		return fmt.Errorf("failed to seek genesis file: %w", err)
 	}
 	defer caution.CloseAndReportError(&err, out, "failed to close genesis file")
 
 	tmpDir, err := os.MkdirTemp("", "signing-genesis-tmp")
 	if err != nil {
-		err = fmt.Errorf("failed to create temporary directory: %w", err)
-		return err
+		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 	defer caution.ExecuteAndReportError(&err, func() error { return os.RemoveAll(tmpDir) },
 		"failed to remove temporary directory")
 
 	writer := newUnitWriter(out)
 	if err = writer.Start(header, "signature", tmpDir); err != nil {
-		err = fmt.Errorf("failed to write start to genesis file: %w", err)
-		return err
+		return fmt.Errorf("failed to write start to genesis file: %w", err)
 	}
 	_, err = writer.Write(signature)
 	if err != nil {
-		err = fmt.Errorf("failed to write signature to genesis file: %w", err)
-		return err
+		return fmt.Errorf("failed to write signature to genesis file: %w", err)
 	}
 	_, err = writer.Flush()
-	if err != nil {
-		err = fmt.Errorf("failed to flush genesis file: %w", err)
-	}
-	return nil
+	utils.AnnotateIfError(err, "failed to flush genesis file:")
+	return err
 }
 
 // TypedDataAndHash is a helper function that calculates a hash for typed data conforming to EIP-712.

--- a/cmd/sonictool/genesis/signature.go
+++ b/cmd/sonictool/genesis/signature.go
@@ -114,7 +114,9 @@ func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file
 		return
 	}
 	_, err = writer.Flush()
-	err = fmt.Errorf("failed to flush genesis file: %w", err)
+	if err != nil {
+		err = fmt.Errorf("failed to flush genesis file: %w", err)
+	}
 	return
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/gossip"
 	"github.com/Fantom-foundation/go-opera/gossip/emitter"
 	"github.com/Fantom-foundation/go-opera/integration"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/Fantom-foundation/go-opera/utils/memory"
 	"github.com/Fantom-foundation/go-opera/vecmt"
 )
@@ -81,12 +82,13 @@ func (c *Config) AppConfigs() integration.Configs {
 	}
 }
 
-func loadAllConfigs(file string, cfg *Config) error {
+func loadAllConfigs(file string, cfg *Config) (err error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return err
+		err = fmt.Errorf("failed to open config file %s: %w", file, err)
+		return
 	}
-	defer f.Close()
+	defer caution.CloseAndReportError(&err, f, "failed to close config file")
 
 	err = TomlSettings.NewDecoder(bufio.NewReader(f)).Decode(cfg)
 	// Add file name to errors that have a line number.
@@ -94,12 +96,11 @@ func loadAllConfigs(file string, cfg *Config) error {
 		err = errors.New(file + ", " + err.Error())
 	}
 	if err != nil {
-
 		return fmt.Errorf("TOML config file error: %v.\n"+
 			"Use 'dumpconfig' command to get an example config file.\n"+
 			"If node was recently upgraded and a previous network config file is used, then check updates for the config file.", err)
 	}
-	return err
+	return
 }
 
 func setBootnodes(ctx *cli.Context, urls []string, cfg *node.Config) {

--- a/config/config.go
+++ b/config/config.go
@@ -85,8 +85,7 @@ func (c *Config) AppConfigs() integration.Configs {
 func loadAllConfigs(file string, cfg *Config) (err error) {
 	f, err := os.Open(file)
 	if err != nil {
-		err = fmt.Errorf("failed to open config file %s: %w", file, err)
-		return
+		return fmt.Errorf("failed to open config file %s: %w", file, err)
 	}
 	defer caution.CloseAndReportError(&err, f, "failed to close config file")
 
@@ -100,7 +99,7 @@ func loadAllConfigs(file string, cfg *Config) (err error) {
 			"Use 'dumpconfig' command to get an example config file.\n"+
 			"If node was recently upgraded and a previous network config file is used, then check updates for the config file.", err)
 	}
-	return
+	return nil
 }
 
 func setBootnodes(ctx *cli.Context, urls []string, cfg *node.Config) {

--- a/debug/api.go
+++ b/debug/api.go
@@ -22,6 +22,7 @@ package debug
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/user"
@@ -31,6 +32,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -60,7 +62,7 @@ func (h *HandlerT) StartCPUProfile(file string) error {
 		return err
 	}
 	if err := pprof.StartCPUProfile(f); err != nil {
-		f.Close()
+		caution.CloseAndReportError(&err, f, "failed to close profile file")
 		return err
 	}
 	h.cpuW = f
@@ -78,7 +80,9 @@ func (h *HandlerT) StopCPUProfile() error {
 		return errors.New("CPU profiling not in progress")
 	}
 	log.Info("Done writing CPU profile", "dump", h.cpuFile)
-	h.cpuW.Close()
+	if err := h.cpuW.Close(); err != nil {
+		return fmt.Errorf("failed to close CPU profile file: %w", err)
+	}
 	h.cpuW = nil
 	h.cpuFile = ""
 	return nil

--- a/debug/api.go
+++ b/debug/api.go
@@ -62,8 +62,9 @@ func (h *HandlerT) StartCPUProfile(file string) error {
 		return err
 	}
 	if err := pprof.StartCPUProfile(f); err != nil {
-		caution.CloseAndReportError(&err, f, "failed to close profile file")
-		return err
+		return errors.Join(
+			fmt.Errorf("failed to start CPU: %w", err),
+			caution.IfErrorAddContext(f.Close(), "failed to close CPU profile file"))
 	}
 	h.cpuW = f
 	h.cpuFile = file

--- a/debug/api.go
+++ b/debug/api.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Fantom-foundation/go-opera/utils/caution"
+	"github.com/Fantom-foundation/go-opera/utils"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -64,7 +64,7 @@ func (h *HandlerT) StartCPUProfile(file string) error {
 	if err := pprof.StartCPUProfile(f); err != nil {
 		return errors.Join(
 			fmt.Errorf("failed to start CPU: %w", err),
-			caution.IfErrorAddContext(f.Close(), "failed to close CPU profile file"))
+			utils.AnnotateIfError(f.Close(), "failed to close CPU profile file"))
 	}
 	h.cpuW = f
 	h.cpuFile = file

--- a/debug/trace.go
+++ b/debug/trace.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime/trace"
 
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -39,7 +40,7 @@ func (h *HandlerT) StartGoTrace(file string) error {
 		return err
 	}
 	if err := trace.Start(f); err != nil {
-		f.Close()
+		caution.CloseAndReportError(&err, f, "failed to close trace file")
 		return err
 	}
 	h.traceW = f
@@ -57,7 +58,9 @@ func (h *HandlerT) StopGoTrace() error {
 		return errors.New("trace not in progress")
 	}
 	log.Info("Done writing Go trace", "dump", h.traceFile)
-	h.traceW.Close()
+	if err := h.traceW.Close(); err != nil {
+		return err
+	}
 	h.traceW = nil
 	h.traceFile = ""
 	return nil

--- a/debug/trace.go
+++ b/debug/trace.go
@@ -21,6 +21,7 @@ package debug
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"runtime/trace"
 
@@ -40,8 +41,9 @@ func (h *HandlerT) StartGoTrace(file string) error {
 		return err
 	}
 	if err := trace.Start(f); err != nil {
-		caution.CloseAndReportError(&err, f, "failed to close trace file")
-		return err
+		return errors.Join(
+			fmt.Errorf("failed to start Go trace: %w", err),
+			caution.IfErrorAddContext(f.Close(), "failed to close trace file"))
 	}
 	h.traceW = f
 	h.traceFile = file

--- a/debug/trace.go
+++ b/debug/trace.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"runtime/trace"
 
-	"github.com/Fantom-foundation/go-opera/utils/caution"
+	"github.com/Fantom-foundation/go-opera/utils"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -43,7 +43,7 @@ func (h *HandlerT) StartGoTrace(file string) error {
 	if err := trace.Start(f); err != nil {
 		return errors.Join(
 			fmt.Errorf("failed to start Go trace: %w", err),
-			caution.IfErrorAddContext(f.Close(), "failed to close trace file"))
+			utils.AnnotateIfError(f.Close(), "failed to close trace file"))
 	}
 	h.traceW = f
 	h.traceFile = file

--- a/evmcore/tx_journal.go
+++ b/evmcore/tx_journal.go
@@ -66,8 +66,7 @@ func (journal *txJournal) load(add func([]*types.Transaction) []error) (err erro
 	// Open the journal for loading any past transactions
 	input, err := os.Open(journal.path)
 	if err != nil {
-		err = fmt.Errorf("Failed to open transaction journal: %w", err)
-		return
+		return fmt.Errorf("Failed to open transaction journal: %w", err)
 	}
 	defer caution.CloseAndReportError(&err, input, "Failed to close transaction journal")
 

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -429,7 +429,9 @@ func (pool *TxPool) Stop() {
 	pool.wg.Wait()
 
 	if pool.journal != nil {
-		pool.journal.close()
+		if err := pool.journal.close(); err != nil {
+			log.Warn("Failed to close transaction journal:", err)
+		}
 	}
 	log.Info("Transaction pool stopped")
 }

--- a/gossip/evmstore/statedb.go
+++ b/gossip/evmstore/statedb.go
@@ -90,5 +90,5 @@ func (s *Store) CheckArchiveStateHash(blockNum idx.Block, root hash.Hash) (err e
 	if cc.Hash(root) != stateHash {
 		return fmt.Errorf("hash of the archive EVM state is incorrect: blockNum: %d expected: %x actual: %x", blockNum, root, stateHash)
 	}
-	return
+	return nil
 }

--- a/gossip/evmstore/statedb_verify.go
+++ b/gossip/evmstore/statedb_verify.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/io"
 	carmen "github.com/Fantom-foundation/Carmen/go/state"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -53,12 +54,12 @@ func (s *Store) VerifyWorldState(expectedBlockNum uint64, expectedHash common.Ha
 	return nil
 }
 
-func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expectedHash common.Hash) error {
+func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expectedHash common.Hash) (err error) {
 	liveState, err := carmen.NewState(params)
 	if err != nil {
 		return fmt.Errorf("failed to open carmen live state in %s: %w", params.Directory, err)
 	}
-	defer liveState.Close()
+	defer caution.CloseAndReportError(&err, liveState, "failed to close carmen live state")
 	if err := checkStateHash(liveState, expectedHash); err != nil {
 		return fmt.Errorf("live state check failed; %w", err)
 	}
@@ -72,17 +73,17 @@ func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expected
 	}
 
 	if params.Archive == carmen.NoArchive {
-		return nil // skip archive checks when archive is not enabled
+		return // skip archive checks when archive is not enabled
 	}
 	archiveState, err := liveState.GetArchiveState(lastArchiveBlock)
 	if err != nil {
 		return fmt.Errorf("failed to get carmen archive state; %w", err)
 	}
-	defer archiveState.Close()
+	defer caution.CloseAndReportError(&err, archiveState, "failed to close carmen archive state")
 	if err := checkStateHash(archiveState, expectedHash); err != nil {
 		return fmt.Errorf("archive state check failed; %w", err)
 	}
-	return nil
+	return
 }
 
 func checkStateHash(state carmen.State, expectedHash common.Hash) error {

--- a/gossip/evmstore/statedb_verify.go
+++ b/gossip/evmstore/statedb_verify.go
@@ -73,7 +73,7 @@ func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expected
 	}
 
 	if params.Archive == carmen.NoArchive {
-		return // skip archive checks when archive is not enabled
+		return nil // skip archive checks when archive is not enabled
 	}
 	archiveState, err := liveState.GetArchiveState(lastArchiveBlock)
 	if err != nil {
@@ -83,7 +83,7 @@ func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expected
 	if err := checkStateHash(archiveState, expectedHash); err != nil {
 		return fmt.Errorf("archive state check failed; %w", err)
 	}
-	return
+	return nil
 }
 
 func checkStateHash(state carmen.State, expectedHash common.Hash) error {

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/gossip"
 	"github.com/Fantom-foundation/go-opera/utils/adapters/vecmt2dagidx"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/Fantom-foundation/go-opera/vecmt"
 	"github.com/Fantom-foundation/lachesis-base/abft"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -81,9 +82,9 @@ func makeEngine(chaindataDir string, cfg Configs) (*abft.Lachesis, *vecmt.Index,
 	}
 	defer func() {
 		if err != nil {
-			gdb.Close()
-			cdb.Close()
-			dbs.Close()
+			caution.CloseAndReportError(&err, gdb, "failed to close gossip store")
+			caution.CloseAndReportError(&err, cdb, "failed to close lachesis store")
+			caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 		}
 	}()
 

--- a/integration/db.go
+++ b/integration/db.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Fantom-foundation/go-opera/gossip"
+	"github.com/Fantom-foundation/go-opera/utils/caution"
 	"github.com/Fantom-foundation/go-opera/utils/dbutil/dbcounter"
 	"github.com/Fantom-foundation/go-opera/utils/dbutil/threads"
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -60,7 +61,7 @@ func isEmpty(dir string) bool {
 	if err != nil {
 		return true
 	}
-	defer f.Close()
+	defer caution.CloseAndReportError(&err, f, "failed to close dir")
 	_, err = f.Readdirnames(1)
 	return err == io.EOF
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -73,7 +73,7 @@ func isPortFree(host string, port int) bool {
 		return false
 	}
 	if err = listener.Close(); err != nil {
-		fmt.Print("failed to close listener:", err)
+		panic(fmt.Errorf("failed to close listener:%w", err))
 	}
 	return true
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -72,12 +72,10 @@ func isPortFree(host string, port int) bool {
 	if err != nil {
 		return false
 	}
-	err = listener.Close()
-	if err != nil {
-		fmt.Printf("failed to close port %d: %v\n", port, err)
+	if err = listener.Close(); err != nil {
+		fmt.Print("failed to close listener:", err)
 	}
-	// if the port reports errors while closing, do not consider it free
-	return err == nil
+	return true
 }
 
 func getFreePort() (int, error) {

--- a/topicsdb/search_parallel.go
+++ b/topicsdb/search_parallel.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type logHandler func(rec *logrec) (gonext bool, err error)
@@ -117,5 +118,7 @@ func (tt *index) scanPatternVariant(pos uint8, variant common.Hash, start uint64
 			break
 		}
 	}
-	onMatched(nil)
+	if _, err := onMatched(nil); err != nil {
+		log.Warn("searchParallel", "err", err)
+	}
 }

--- a/utils/annotateError.go
+++ b/utils/annotateError.go
@@ -1,0 +1,11 @@
+package utils
+
+import "fmt"
+
+// AnnotateIfError adds a message to an error, if the error is not nil.
+func AnnotateIfError(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}

--- a/utils/annotateError_test.go
+++ b/utils/annotateError_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotateIfError_PropagatesNil(t *testing.T) {
+	if AnnotateIfError(nil, "message") != nil {
+		t.Error("AnnotateIfError should return nil when err is nil")
+	}
+}
+
+func TestAnnotateIfError_AddsContextToError(t *testing.T) {
+	err := fmt.Errorf("someError")
+	errWithContext := AnnotateIfError(err, "message")
+	require.ErrorContains(t, errWithContext, "message: someError")
+}

--- a/utils/annotateError_test.go
+++ b/utils/annotateError_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -17,4 +18,5 @@ func TestAnnotateIfError_AddsContextToError(t *testing.T) {
 	err := fmt.Errorf("someError")
 	errWithContext := AnnotateIfError(err, "message")
 	require.ErrorContains(t, errWithContext, "message: someError")
+	require.True(t, errors.Is(errWithContext, err))
 }

--- a/utils/caution/caution.go
+++ b/utils/caution/caution.go
@@ -67,3 +67,11 @@ func CloseAndReportError(err *error, closer io.Closer, message string) {
 		return closer.Close()
 	}, message)
 }
+
+// IfErrorAddContext adds a message to an error, if the error is not nil.
+func IfErrorAddContext(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}

--- a/utils/caution/caution.go
+++ b/utils/caution/caution.go
@@ -67,11 +67,3 @@ func CloseAndReportError(err *error, closer io.Closer, message string) {
 		return closer.Close()
 	}, message)
 }
-
-// IfErrorAddContext adds a message to an error, if the error is not nil.
-func IfErrorAddContext(err error, message string) error {
-	if err == nil {
-		return nil
-	}
-	return fmt.Errorf("%s: %w", message, err)
-}

--- a/utils/caution/caution_test.go
+++ b/utils/caution/caution_test.go
@@ -43,7 +43,7 @@ func (c *closeMe) Close() error {
 	return c.err
 }
 
-func TestCloseAndReportError_(t *testing.T) {
+func TestCloseAndReportError_AddsMessageToError(t *testing.T) {
 	file := &closeMe{}
 	var err error
 	CloseAndReportError(&err, file, "message")
@@ -65,16 +65,4 @@ func TestCloseAndReportError_UsagePatternPropagatesError(t *testing.T) {
 
 	gotError := testFun()
 	require.ErrorIs(t, gotError, expectedError)
-}
-
-func TestIfErrorAddContext_PropagatesNil(t *testing.T) {
-	if IfErrorAddContext(nil, "message") != nil {
-		t.Error("IfErrorAddContext should return nil when err is nil")
-	}
-}
-
-func TestIfErrorAddContext_AddsContextToError(t *testing.T) {
-	err := fmt.Errorf("someError")
-	errWithContext := IfErrorAddContext(err, "message")
-	require.ErrorContains(t, errWithContext, "message: someError")
 }

--- a/utils/caution/caution_test.go
+++ b/utils/caution/caution_test.go
@@ -66,3 +66,15 @@ func TestCloseAndReportError_UsagePatternPropagatesError(t *testing.T) {
 	gotError := testFun()
 	require.ErrorIs(t, gotError, expectedError)
 }
+
+func TestIfErrorAddContext_PropagatesNil(t *testing.T) {
+	if IfErrorAddContext(nil, "message") != nil {
+		t.Error("IfErrorAddContext should return nil when err is nil")
+	}
+}
+
+func TestIfErrorAddContext_AddsContextToError(t *testing.T) {
+	err := fmt.Errorf("someError")
+	errWithContext := IfErrorAddContext(err, "message")
+	require.ErrorContains(t, errWithContext, "message: someError")
+}

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -13,11 +13,15 @@ import (
 func Check() error {
 	locked, reason, eLockPath, err := read(datadir)
 	if err != nil {
-		return fmt.Errorf("Node isn't allowed to start due to an error reading lock file. Please fix the issue and then delete file \"%s\". Error message:\n%w", eLockPath, err)
+		return fmt.Errorf("Node isn't allowed to start due to an error reading"+
+			" the lock file %s.\n Please fix the issue. Error message:\n%w",
+			eLockPath, err)
 	}
 
 	if locked {
-		return fmt.Errorf("Node isn't allowed to start due to a previous error. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, reason)
+		return fmt.Errorf("Node isn't allowed to start due to a previous error."+
+			" Please fix the issue and then delete file \"%s\". Error message:\n%s",
+			eLockPath, reason)
 	}
 	return nil
 }
@@ -34,7 +38,9 @@ func SetDefaultDatadir(dir string) {
 // Permanent error
 func Permanent(err error) {
 	eLockPath, _ := write(datadir, err.Error())
-	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, err.Error()))
+	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix"+
+		" the issue and then delete file \"%s\". Error message:\n%s",
+		eLockPath, err.Error()))
 }
 
 func readAll(reader io.Reader, max int) ([]byte, error) {
@@ -69,9 +75,7 @@ func read(dir string) (locked bool, reason string, eLockPath string, err error) 
 	if err != nil {
 		return true, "", eLockPath, fmt.Errorf("failed to read lock file %v: %w", eLockPath, err)
 	}
-	reason = string(eLockBytes)
-	locked = true
-	return
+	return true, string(eLockBytes), eLockPath, nil
 }
 
 // write errlock file

--- a/valkeystore/encryption/io.go
+++ b/valkeystore/encryption/io.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Fantom-foundation/go-opera/utils/caution"
+	"github.com/Fantom-foundation/go-opera/utils"
 )
 
 func writeTemporaryKeyFile(file string, content []byte) (string, error) {
@@ -26,8 +26,8 @@ func writeTemporaryKeyFile(file string, content []byte) (string, error) {
 	if _, err = f.Write(content); err != nil {
 		return "", errors.Join(
 			fmt.Errorf("failed to write key file: %w", err),
-			caution.IfErrorAddContext(f.Close(), "failed to close key file"),
-			caution.IfErrorAddContext(os.Remove(f.Name()), "failed to remove temporary key file"),
+			utils.AnnotateIfError(f.Close(), "failed to close key file"),
+			utils.AnnotateIfError(os.Remove(f.Name()), "failed to remove temporary key file"),
 		)
 	}
 


### PR DESCRIPTION
This PR contributes to https://github.com/Fantom-foundation/sonic-admin/issues/90

This PR adds real life use cases of both functions provided the caution package to properly handler errors in case of `defer` and `close`. 

This PR fixes some of the unhandled errors reported by the external audit. Most (if not all) of them are from either `defer close` patterns or similar cleanups or unhandled close errors.

Test list to verify we don't have double closes (or other errors) and panic now because error is no longer ignored:
- [x] run `make test`
- [x] Norma test
    - demonet/static.yml
    - demonet/dynamic.yml
- [ ] testing suggestions ?

