### PR TITLE
Fix typos in flag usage description and error message

### DIFF
--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -303,7 +303,7 @@ var (
 	}
 	JSTracerLimitFlag = cli.IntFlag{
 		Name:  "rpc.jstracerlimit",
-		Usage: "Limit for concurent js engines in RPC calls execution",
+		Usage: "Limit for concurrent js engines in RPC calls execution",
 		Value: gossip.DefaultConfig(cachescale.Identity).JSTracerLimit,
 	}
 	MaxResponseSizeFlag = cli.IntFlag{

--- a/txtrace/js_tracer_test.go
+++ b/txtrace/js_tracer_test.go
@@ -233,7 +233,7 @@ func getEVMEnv() *vm.EVM {
 func checkTracerResult(t *testing.T, result json.RawMessage, expectedResult string) {
 	result, err := json.MarshalIndent(result, "", "    ")
 	if err != nil {
-		t.Errorf("problem with formating result, got error: %v", err)
+		t.Errorf("problem with formatting result, got error: %v", err)
 	}
 
 	if expectedResult != string(result) {


### PR DESCRIPTION

Description:  
This pull request corrects two minor typos in the codebase:
- In config/flags/flags.go, the word "concurent" was corrected to "concurrent" in the usage description for the `rpc.jstracerlimit` flag.
- In txtrace/js_tracer_test.go, the word "formating" was corrected to "formatting" in an error message within the `checkTracerResult` function.

These changes improve code clarity and maintain consistency in documentation and error reporting. No functional changes were made.
