### PR TITLE
Check archive block height before sending subscribers notification

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 
-	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip/blockproc/verwatcher"
 	"github.com/Fantom-foundation/go-opera/gossip/emitter"
 	"github.com/Fantom-foundation/go-opera/gossip/evmstore"

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -398,14 +398,11 @@ func consensusCallbackBeginBlockFn(
 
 					// Notify about new block
 					if feed != nil {
-						feed.newBlock.Send(evmcore.ChainHeadNotify{Block: evmBlock})
 						var logs []*types.Log
 						for _, r := range allReceipts {
-							for _, l := range r.Logs {
-								logs = append(logs, l)
-							}
+							logs = append(logs, r.Logs...)
 						}
-						feed.newLogs.Send(logs)
+						feed.notifyAboutNewBlock(evmBlock, logs)
 					}
 
 					now := time.Now()

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -199,6 +199,7 @@ func newTestEnv(firstEpoch idx.Epoch, validatorsNum idx.Validator, tb testing.TB
 
 	env.blockProcTasks.Start(1)
 	env.verWatcher.Start()
+	env.feed.Start(env.Service.store.evm)
 
 	return env
 }

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -197,9 +197,9 @@ func newTestEnv(firstEpoch idx.Epoch, validatorsNum idx.Validator, tb testing.TB
 		em.Start()
 	}
 
+	env.feed.Start(store.evm)
 	env.blockProcTasks.Start(1)
 	env.verWatcher.Start()
-	env.feed.Start(env.Service.store.evm)
 
 	return env
 }

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -222,8 +222,6 @@ func (env *testEnv) ApplyTxs(spent time.Duration, txs ...*types.Transaction) (ty
 
 	externalReceipts := make(types.Receipts, 0, len(txs))
 
-	env.txpool.AddRemotes(txs)
-	defer env.txpool.(*dummyTxPool).Clear()
 	newBlocks := make(chan evmcore.ChainHeadNotify)
 	chainHeadSub := env.feed.SubscribeNewBlock(newBlocks)
 	mu := &sync.Mutex{}
@@ -248,6 +246,9 @@ func (env *testEnv) ApplyTxs(spent time.Duration, txs ...*types.Transaction) (ty
 			}
 		}
 	}()
+	env.txpool.AddRemotes(txs)
+	defer env.txpool.(*dummyTxPool).Clear()
+
 	err := env.EmitUntil(func() bool {
 		mu.Lock()
 		defer mu.Unlock()

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -205,6 +205,7 @@ func newTestEnv(firstEpoch idx.Epoch, validatorsNum idx.Validator, tb testing.TB
 }
 
 func (env *testEnv) Close() {
+	env.feed.Stop()
 	env.verWatcher.Stop()
 	env.store.Close()
 	env.tflusher.Stop()

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -560,7 +560,6 @@ func (s *Service) Stop() error {
 
 	s.handler.Stop()
 	s.feed.Stop()
-	s.feed.scope.Close()
 	s.gpo.Stop()
 	// it's safe to stop tflusher only before locking engineMu
 	s.tflusher.Stop()


### PR DESCRIPTION
This PR solves issue, when there is a asynchronous write to the archive state database. This approach was added not to block block processing with write to archive as this is expensive operation.
In some cases update was done only to live database and RPC subscribers were notified about new block, but it was not yet written to archive.