### PR TITLE
Fix recognition of intrinsic gas error

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1189,7 +1189,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 
 		result, err := DoCall(ctx, b, args, blockNrOrHash, nil, 0, gasCap)
 		if err != nil {
-			if errors.Is(err, evmcore.ErrIntrinsicGas) {
+			if errors.Is(err, core.ErrIntrinsicGas) {
 				return true, nil, nil // Special case, raise gas limit
 			}
 			return true, nil, err // Bail out

--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -18,7 +18,9 @@ package evmcore
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -60,7 +62,7 @@ var (
 
 	// ErrIntrinsicGas is returned if the transaction is specified to use less gas
 	// than required to start the invocation.
-	ErrIntrinsicGas = errors.New("intrinsic gas too low")
+	ErrIntrinsicGas = fmt.Errorf("%w", core.ErrIntrinsicGas)
 
 	// ErrTxTypeNotSupported is returned if a transaction is not supported in the
 	// current network configuration.


### PR DESCRIPTION
This PR fixes situation, when gas estimation failed because of intrinsic gas too low error. Error was not correctly recognized, because raised error was from go-ethereum libary, not the one from sonic repository.

This is a copy of https://github.com/0xsoniclabs/sonic/pull/4 because we want this include into 2.0.2