### PR TITLE
fix: expose RPC flags in launcher

### DIFF
--- a/cmd/sonicd/launcher.go
+++ b/cmd/sonicd/launcher.go
@@ -126,6 +126,9 @@ func initFlags() {
 		flags.RPCGlobalEVMTimeoutFlag,
 		flags.RPCGlobalTxFeeCapFlag,
 		flags.RPCGlobalTimeoutFlag,
+		flags.BatchRequestLimitFlag,
+		flags.JSTracerLimitFlag,
+		flags.MaxResponseSizeFlag,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,15 @@ func gossipConfigWithFlags(ctx *cli.Context, src gossip.Config) gossip.Config {
 	if ctx.GlobalIsSet(flags.RPCGlobalTimeoutFlag.Name) {
 		cfg.RPCTimeout = ctx.GlobalDuration(flags.RPCGlobalTimeoutFlag.Name)
 	}
+	if ctx.GlobalIsSet(flags.BatchRequestLimitFlag.Name) {
+		cfg.BatchRequestLimit = ctx.GlobalInt(flags.BatchRequestLimitFlag.Name)
+	}
+	if ctx.GlobalIsSet(flags.JSTracerLimitFlag.Name) {
+		cfg.JSTracerLimit = ctx.GlobalInt(flags.JSTracerLimitFlag.Name)
+	}
+	if ctx.GlobalIsSet(flags.MaxResponseSizeFlag.Name) {
+		cfg.MaxResponseSize = ctx.GlobalInt(flags.MaxResponseSizeFlag.Name)
+	}
 
 	return cfg
 }


### PR DESCRIPTION
Expose three flags (rpc.batchrequestlimit, rpc.jstracerlimit, rpc.maxresponsesize) so they can be configured through the CLI.
