### PR TITLE
Get current version from git tag 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ sonicd:
 	go build \
 			-ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \
 							-X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE} \
-							-X github.com/Fantom-foundation/go-opera/version.GitTag=$${GIT_TAG}" \
+							-X github.com/Fantom-foundation/go-opera/version.Version=$${GIT_TAG}" \
             -o build/sonicd \
             ./cmd/sonicd && \
 			./build/sonicd version
@@ -24,7 +24,7 @@ sonictool:
 	go build \
 			-ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \
 							-X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE} \
-							-X github.com/Fantom-foundation/go-opera/version.GitTag=$${GIT_TAG}" \
+							-X github.com/Fantom-foundation/go-opera/version.Version=$${GIT_TAG}" \
             -o build/sonictool \
             ./cmd/sonictool && \
 			./build/sonictool --version

--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,28 @@ GOPROXY ?= "https://proxy.golang.org,direct"
 sonicd:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
+	GIT_TAG=`echo $(call get_git_tag)` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE}" \
-	    -o build/sonicd \
-	    ./cmd/sonicd
+			-ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \
+							-X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE} \
+							-X github.com/Fantom-foundation/go-opera/version.GitTag=$${GIT_TAG}" \
+            -o build/sonicd \
+            ./cmd/sonicd && \
+			./build/sonicd version
 
 sonictool:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
+	GIT_TAG=`echo $(call get_git_tag)` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE}" \
-	    -o build/sonictool \
-	    ./cmd/sonictool
+			-ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \
+							-X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE} \
+							-X github.com/Fantom-foundation/go-opera/version.GitTag=$${GIT_TAG}" \
+            -o build/sonictool \
+            ./cmd/sonictool && \
+			./build/sonictool --version
 
 TAG ?= "latest"
 .PHONY: sonic-image
@@ -74,3 +82,21 @@ deadcode:
 
 .PHONY: lint
 lint: vet staticcheck deadcode # errorcheck
+
+# get_git_tag get the last git tag and append -dev if there are commits since
+# the last tag and -dirty if there are uncommitted changes
+define get_git_tag
+    $(shell \
+        GIT_TAG=$$(git describe --tags --abbrev=0 2>/dev/null); \
+        COMMITS_SINCE=$$(git log $${GIT_TAG}..HEAD --oneline 2>/dev/null | wc -l); \
+        DIRTY_STATE=$$(git status --porcelain 2>/dev/null); \
+        FINAL_TAG=$${GIT_TAG}; \
+        if [ "$${COMMITS_SINCE}" -ne 0 ]; then \
+            FINAL_TAG=$${FINAL_TAG}-dev; \
+        fi; \
+        if [ -n "$${DIRTY_STATE}" ]; then \
+            FINAL_TAG=$${FINAL_TAG}-dirty; \
+        fi; \
+        echo "$${FINAL_TAG}"
+    )
+endef

--- a/cmd/sonicd/app/misccmd.go
+++ b/cmd/sonicd/app/misccmd.go
@@ -28,7 +28,7 @@ The output of this command is supposed to be machine-readable.
 
 func versionAction(ctx *cli.Context) error {
 	fmt.Println(config.ClientIdentifier)
-	fmt.Println("Version:", version.VersionWithMeta)
+	fmt.Println("Version:", version.Version)
 	if config.GitCommit != "" {
 		fmt.Println("Git Commit:", config.GitCommit)
 	}

--- a/gossip/emitter/config.go
+++ b/gossip/emitter/config.go
@@ -57,7 +57,7 @@ type Config struct {
 // DefaultConfig returns the default configurations for the events emitter.
 func DefaultConfig() Config {
 	return Config{
-		VersionToPublish: version.VersionWithMeta,
+		VersionToPublish: version.Version,
 
 		EmitIntervals: EmitIntervals{
 			Min:                        150 * time.Millisecond,

--- a/version/version.go
+++ b/version/version.go
@@ -6,23 +6,8 @@ import (
 	"strings"
 )
 
-var (
-	GitTag       = "" // Git tag of this release
-	versionMajor = 0  // Major version component of the current release
-	versionMinor = 0  // Minor version component of the current release
-	versionPatch = 0  // Patch version component of the current release
-	versionMeta  = "" // Meta information of the current release
-)
-
 // Version holds the textual version string.
-var Version = func() string {
-	// in case of no tag or small/irregular tag, return it as is
-	if len(GitTag) < 2 {
-		return GitTag
-	}
-	versionMajor, versionMinor, versionPatch, versionMeta = parseVersion(GitTag)
-	return GitTag
-}()
+var Version = ""
 
 // parseVersion parses the GitTag into major, minor, patch, and meta components.
 func parseVersion(gitTag string) (vMajor, vMinor, vPatch int, vMeta string) {
@@ -64,21 +49,25 @@ func parseVersionComponent(parts []string, index int, stripPrefix bool) int {
 }
 
 func VersionWithCommit(gitCommit, gitDate string) string {
-	vsn := GitTag
+	vsn := Version
 	if len(gitCommit) >= 8 {
 		vsn += "-" + gitCommit[:8]
 	}
-	if (strings.Split(GitTag, "-")[0] != "") && (gitDate != "") {
+	if (strings.Split(Version, "-")[0] != "") && (gitDate != "") {
 		vsn += "-" + gitDate
 	}
 	return vsn
 }
 
 func AsString() string {
+	// meta is not used for now, so we ignore it.
+	versionMajor, versionMinor, versionPatch, _ := parseVersion(Version)
 	return ToString(uint16(versionMajor), uint16(versionMinor), uint16(versionPatch))
 }
 
 func AsU64() uint64 {
+	// meta is not used for now, so we ignore it.
+	versionMajor, versionMinor, versionPatch, _ := parseVersion(Version)
 	return ToU64(uint16(versionMajor), uint16(versionMinor), uint16(versionPatch))
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,46 +2,84 @@ package version
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 )
 
-const (
-	VersionMajor = 2     // Major version component of the current release
-	VersionMinor = 0     // Minor version component of the current release
-	VersionPatch = 2     // Patch version component of the current release
-	VersionMeta  = "dev" // Version metadata to append to the version string
+var (
+	GitTag       = "" // Git tag of this release
+	versionMajor = 0  // Major version component of the current release
+	versionMinor = 0  // Minor version component of the current release
+	versionPatch = 0  // Patch version component of the current release
+	versionMeta  = "" // Meta information of the current release
 )
 
 // Version holds the textual version string.
 var Version = func() string {
-	return fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)
+	// in case of no tag or small/irregular tag, return it as is
+	if len(GitTag) < 2 {
+		return GitTag
+	}
+	versionMajor, versionMinor, versionPatch, versionMeta = parseVersion(GitTag)
+	return GitTag
 }()
 
-// VersionWithMeta holds the textual version string including the metadata.
-var VersionWithMeta = func() string {
-	v := Version
-	if VersionMeta != "" {
-		v += "-" + VersionMeta
+// parseVersion parses the GitTag into major, minor, patch, and meta components.
+func parseVersion(gitTag string) (vMajor, vMinor, vPatch int, vMeta string) {
+	parts := strings.SplitN(gitTag, "-", 2)
+	versionParts := strings.Split(parts[0], ".")
+
+	// Parse major, minor, and patch
+	vMajor = parseVersionComponent(versionParts, 0, true)
+	vMinor = parseVersionComponent(versionParts, 1, false)
+	if len(versionParts) > 2 {
+		dashSplits := strings.Split(versionParts[2], "-")
+		vPatch = parseVersionComponent(dashSplits, 0, false)
 	}
-	return v
-}()
+	// Parse meta if available
+	if (vMajor != 0 || vMinor != 0 || vPatch != 0) && len(parts) > 1 {
+		vMeta = parts[1]
+	}
+	return
+}
+
+// parseVersionComponent parses and returns a specific version component.
+// If `stripPrefix` is true, it strips the leading "v" from the major version.
+func parseVersionComponent(parts []string, index int, stripPrefix bool) int {
+	if len(parts) <= index {
+		return 0
+	}
+
+	component := parts[index]
+	if stripPrefix {
+		component = strings.TrimPrefix(component, "v")
+	}
+
+	value, err := strconv.Atoi(component)
+	if err != nil {
+		return 0
+	}
+
+	return value
+}
 
 func VersionWithCommit(gitCommit, gitDate string) string {
-	vsn := VersionWithMeta
+	vsn := GitTag
 	if len(gitCommit) >= 8 {
 		vsn += "-" + gitCommit[:8]
 	}
-	if (VersionMeta != "stable") && (gitDate != "") {
+	if (strings.Split(GitTag, "-")[0] != "") && (gitDate != "") {
 		vsn += "-" + gitDate
 	}
 	return vsn
 }
 
 func AsString() string {
-	return ToString(uint16(VersionMajor), uint16(VersionMinor), uint16(VersionPatch))
+	return ToString(uint16(versionMajor), uint16(versionMinor), uint16(versionPatch))
 }
 
 func AsU64() uint64 {
-	return ToU64(uint16(VersionMajor), uint16(VersionMinor), uint16(VersionPatch))
+	return ToU64(uint16(versionMajor), uint16(versionMinor), uint16(versionPatch))
 }
 
 func ToU64(vMajor, vMinor, vPatch uint16) uint64 {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -39,3 +39,38 @@ func TestAsBigInt(t *testing.T) {
 		prev = next
 	}
 }
+
+func TestVersion_parseVersion(t *testing.T) {
+	require := require.New(t)
+
+	tests := map[string]struct {
+		major int
+		minor int
+		patch int
+		meta  string
+	}{
+		"v1.2.3":                       {major: 1, minor: 2, patch: 3},
+		"v1.2.3-alpha":                 {major: 1, minor: 2, patch: 3, meta: "alpha"},
+		"v1.2.3-alpha-dirty":           {major: 1, minor: 2, patch: 3, meta: "alpha-dirty"},
+		"some-non.stan-dard.12tag":     {},
+		"!`@#$%^&*()_{}|:<>?[]\\;',./": {},
+		"myTestTag":                    {},
+	}
+
+	originalGitTag := GitTag
+	for tag, want := range tests {
+		versionMajor = 0
+		versionMinor = 0
+		versionPatch = 0
+		versionMeta = ""
+
+		versionMajor, versionMinor, versionPatch, versionMeta = parseVersion(tag)
+
+		require.Equal(want.major, versionMajor, "major version mismatch")
+		require.Equal(want.minor, versionMinor, "minor version mismatch")
+		require.Equal(want.patch, versionPatch, "patch version mismatch")
+		require.Equal(want.meta, versionMeta, "meta version mismatch")
+	}
+
+	GitTag = originalGitTag
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -57,20 +57,12 @@ func TestVersion_parseVersion(t *testing.T) {
 		"myTestTag":                    {},
 	}
 
-	originalGitTag := GitTag
 	for tag, want := range tests {
-		versionMajor = 0
-		versionMinor = 0
-		versionPatch = 0
-		versionMeta = ""
+		testVMajor, testVMinor, testVPatch, testVMeta := parseVersion(tag)
 
-		versionMajor, versionMinor, versionPatch, versionMeta = parseVersion(tag)
-
-		require.Equal(want.major, versionMajor, "major version mismatch")
-		require.Equal(want.minor, versionMinor, "minor version mismatch")
-		require.Equal(want.patch, versionPatch, "patch version mismatch")
-		require.Equal(want.meta, versionMeta, "meta version mismatch")
+		require.Equal(want.major, testVMajor, "major version mismatch")
+		require.Equal(want.minor, testVMinor, "minor version mismatch")
+		require.Equal(want.patch, testVPatch, "patch version mismatch")
+		require.Equal(want.meta, testVMeta, "meta version mismatch")
 	}
-
-	GitTag = originalGitTag
 }


### PR DESCRIPTION
This PR adds a mechanism that uses the git tag (if any) as release version. Hence preventing the task to update both the version file as well as the release tag in git. It also should check if there have been any commits since the last label, and if the build is a dirty build (aka has uncommitted changes)

the git tag is "v2.0.1" => Major=2, Minor=0, Patch=1, Meta=""
the git tag is "v2.0.1-rc1" => Major=2, Minor=0, Patch=1, Meta="rc1"
the git tag is "v2.0.1" but there are extra commits on top: => Major=2, Minor=0, Patch=1, Meta="dev"
the git tag is "v2.0.1-rc1" with extra commits on top => Major=2, Minor=0, Patch=1, Meta="rc1-dev"
there is no git tag (e.g. development) => handle like "v0.0.0" with extra commits on top