### PR TITLE
Expose RPC limit flags as command line flags

### DIFF
--- a/cmd/sonicd/launcher.go
+++ b/cmd/sonicd/launcher.go
@@ -126,6 +126,9 @@ func initFlags() {
 		flags.RPCGlobalEVMTimeoutFlag,
 		flags.RPCGlobalTxFeeCapFlag,
 		flags.RPCGlobalTimeoutFlag,
+		flags.MaxResponseSizeFlag,
+		flags.BatchRequestLimitFlag,
+		flags.JSTracerLimitFlag,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,15 @@ func gossipConfigWithFlags(ctx *cli.Context, src gossip.Config) gossip.Config {
 	if ctx.GlobalIsSet(flags.RPCGlobalTimeoutFlag.Name) {
 		cfg.RPCTimeout = ctx.GlobalDuration(flags.RPCGlobalTimeoutFlag.Name)
 	}
+	if ctx.GlobalIsSet(flags.MaxResponseSizeFlag.Name) {
+		cfg.MaxResponseSize = ctx.GlobalInt(flags.MaxResponseSizeFlag.Name)
+	}
+	if ctx.GlobalIsSet(flags.BatchRequestLimitFlag.Name) {
+		cfg.BatchRequestLimit = ctx.GlobalInt(flags.BatchRequestLimitFlag.Name)
+	}
+	if ctx.GlobalIsSet(flags.JSTracerLimitFlag.Name) {
+		cfg.JSTracerLimit = ctx.GlobalInt(flags.JSTracerLimitFlag.Name)
+	}
 
 	return cfg
 }


### PR DESCRIPTION
This PR adds three additional command line flags to support the configuration of various RPC service limit parameters.

This PR is equivalent to #400.